### PR TITLE
OBSDATA-1786: Adding metrics for the queue size at the jetty HTTP Client

### DIFF
--- a/server/src/main/java/org/apache/druid/guice/http/JettyHttpClientModule.java
+++ b/server/src/main/java/org/apache/druid/guice/http/JettyHttpClientModule.java
@@ -23,16 +23,26 @@ import com.google.common.base.Preconditions;
 import com.google.inject.Binder;
 import com.google.inject.Binding;
 import com.google.inject.Module;
+import com.google.inject.Provides;
+import com.google.inject.Singleton;
 import org.apache.druid.guice.JsonConfigProvider;
 import org.apache.druid.guice.LazySingleton;
 import org.apache.druid.guice.annotations.Global;
 import org.apache.druid.java.util.common.lifecycle.Lifecycle;
+import org.apache.druid.java.util.emitter.service.ServiceEmitter;
+import org.apache.druid.java.util.emitter.service.ServiceMetricEvent;
+import org.apache.druid.java.util.metrics.AbstractMonitor;
+import org.apache.druid.java.util.metrics.MonitorUtils;
+import org.apache.druid.server.metrics.DataSourceTaskIdHolder;
+import org.apache.druid.server.metrics.MetricsModule;
+import org.apache.druid.server.metrics.MonitorsConfig;
 import org.eclipse.jetty.client.HttpClient;
 import org.eclipse.jetty.util.ssl.SslContextFactory;
 import org.eclipse.jetty.util.thread.QueuedThreadPool;
 
 import javax.net.ssl.SSLContext;
 import java.lang.annotation.Annotation;
