### PR TITLE
Emit Broker time as a response header

### DIFF
--- a/server/src/test/java/org/apache/druid/server/QueryResourceTest.java
+++ b/server/src/test/java/org/apache/druid/server/QueryResourceTest.java
@@ -252,6 +252,8 @@ public class QueryResourceTest
     Assert.assertNotNull(response);
     Assert.assertTrue(String.format(Locale.ENGLISH, "Successful query response must have header %s", QueryResource.QUERY_SEGMENT_COUNT_HEADER),
             response.getMetadata().containsKey(QueryResource.QUERY_SEGMENT_COUNT_HEADER));
+    Assert.assertTrue(String.format(Locale.ENGLISH, "Successful query response must have header %s", QueryResource.BROKER_QUERY_TIME_RESPONSE_HEADER),
+            response.getMetadata().containsKey(QueryResource.BROKER_QUERY_TIME_RESPONSE_HEADER));
   }
 
   @Test

--- a/sql/src/main/java/org/apache/druid/sql/http/SqlResource.java
+++ b/sql/src/main/java/org/apache/druid/sql/http/SqlResource.java
@@ -76,6 +76,7 @@ import java.io.IOException;
 import java.io.OutputStream;
 import java.util.List;
 import java.util.Set;
+import java.util.concurrent.TimeUnit;
 import java.util.stream.Collectors;
 
 @Path("/druid/v2/sql/")
@@ -84,6 +85,7 @@ public class SqlResource
   public static final String SQL_QUERY_ID_RESPONSE_HEADER = "X-Druid-SQL-Query-Id";
   public static final String SQL_HEADER_RESPONSE_HEADER = "X-Druid-SQL-Header-Included";
   public static final String QUERY_SEGMENT_COUNT_HEADER = "X-Druid-Query-Segment-Count";
+  public static final String BROKER_QUERY_TIME_RESPONSE_HEADER = "X-Broker-Query-Time";
   public static final String SQL_HEADER_VALUE = "yes";
   private static final Logger log = new Logger(SqlResource.class);
 
@@ -127,6 +129,7 @@ public class SqlResource
     final HttpStatement stmt = sqlStatementFactory.httpStatement(sqlQuery, req);
     final String sqlQueryId = stmt.sqlQueryId();
     final String currThreadName = Thread.currentThread().getName();
+    long startTime = System.nanoTime();
 
     try {
       Thread.currentThread().setName(StringUtils.format("sql[%s]", sqlQueryId));
@@ -192,7 +195,9 @@ public class SqlResource
               }
           )
           .header(SQL_QUERY_ID_RESPONSE_HEADER, sqlQueryId)
-          .header(QUERY_SEGMENT_COUNT_HEADER, segmentCount);
+          .header(QUERY_SEGMENT_COUNT_HEADER, segmentCount)
+          .header(BROKER_QUERY_TIME_RESPONSE_HEADER,
+                  TimeUnit.NANOSECONDS.toMillis(System.nanoTime() - startTime));
 
       if (sqlQuery.includeHeader()) {
         responseBuilder.header(SQL_HEADER_RESPONSE_HEADER, SQL_HEADER_VALUE);

--- a/sql/src/test/java/org/apache/druid/sql/http/SqlResourceTest.java
+++ b/sql/src/test/java/org/apache/druid/sql/http/SqlResourceTest.java
@@ -353,6 +353,8 @@ public class SqlResourceTest extends CalciteTestBase
     Assert.assertNotNull(response);
     Assert.assertTrue(String.format(Locale.ENGLISH, "Successful query response must have header %s", QueryResource.QUERY_SEGMENT_COUNT_HEADER),
             response.getMetadata().containsKey(QueryResource.QUERY_SEGMENT_COUNT_HEADER));
+    Assert.assertTrue(String.format(Locale.ENGLISH, "Successful query response must have header %s", QueryResource.BROKER_QUERY_TIME_RESPONSE_HEADER),
+            response.getMetadata().containsKey(QueryResource.BROKER_QUERY_TIME_RESPONSE_HEADER));
   }
 
   @Test


### PR DESCRIPTION
Add additional header to broker to emit Broker time

OBSDATA-4862

### Description
Add additional header to broker to emit Broker time

<!-- Check the items by putting "x" in the brackets for the done things. Not all of these items apply to every PR. Remove the items which are not done or not relevant to the PR. None of the items from the checklist below are strictly necessary, but it would be very helpful if you at least self-review the PR. -->

This PR has:

- [x ] been self-reviewed.
   - [ ] using the [concurrency checklist](https://github.com/apache/druid/blob/master/dev/code-review/concurrency.md) (Remove this item if the PR doesn't have any relation to concurrency.)
- [ ] added documentation for new or modified features or behaviors.
- [ ] a release note entry in the PR description.
- [ ] added Javadocs for most classes and all non-trivial methods. Linked related entities via Javadoc links.
- [ ] added or updated version, license, or notice information in [licenses.yaml](https://github.com/apache/druid/blob/master/dev/license.md)
- [ ] added comments explaining the "why" and the intent of the code wherever would not be obvious for an unfamiliar reader.
- [ x] added unit tests or modified existing tests to cover new code paths, ensuring the threshold for [code coverage](https://github.com/apache/druid/blob/master/dev/code-review/code-coverage.md) is met.
- [ ] added integration tests.
- [ x] been tested in a test Druid cluster.
