### PR TITLE
Seek bytebuffer to end when encountered with exception

### DIFF
--- a/extensions-contrib/opencensus-extensions/src/main/java/org/apache/druid/data/input/opencensus/protobuf/OpenCensusProtobufReader.java
+++ b/extensions-contrib/opencensus-extensions/src/main/java/org/apache/druid/data/input/opencensus/protobuf/OpenCensusProtobufReader.java
@@ -104,15 +104,16 @@ public class OpenCensusProtobufReader implements InputEntityReader
   {
     ByteBuffer buffer = source.getEntity().getBuffer();
     try {
-      List<InputRow> rows = parseMetric(Metric.parseFrom(buffer));
-      // Explicitly move the position assuming that all the remaining bytes have been consumed because the protobuf
-      // parser does not update the position itself
-      buffer.position(buffer.limit());
-      return rows;
+      return parseMetric(Metric.parseFrom(buffer));
     }
     catch (InvalidProtocolBufferException e) {
-      buffer.position(buffer.limit());
       throw new ParseException(null, e, "Protobuf message could not be parsed");
+    }
+    finally {
+      // Explicitly move the position assuming that all the remaining bytes have been consumed because the protobuf
+      // parser does not update the position itself
+      // In case of an exception, the buffer is moved to the end to avoid parsing it in a loop.
+      buffer.position(buffer.limit());
     }
   }
 

--- a/extensions-contrib/opencensus-extensions/src/main/java/org/apache/druid/data/input/opencensus/protobuf/OpenCensusProtobufReader.java
+++ b/extensions-contrib/opencensus-extensions/src/main/java/org/apache/druid/data/input/opencensus/protobuf/OpenCensusProtobufReader.java
@@ -102,8 +102,8 @@ public class OpenCensusProtobufReader implements InputEntityReader
 
   List<InputRow> readAsList()
   {
+    ByteBuffer buffer = source.getEntity().getBuffer();
     try {
-      ByteBuffer buffer = source.getEntity().getBuffer();
       List<InputRow> rows = parseMetric(Metric.parseFrom(buffer));
       // Explicitly move the position assuming that all the remaining bytes have been consumed because the protobuf
       // parser does not update the position itself
@@ -111,6 +111,7 @@ public class OpenCensusProtobufReader implements InputEntityReader
       return rows;
     }
     catch (InvalidProtocolBufferException e) {
+      buffer.position(buffer.limit());
       throw new ParseException(null, e, "Protobuf message could not be parsed");
     }
   }

--- a/extensions-contrib/opencensus-extensions/src/test/java/org/apache/druid/data/input/opencensus/protobuf/OpenCensusProtobufReaderTest.java
+++ b/extensions-contrib/opencensus-extensions/src/test/java/org/apache/druid/data/input/opencensus/protobuf/OpenCensusProtobufReaderTest.java
@@ -51,6 +51,7 @@ import java.nio.ByteOrder;
 import java.time.Instant;
 import java.util.ArrayList;
 import java.util.List;
+import java.util.NoSuchElementException;
 import java.util.Optional;
 import java.util.concurrent.TimeUnit;
 
@@ -354,7 +355,7 @@ public class OpenCensusProtobufReaderTest
     entity.setEntity(new KafkaRecordEntity(consumerRecord));
     try (CloseableIterator<InputRow> rows = reader.read()) {
       Assert.assertThrows(ParseException.class, () -> rows.hasNext());
-      Assert.assertThrows(ParseException.class, () -> rows.next());
+      Assert.assertThrows(NoSuchElementException.class, () -> rows.next());
     }
   }
 