+import java.util.Map;
 import java.util.concurrent.TimeUnit;
 
 /**
@@ -41,6 +51,7 @@ import java.util.concurrent.TimeUnit;
 public class JettyHttpClientModule implements Module
 {
   private static final long CLIENT_CONNECT_TIMEOUT_MILLIS = TimeUnit.MILLISECONDS.toMillis(500);
+  private static QueuedThreadPool httpClientThreadPool = null;
 
   public static JettyHttpClientModule global()
   {
@@ -64,6 +75,8 @@ public class JettyHttpClientModule implements Module
           .annotatedWith(annotationClazz)
           .toProvider(new HttpClientProvider(annotationClazz))
           .in(LazySingleton.class);
+
+    MetricsModule.register(binder, JettyHttpClientModule.JettyMonitor.class);
   }
 
   public static class HttpClientProvider extends AbstractHttpClientProvider<HttpClient>
@@ -126,6 +139,34 @@ public class JettyHttpClientModule implements Module
       }
 
       return httpClient;
+    }
+  }
+
+  @Provides
+  @Singleton
+  public JettyHttpClientModule.JettyMonitor getJettyMonitor(DataSourceTaskIdHolder dataSourceTaskIdHolder)
+  {
+    return new JettyHttpClientModule.JettyMonitor(dataSourceTaskIdHolder.getDataSource(), dataSourceTaskIdHolder.getTaskId());
+  }
+
+  public static class JettyMonitor extends AbstractMonitor
+  {
+    private final Map<String, String[]> dimensions;
+
+    public JettyMonitor(String dataSource, String taskId)
+    {
+      this.dimensions = MonitorsConfig.mapOfDatasourceAndTaskID(dataSource, taskId);
+    }
+
+    @Override
+    public boolean doMonitor(ServiceEmitter emitter)
+    {
+      final ServiceMetricEvent.Builder builder = new ServiceMetricEvent.Builder();
+      MonitorUtils.addDimensionsToBuilder(builder, dimensions);
+      if (httpClientThreadPool != null) {
+        emitter.emit(builder.build("jetty/httpClient/threadpool/queueSize", httpClientThreadPool.getQueueSize()));
+      }
+      return true;
     }
   }
 }

--- a/server/src/main/java/org/apache/druid/guice/http/JettyHttpClientModule.java
+++ b/server/src/main/java/org/apache/druid/guice/http/JettyHttpClientModule.java
@@ -109,6 +109,7 @@ public class JettyHttpClientModule implements Module
       final QueuedThreadPool pool = new QueuedThreadPool(config.getNumMaxThreads());
       pool.setName(JettyHttpClientModule.class.getSimpleName() + "-threadPool-" + pool.hashCode());
       httpClient.setExecutor(pool);
+      httpClientThreadPool = pool;
 
       final Lifecycle lifecycle = getLifecycleProvider().get();
 

--- a/server/src/test/java/org/apache/druid/guice/JettyHttpClientModuleTest.java
+++ b/server/src/test/java/org/apache/druid/guice/JettyHttpClientModuleTest.java
@@ -1,0 +1,73 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+package org.apache.druid.guice;
+
+import org.apache.druid.guice.http.JettyHttpClientModule;
+import org.apache.druid.java.util.common.Pair;
+import org.apache.druid.java.util.emitter.core.Emitter;
+import org.apache.druid.java.util.emitter.core.Event;
+import org.apache.druid.java.util.emitter.service.ServiceEmitter;
+import org.apache.druid.java.util.emitter.service.ServiceMetricEvent;
+import org.apache.druid.server.initialization.jetty.JettyServerModule;
+import org.eclipse.jetty.util.thread.QueuedThreadPool;
+import org.junit.Assert;
+import org.junit.Test;
+import org.mockito.Mockito;
+
+import java.util.ArrayList;
+import java.util.List;
+
+public class JettyHttpClientModuleTest
+{
+  @Test
+  public void testJettyHttpClientModule()
+  {
+    List<Event> events = new ArrayList<>();
+    ServiceEmitter serviceEmitter = new ServiceEmitter("service", "host", Mockito.mock(Emitter.class))
+    {
+      @Override
+      public void emit(Event event)
+      {
+        events.add(event);
+      }
+    };
+    QueuedThreadPool threadPool = Mockito.mock(QueuedThreadPool.class);
+    JettyServerModule.setJettyServerThreadPool(threadPool);
+    Mockito.when(threadPool.getThreads()).thenReturn(100);
+    Mockito.when(threadPool.getIdleThreads()).thenReturn(40);
+    Mockito.when(threadPool.isLowOnThreads()).thenReturn(true);
+    Mockito.when(threadPool.getMinThreads()).thenReturn(30);
+    Mockito.when(threadPool.getMaxThreads()).thenReturn(100);
+    Mockito.when(threadPool.getQueueSize()).thenReturn(50);
+    Mockito.when(threadPool.getBusyThreads()).thenReturn(60);
+
+    JettyHttpClientModule.JettyMonitor jettyMonitor = new JettyHttpClientModule.JettyMonitor("ds", "t0", threadPool);
+    jettyMonitor.doMonitor(serviceEmitter);
+
+    Assert.assertEquals(1, events.size());
+    Pair<String, Number> expectedEvent = new Pair<>("jetty/httpClient/threadpool/queueSize", 50);
+
+
+    ServiceMetricEvent actual = (ServiceMetricEvent) (events.get(0));
+    Assert.assertEquals(expectedEvent.lhs, actual.getMetric());
+    Assert.assertEquals(expectedEvent.rhs, actual.getValue());
+
+  }
+}


### PR DESCRIPTION
### Description

- Adding metrics for the queue size at the jetty HTTP Client.

#### Release note
<!-- Give your best effort to summarize your changes in a couple of sentences aimed toward Druid users. 

If your change doesn't have end user impact, you can skip this section.

-->
For tips about how to write a good release note, see [Release notes](https://github.com/apache/druid/blob/master/CONTRIBUTING.md#release-notes).


<hr>

##### Key changed/added classes in this PR
 * `MyFoo`
 * `OurBar`
 * `TheirBaz`

<hr>

<!-- Check the items by putting "x" in the brackets for the done things. Not all of these items apply to every PR. Remove the items which are not done or not relevant to the PR. None of the items from the checklist below are strictly necessary, but it would be very helpful if you at least self-review the PR. -->

This PR has:

- [ ] been self-reviewed.
   - [ ] using the [concurrency checklist](https://github.com/apache/druid/blob/master/dev/code-review/concurrency.md) (Remove this item if the PR doesn't have any relation to concurrency.)
- [ ] added documentation for new or modified features or behaviors.
- [ ] a release note entry in the PR description.
- [ ] added Javadocs for most classes and all non-trivial methods. Linked related entities via Javadoc links.
- [ ] added or updated version, license, or notice information in [licenses.yaml](https://github.com/apache/druid/blob/master/dev/license.md)
- [ ] added comments explaining the "why" and the intent of the code wherever would not be obvious for an unfamiliar reader.
- [ ] added unit tests or modified existing tests to cover new code paths, ensuring the threshold for [code coverage](https://github.com/apache/druid/blob/master/dev/code-review/code-coverage.md) is met.
- [ ] added integration tests.
- [ ] been tested in a test Druid cluster.
