### PR TITLE
Add additional header to broker to support segment count

### DIFF
--- a/processing/src/main/java/org/apache/druid/query/context/ResponseContext.java
+++ b/processing/src/main/java/org/apache/druid/query/context/ResponseContext.java
@@ -406,6 +406,13 @@ public abstract class ResponseContext
     };
 
     /**
+     * Query Segment Count.
+     */
+    public static final Key QUERY_SEGMENT_COUNT = new LongKey(
+            "querySegmentCount",
+            false);
+
+    /**
      * Query fail time (current time + timeout).
      */
     public static final Key QUERY_FAIL_DEADLINE_MILLIS = new LongKey(
@@ -474,6 +481,7 @@ public abstract class ResponseContext
           NUM_SCANNED_ROWS,
           CPU_CONSUMED_NANOS,
           TRUNCATED,
+          QUERY_SEGMENT_COUNT,
       });
     }
 

--- a/server/src/main/java/org/apache/druid/client/CachingClusteredClient.java
+++ b/server/src/main/java/org/apache/druid/client/CachingClusteredClient.java
@@ -369,6 +369,7 @@ public class CachingClusteredClient implements QuerySegmentWalker
       query = scheduler.prioritizeAndLaneQuery(queryPlus, segmentServers);
       queryPlus = queryPlus.withQuery(query);
       queryPlus = queryPlus.withQueryMetrics(toolChest);
+      this.responseContext.put(ResponseContext.Keys.QUERY_SEGMENT_COUNT, segmentServers.size());
       queryPlus.getQueryMetrics().reportQueriedSegmentCount(segmentServers.size()).emit(emitter);
 
       final SortedMap<DruidServer, List<SegmentDescriptor>> segmentsByServer = groupSegmentsByServer(segmentServers);

--- a/server/src/main/java/org/apache/druid/server/QueryResource.java
+++ b/server/src/main/java/org/apache/druid/server/QueryResource.java
@@ -99,6 +99,7 @@ public class QueryResource implements QueryCountStatsProvider
   public static final String HEADER_RESPONSE_CONTEXT = "X-Druid-Response-Context";
   public static final String HEADER_IF_NONE_MATCH = "If-None-Match";
   public static final String QUERY_ID_RESPONSE_HEADER = "X-Druid-Query-Id";
+  public static final String QUERY_SEGMENT_COUNT_HEADER = "X-Druid-Query-Segment-Count";
   public static final String HEADER_ETAG = "ETag";
 
   protected final QueryLifecycleFactory queryLifecycleFactory;
@@ -253,7 +254,10 @@ public class QueryResource implements QueryCountStatsProvider
                 },
                 ioReaderWriter.getResponseWriter().getResponseType()
             )
-            .header(QUERY_ID_RESPONSE_HEADER, queryId);
+            .header(QUERY_ID_RESPONSE_HEADER, queryId)
+            .header(QUERY_SEGMENT_COUNT_HEADER,
+                    responseContext.get(ResponseContext.Keys.QUERY_SEGMENT_COUNT) != null ?
+                            responseContext.get(ResponseContext.Keys.QUERY_SEGMENT_COUNT) : 0);
 
         attachResponseContextToHttpResponse(queryId, responseContext, responseBuilder, jsonMapper,
                                             responseContextConfig, selfNode

--- a/server/src/test/java/org/apache/druid/client/CachingClusteredClientTest.java
+++ b/server/src/test/java/org/apache/druid/client/CachingClusteredClientTest.java
@@ -3340,6 +3340,7 @@ public class CachingClusteredClientTest
     final ResponseContext responseContext = initializeResponseContext();
 
     getDefaultQueryRunner().run(QueryPlus.wrap(query), responseContext);
+    Assert.assertEquals(1, (int) responseContext.get(ResponseContext.Keys.QUERY_SEGMENT_COUNT));
     final String etag1 = responseContext.getEntityTag();
     getDefaultQueryRunner().run(QueryPlus.wrap(query2), responseContext);
     final String etag2 = responseContext.getEntityTag();

--- a/server/src/test/java/org/apache/druid/server/QueryResourceTest.java
+++ b/server/src/test/java/org/apache/druid/server/QueryResourceTest.java
@@ -96,6 +96,7 @@ import java.util.List;
 import java.util.concurrent.CountDownLatch;
 import java.util.concurrent.Executors;
 import java.util.function.Consumer;
+import java.util.Locale;
 
 public class QueryResourceTest
 {
@@ -249,6 +250,8 @@ public class QueryResourceTest
         testServletRequest
     );
     Assert.assertNotNull(response);
+    Assert.assertTrue(String.format(Locale.ENGLISH, "Successful query response must have header %s", QueryResource.QUERY_SEGMENT_COUNT_HEADER),
+            response.getMetadata().containsKey(QueryResource.QUERY_SEGMENT_COUNT_HEADER));
   }
 
   @Test