--- a/extensions-contrib/opentelemetry-extensions/src/main/java/org/apache/druid/data/input/opentelemetry/protobuf/OpenTelemetryMetricsProtobufReader.java
+++ b/extensions-contrib/opentelemetry-extensions/src/main/java/org/apache/druid/data/input/opentelemetry/protobuf/OpenTelemetryMetricsProtobufReader.java
@@ -100,8 +100,8 @@ public class OpenTelemetryMetricsProtobufReader implements InputEntityReader
 
   List<InputRow> readAsList()
   {
+    ByteBuffer buffer = source.getEntity().getBuffer();
     try {
-      ByteBuffer buffer = source.getEntity().getBuffer();
       List<InputRow> rows = parseMetricsData(MetricsData.parseFrom(buffer));
       // Explicitly move the position assuming that all the remaining bytes have been consumed because the protobuf
       // parser does not update the position itself
@@ -109,6 +109,7 @@ public class OpenTelemetryMetricsProtobufReader implements InputEntityReader
       return rows;
     }
     catch (InvalidProtocolBufferException e) {
+      buffer.position(buffer.limit());
       throw new ParseException(null, e, "Protobuf message could not be parsed");
     }
   }

--- a/extensions-contrib/opentelemetry-extensions/src/main/java/org/apache/druid/data/input/opentelemetry/protobuf/OpenTelemetryMetricsProtobufReader.java
+++ b/extensions-contrib/opentelemetry-extensions/src/main/java/org/apache/druid/data/input/opentelemetry/protobuf/OpenTelemetryMetricsProtobufReader.java
@@ -102,15 +102,16 @@ public class OpenTelemetryMetricsProtobufReader implements InputEntityReader
   {
     ByteBuffer buffer = source.getEntity().getBuffer();
     try {
-      List<InputRow> rows = parseMetricsData(MetricsData.parseFrom(buffer));
-      // Explicitly move the position assuming that all the remaining bytes have been consumed because the protobuf
-      // parser does not update the position itself
-      buffer.position(buffer.limit());
-      return rows;
+      return parseMetricsData(MetricsData.parseFrom(buffer));
     }
     catch (InvalidProtocolBufferException e) {
-      buffer.position(buffer.limit());
       throw new ParseException(null, e, "Protobuf message could not be parsed");
+    }
+    finally {
+      // Explicitly move the position assuming that all the remaining bytes have been consumed because the protobuf
+      // parser does not update the position itself
+      // In case of an exception, the buffer is moved to the end to avoid parsing it in a loop.
+      buffer.position(buffer.limit());
     }
   }
 

--- a/extensions-contrib/opentelemetry-extensions/src/test/java/org/apache/druid/data/input/opentelemetry/protobuf/OpenTelemetryMetricsProtobufReaderTest.java
+++ b/extensions-contrib/opentelemetry-extensions/src/test/java/org/apache/druid/data/input/opentelemetry/protobuf/OpenTelemetryMetricsProtobufReaderTest.java
@@ -43,6 +43,7 @@ import java.io.IOException;
 import java.time.Instant;
 import java.util.ArrayList;
 import java.util.List;
+import java.util.NoSuchElementException;
 import java.util.concurrent.TimeUnit;
 
 public class OpenTelemetryMetricsProtobufReaderTest