--- a/server/src/test/java/org/apache/druid/server/QueryResourceTest.java
+++ b/server/src/test/java/org/apache/druid/server/QueryResourceTest.java
@@ -93,10 +93,10 @@ import java.nio.charset.StandardCharsets;
 import java.util.Collection;
 import java.util.Collections;
 import java.util.List;
+import java.util.Locale;
 import java.util.concurrent.CountDownLatch;
 import java.util.concurrent.Executors;
 import java.util.function.Consumer;
-import java.util.Locale;
 
 public class QueryResourceTest
 {

--- a/sql/src/test/java/org/apache/druid/sql/http/SqlResourceTest.java
+++ b/sql/src/test/java/org/apache/druid/sql/http/SqlResourceTest.java
@@ -61,6 +61,7 @@ import org.apache.druid.query.ResourceLimitExceededException;
 import org.apache.druid.query.context.ResponseContext;
 import org.apache.druid.query.groupby.GroupByQueryConfig;
 import org.apache.druid.server.DruidNode;
+import org.apache.druid.server.QueryResource;
 import org.apache.druid.server.QueryResponse;
 import org.apache.druid.server.QueryScheduler;
 import org.apache.druid.server.QueryStackTests;
@@ -342,6 +343,15 @@ public class SqlResourceTest extends CalciteTestBase
     }
     Assert.assertEquals(0, testRequestLogger.getSqlQueryLogs().size());
     Assert.assertTrue(lifecycleManager.getAll("id").isEmpty());
+  }
+
+  @Test
+  public void testGoodQuery() throws Exception
+  {
+    final Response response = resource.doPost(createSimpleQueryWithId("id", "SELECT COUNT(*) AS cnt, 'foo' AS TheFoo FROM druid.foo"), req);
+    Assert.assertNotNull(response);
+    Assert.assertTrue(String.format("Successful query response must have header %s", QueryResource.QUERY_SEGMENT_COUNT_HEADER),
+            response.getMetadata().containsKey(QueryResource.QUERY_SEGMENT_COUNT_HEADER));
   }
 
   @Test

--- a/sql/src/test/java/org/apache/druid/sql/http/SqlResourceTest.java
+++ b/sql/src/test/java/org/apache/druid/sql/http/SqlResourceTest.java
@@ -120,6 +120,7 @@ import java.util.Arrays;
 import java.util.Collections;
 import java.util.HashMap;
 import java.util.List;
+import java.util.Locale;
 import java.util.Map;
 import java.util.Optional;
 import java.util.Set;
@@ -350,7 +351,7 @@ public class SqlResourceTest extends CalciteTestBase
   {
     final Response response = resource.doPost(createSimpleQueryWithId("id", "SELECT COUNT(*) AS cnt, 'foo' AS TheFoo FROM druid.foo"), req);
     Assert.assertNotNull(response);
-    Assert.assertTrue(String.format("Successful query response must have header %s", QueryResource.QUERY_SEGMENT_COUNT_HEADER),
+    Assert.assertTrue(String.format(Locale.ENGLISH, "Successful query response must have header %s", QueryResource.QUERY_SEGMENT_COUNT_HEADER),
             response.getMetadata().containsKey(QueryResource.QUERY_SEGMENT_COUNT_HEADER));
   }
 


### PR DESCRIPTION
Adds additional header to broker to support segment count

OBSDATA-4891 

### Description
Adds additional header to broker to support segment count

<!-- Check the items by putting "x" in the brackets for the done things. Not all of these items apply to every PR. Remove the items which are not done or not relevant to the PR. None of the items from the checklist below are strictly necessary, but it would be very helpful if you at least self-review the PR. -->

This PR has:

- [x ] been self-reviewed.
   - [ ] using the [concurrency checklist](https://github.com/apache/druid/blob/master/dev/code-review/concurrency.md) (Remove this item if the PR doesn't have any relation to concurrency.)
- [ ] added documentation for new or modified features or behaviors.
- [ ] a release note entry in the PR description.
- [ ] added Javadocs for most classes and all non-trivial methods. Linked related entities via Javadoc links.
- [ ] added or updated version, license, or notice information in [licenses.yaml](https://github.com/apache/druid/blob/master/dev/license.md)
- [ ] added comments explaining the "why" and the intent of the code wherever would not be obvious for an unfamiliar reader.
- [ x] added unit tests or modified existing tests to cover new code paths, ensuring the threshold for [code coverage](https://github.com/apache/druid/blob/master/dev/code-review/code-coverage.md) is met.
- [ ] added integration tests.
- [ x] been tested in a test Druid cluster.