@@ -371,7 +372,7 @@ public class OpenTelemetryMetricsProtobufReaderTest
         "custom."
     ).read()) {
       Assert.assertThrows(ParseException.class, () -> rows.hasNext());
-      Assert.assertThrows(ParseException.class, () -> rows.next());
+      Assert.assertThrows(NoSuchElementException.class, () -> rows.next());
     }
     catch (IOException e) {
       // Comes from the implicit call to close. Ignore


### PR DESCRIPTION
<!-- Thanks for trying to help us make Apache Druid be the best it can be! Please fill out as much of the following information as is possible (where relevant, and remove it when irrelevant) to help make the intention and scope of this PR clear in order to ease review. -->

<!-- Please read the doc for contribution (https://github.com/apache/druid/blob/master/CONTRIBUTING.md) before making this PR. Also, once you open a PR, please _avoid using force pushes and rebasing_ since these make it difficult for reviewers to see what you've changed in response to their reviews. See [the 'If your pull request shows conflicts with master' section](https://github.com/apache/druid/blob/master/CONTRIBUTING.md#if-your-pull-request-shows-conflicts-with-master) for more details. -->


<!-- Replace XXXX with the id of the issue fixed in this PR. Remove this section if there is no corresponding issue. Don't reference the issue in the title of this pull-request. -->

<!-- If you are a committer, follow the PR action item checklist for committers:
https://github.com/apache/druid/blob/master/dev/committer-instructions.md#pr-and-issue-action-item-checklist-for-committers. -->

### Description

<!-- Describe the goal of this PR, what problem are you fixing. If there is a corresponding issue (referenced above), it's not necessary to repeat the description here, however, you may choose to keep one summary sentence. -->

<!-- Describe your patch: what did you change in code? How did you fix the problem? -->

<!-- If there are several relatively logically separate changes in this PR, create a mini-section for each of them. For example: -->

#### Fixed the bug which causes ingestion halt for invalid proto message
When Druid encounters an invalid protobuf kafka message, the ingestion on that partition gets halted as `hasNext()` method of the `FilteringCloseableInputRowIterator.java` gets stuck in a endless while loop, until maxParseExceptions is reached. 
The fix is to seek the byte buffer to its limit whenever there's a parsing failure. This would allow the buffer to move on and not get stuck at the same place. 

<!--
In each section, please describe design decisions made, including:
 - Choice of algorithms
 - Behavioral aspects. What configuration values are acceptable? How are corner cases and error conditions handled, such as when there are insufficient resources?
 - Class organization and design (how the logic is split between classes, inheritance, composition, design patterns)
 - Method organization and design (how the logic is split between methods, parameters and return types)
 - Naming (class, method, API, configuration, HTTP endpoint, names of emitted metrics)
-->


<!-- It's good to describe an alternative design (or mention an alternative name) for every design (or naming) decision point and compare the alternatives with the designs that you've implemented (or the names you've chosen) to highlight the advantages of the chosen designs and names. -->

<!-- If there was a discussion of the design of the feature implemented in this PR elsewhere (e. g. a "Proposal" issue, any other issue, or a thread in the development mailing list), link to that discussion from this PR description and explain what have changed in your final design compared to your original proposal or the consensus version in the end of the discussion. If something hasn't changed since the original discussion, you can omit a detailed discussion of those aspects of the design here, perhaps apart from brief mentioning for the sake of readability of this PR description. -->

<!-- Some of the aspects mentioned above may be omitted for simple and small changes. -->

#### Release note
<!-- Give your best effort to summarize your changes in a couple of sentences aimed toward Druid users. 

If your change doesn't have end user impact, you can skip this section.

-->
For tips about how to write a good release note, see [Release notes](https://github.com/apache/druid/blob/master/CONTRIBUTING.md#release-notes).


<hr>


<hr>

<!-- Check the items by putting "x" in the brackets for the done things. Not all of these items apply to every PR. Remove the items which are not done or not relevant to the PR. None of the items from the checklist below are strictly necessary, but it would be very helpful if you at least self-review the PR. -->

This PR has:

- [x] been self-reviewed.
   - [x] using the [concurrency checklist](https://github.com/apache/druid/blob/master/dev/code-review/concurrency.md) (Remove this item if the PR doesn't have any relation to concurrency.)
- [ ] added documentation for new or modified features or behaviors.
- [ ] a release note entry in the PR description.
- [ ] added Javadocs for most classes and all non-trivial methods. Linked related entities via Javadoc links.
- [ ] added or updated version, license, or notice information in [licenses.yaml](https://github.com/apache/druid/blob/master/dev/license.md)
- [ ] added comments explaining the "why" and the intent of the code wherever would not be obvious for an unfamiliar reader.
- [ ] added unit tests or modified existing tests to cover new code paths, ensuring the threshold for [code coverage](https://github.com/apache/druid/blob/master/dev/code-review/code-coverage.md) is met.
- [ ] added integration tests.
- [ ] been tested in a test Druid cluster.
