### PR TITLE
[BACKPORT] feat: add the number of merge buffers used for druid emitter (#49)

### DIFF
--- a/core/src/main/java/org/apache/druid/collections/BlockingPool.java
+++ b/core/src/main/java/org/apache/druid/collections/BlockingPool.java
@@ -49,4 +49,9 @@ public interface BlockingPool<T>
    * @return count of pending requests
    */
   long getPendingRequests();
+
+  /**
+   * @return number of buffers used/polled from the pool at that time.
+   */
+  int getUsedBufferCount();
 }

--- a/core/src/main/java/org/apache/druid/collections/DefaultBlockingPool.java
+++ b/core/src/main/java/org/apache/druid/collections/DefaultBlockingPool.java
@@ -212,4 +212,10 @@ public class DefaultBlockingPool<T> implements BlockingPool<T>
       lock.unlock();
     }
   }
+
+  @Override
+  public int getUsedBufferCount()
+  {
+    return maxSize - objects.size();
+  }
 }

--- a/core/src/main/java/org/apache/druid/collections/DummyBlockingPool.java
+++ b/core/src/main/java/org/apache/druid/collections/DummyBlockingPool.java
@@ -61,4 +61,10 @@ public final class DummyBlockingPool<T> implements BlockingPool<T>
   {
     return 0;
   }
+
+  @Override
+  public int getUsedBufferCount()
+  {
+    return 0;
+  }
 }

--- a/core/src/test/java/org/apache/druid/collections/BlockingPoolTest.java
+++ b/core/src/test/java/org/apache/druid/collections/BlockingPoolTest.java
@@ -292,4 +292,14 @@ public class BlockingPoolTest
     r2.forEach(ReferenceCountingResourceHolder::close);
     Assert.assertEquals(pool.maxSize(), pool.getPoolSize());
   }
+
+  @Test(timeout = 60_000L)
+  public void testGetUsedBufferCount()
+  {
+    final List<ReferenceCountingResourceHolder<Integer>> holder = pool.takeBatch(6, 100L);
+    Assert.assertNotNull(holder);
+    Assert.assertEquals(6, pool.getUsedBufferCount());
+    holder.forEach(ReferenceCountingResourceHolder::close);
+    Assert.assertEquals(0, pool.getUsedBufferCount());
+  }
 }

--- a/docs/operations/metrics.md
+++ b/docs/operations/metrics.md
@@ -58,6 +58,7 @@ Metrics may have additional dimensions beyond those listed above.
 |`query/success/count`|Number of queries successfully processed.|This metric is only available if the `QueryCountStatsMonitor` module is included.| |
 |`query/failed/count`|Number of failed queries.|This metric is only available if the `QueryCountStatsMonitor` module is included.| |
 |`query/interrupted/count`|Number of queries interrupted due to cancellation.|This metric is only available if the `QueryCountStatsMonitor` module is included.| |
+|`query/merge/buffersUsed`|Number of merge buffers used up to merge the results of group by queries.|This metric is only available if the `QueryCountStatsMonitor` module is included.| |
 |`query/timeout/count`|Number of timed out queries.|This metric is only available if the `QueryCountStatsMonitor` module is included.| |
 |`mergeBuffer/pendingRequests`|Number of requests waiting to acquire a batch of buffers from the merge buffer pool.|This metric is only available if the `QueryCountStatsMonitor` module is included.| |
 |`query/segments/count`|This metric is not enabled by default. See the `QueryMetrics` Interface for reference regarding enabling this metric. Number of segments that will be touched by the query. In the broker, it makes a plan to distribute the query to realtime tasks and historicals based on a snapshot of segment distribution state. If there are some segments moved after this snapshot is created, certain historicals and realtime tasks can report those segments as missing to the broker. The broker will resend the query to the new servers that serve those segments after move. In this case, those segments can be counted more than once in this metric.||Varies|
@@ -81,6 +82,7 @@ Metrics may have additional dimensions beyond those listed above.
 |`query/success/count`|Number of queries successfully processed.|This metric is only available if the `QueryCountStatsMonitor` module is included.||
 |`query/failed/count`|Number of failed queries.|This metric is only available if the `QueryCountStatsMonitor` module is included.||
 |`query/interrupted/count`|Number of queries interrupted due to cancellation.|This metric is only available if the `QueryCountStatsMonitor` module is included.||
+|`query/merge/buffersUsed`|Number of merge buffers used up to merge the results of group by queries.|This metric is only available if the `QueryCountStatsMonitor` module is included.| |
 |`query/timeout/count`|Number of timed out queries.|This metric is only available if the `QueryCountStatsMonitor` module is included.||
 |`mergeBuffer/pendingRequests`|Number of requests waiting to acquire a batch of buffers from the merge buffer pool.|This metric is only available if the `QueryCountStatsMonitor` module is included.||
 
@@ -98,6 +100,8 @@ Metrics may have additional dimensions beyond those listed above.
 |`query/failed/count`|Number of failed queries.|This metric is only available if the `QueryCountStatsMonitor` module is included.||
 |`query/interrupted/count`|Number of queries interrupted due to cancellation.|This metric is only available if the `QueryCountStatsMonitor` module is included.||
 |`query/timeout/count`|Number of timed out queries.|This metric is only available if the `QueryCountStatsMonitor` module is included.||
+|`query/merge/buffersUsed`|Number of merge buffers used up to merge the results of group by queries.|This metric is only available if the `QueryCountStatsMonitor` module is included.||
+|`mergeBuffer/pendingRequests`|Number of requests waiting to acquire a batch of buffers from the merge buffer pool.|This metric is only available if the `QueryCountStatsMonitor` module is included.||
 
 ### Jetty
 

--- a/processing/src/main/java/org/apache/druid/query/MetricsEmittingMergingBlockingPool.java
+++ b/processing/src/main/java/org/apache/druid/query/MetricsEmittingMergingBlockingPool.java
@@ -41,7 +41,9 @@ public class MetricsEmittingMergingBlockingPool<T> extends DefaultBlockingPool<T
   @Override
   public void emitMetrics(ServiceEmitter emitter, ServiceMetricEvent.Builder metricBuilder)
   {
-    emitter.emit(metricBuilder.setMetric("query/merge/buffersUsed", getUsedBufferCount()));
-    emitter.emit(metricBuilder.setMetric("query/merge/totalBuffers", maxSize()));
+    emitter.emit(ServiceMetricEvent.builder()
+                                   .build("query/merge/buffersUsed", getUsedBufferCount()));
+    emitter.emit(ServiceMetricEvent.builder()
+                                   .build("query/merge/totalBuffers", getUsedBufferCount()));
   }
 }

--- a/processing/src/main/java/org/apache/druid/query/MetricsEmittingMergingBlockingPool.java
+++ b/processing/src/main/java/org/apache/druid/query/MetricsEmittingMergingBlockingPool.java
@@ -1,0 +1,47 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+package org.apache.druid.query;
+
+import com.google.common.base.Supplier;
+import org.apache.druid.collections.DefaultBlockingPool;
+import org.apache.druid.java.util.emitter.service.ServiceEmitter;
+import org.apache.druid.java.util.emitter.service.ServiceMetricEvent;
+
+public class MetricsEmittingMergingBlockingPool<T> extends DefaultBlockingPool<T>
+    implements ExecutorServiceMonitor.MetricEmitter
+{
+
+  public MetricsEmittingMergingBlockingPool(
+      Supplier<T> generator,
+      int limit,
+      ExecutorServiceMonitor executorServiceMonitor
+  )
+  {
+    super(generator, limit);
+    executorServiceMonitor.add(this);
+  }
+
+  @Override
+  public void emitMetrics(ServiceEmitter emitter, ServiceMetricEvent.Builder metricBuilder)
+  {
+    emitter.emit(metricBuilder.setMetric("query/merge/buffersUsed", getUsedBufferCount()));
+    emitter.emit(metricBuilder.setMetric("query/merge/totalBuffers", maxSize()));
+  }
+}

--- a/processing/src/main/java/org/apache/druid/query/MetricsEmittingMergingBlockingPool.java
+++ b/processing/src/main/java/org/apache/druid/query/MetricsEmittingMergingBlockingPool.java
@@ -41,9 +41,7 @@ public class MetricsEmittingMergingBlockingPool<T> extends DefaultBlockingPool<T
   @Override
   public void emitMetrics(ServiceEmitter emitter, ServiceMetricEvent.Builder metricBuilder)
   {
-    emitter.emit(ServiceMetricEvent.builder()
-                                   .build("query/merge/buffersUsed", getUsedBufferCount()));
-    emitter.emit(ServiceMetricEvent.builder()
-                                   .build("query/merge/totalBuffers", getUsedBufferCount()));
+    emitter.emit(metricBuilder.build("query/merge/buffersUsed", getUsedBufferCount()));
+    emitter.emit(metricBuilder.build("query/merge/totalBuffers",  maxSize()));
   }
 }

--- a/processing/src/main/java/org/apache/druid/query/MetricsEmittingMergingBlockingPool.java
+++ b/processing/src/main/java/org/apache/druid/query/MetricsEmittingMergingBlockingPool.java
@@ -42,6 +42,6 @@ public class MetricsEmittingMergingBlockingPool<T> extends DefaultBlockingPool<T
   public void emitMetrics(ServiceEmitter emitter, ServiceMetricEvent.Builder metricBuilder)
   {
     emitter.emit(metricBuilder.build("query/merge/buffersUsed", getUsedBufferCount()));
-    emitter.emit(metricBuilder.build("query/merge/totalBuffers",  maxSize()));
+    emitter.emit(metricBuilder.build("query/merge/totalBuffers", maxSize()));
   }
 }

--- a/processing/src/test/java/org/apache/druid/query/TestBufferPool.java
+++ b/processing/src/test/java/org/apache/druid/query/TestBufferPool.java
@@ -147,4 +147,10 @@ public class TestBufferPool implements NonBlockingPool<ByteBuffer>, BlockingPool
   {
     return takenFromMap.values();
   }
+
+  @Override
+  public int getUsedBufferCount()
+  {
+    return takenFromMap.size();
+  }
 }

--- a/server/src/main/java/org/apache/druid/guice/DruidProcessingModule.java
+++ b/server/src/main/java/org/apache/druid/guice/DruidProcessingModule.java
@@ -31,7 +31,6 @@ import org.apache.druid.client.cache.CachePopulator;
 import org.apache.druid.client.cache.CachePopulatorStats;
 import org.apache.druid.client.cache.ForegroundCachePopulator;
 import org.apache.druid.collections.BlockingPool;
-import org.apache.druid.collections.DefaultBlockingPool;
 import org.apache.druid.collections.NonBlockingPool;
 import org.apache.druid.collections.StupidPool;
 import org.apache.druid.guice.annotations.Global;
@@ -44,6 +43,7 @@ import org.apache.druid.java.util.common.logger.Logger;
 import org.apache.druid.offheap.OffheapBufferGenerator;
 import org.apache.druid.query.DruidProcessingConfig;
 import org.apache.druid.query.ExecutorServiceMonitor;
+import org.apache.druid.query.MetricsEmittingMergingBlockingPool;
 import org.apache.druid.query.MetricsEmittingQueryProcessingPool;
 import org.apache.druid.query.PrioritizedExecutorService;
 import org.apache.druid.query.QueryProcessingPool;
@@ -126,12 +126,13 @@ public class DruidProcessingModule implements Module
   @Provides
   @LazySingleton
   @Merging
-  public BlockingPool<ByteBuffer> getMergeBufferPool(DruidProcessingConfig config)
+  public BlockingPool<ByteBuffer> getMergeBufferPool(DruidProcessingConfig config, ExecutorServiceMonitor executorServiceMonitor)
   {
     verifyDirectMemory(config);
-    return new DefaultBlockingPool<>(
+    return new MetricsEmittingMergingBlockingPool<>(
         new OffheapBufferGenerator("result merging", config.intermediateComputeSizeBytes()),
-        config.getNumMergeBuffers()
+        config.getNumMergeBuffers(),
+        executorServiceMonitor
     );
   }
 


### PR DESCRIPTION
This PR adds the metric for number of merge buffers used.

While cherry-picking, updated the code at:
```
@Provides
  @LazySingleton
  @Merging
  public BlockingPool<ByteBuffer> getMergeBufferPool(DruidProcessingConfig config, ExecutorServiceMonitor executorServiceMonitor)
  {
    verifyDirectMemory(config);
    return new MetricsEmittingMergingBlockingPool<>(
        new OffheapBufferGenerator("result merging", config.intermediateComputeSizeBytes()),
        config.getNumMergeBuffers(),
        executorServiceMonitor
    );
  }
  ```
  as the upstream one had different function definition which was changed in this PR: https://github.com/apache/druid/commit/72fbaf2e56e7606e4ba8862dbcd70a2687bb843b#diff-ac792edffdc7ef597fa20e25bdea5df2f5a9e3cf149cdb741d7a90c3c5d0262aR176

Also updated the way in which metrics are emitted because https://github.com/apache/druid/pull/14933 PR is not yet backported.
<!-- Thanks for trying to help us make Apache Druid be the best it can be! Please fill out as much of the following information as is possible (where relevant, and remove it when irrelevant) to help make the intention and scope of this PR clear in order to ease review. -->

<!-- Please read the doc for contribution (https://github.com/apache/druid/blob/master/CONTRIBUTING.md) before making this PR. Also, once you open a PR, please _avoid using force pushes and rebasing_ since these make it difficult for reviewers to see what you've changed in response to their reviews. See [the 'If your pull request shows conflicts with master' section](https://github.com/apache/druid/blob/master/CONTRIBUTING.md#if-your-pull-request-shows-conflicts-with-master) for more details. -->

Fixes #XXXX.

<!-- Replace XXXX with the id of the issue fixed in this PR. Remove this section if there is no corresponding issue. Don't reference the issue in the title of this pull-request. -->

<!-- If you are a committer, follow the PR action item checklist for committers:
https://github.com/apache/druid/blob/master/dev/committer-instructions.md#pr-and-issue-action-item-checklist-for-committers. -->

### Description

<!-- Describe the goal of this PR, what problem are you fixing. If there is a corresponding issue (referenced above), it's not necessary to repeat the description here, however, you may choose to keep one summary sentence. -->

<!-- Describe your patch: what did you change in code? How did you fix the problem? -->

<!-- If there are several relatively logically separate changes in this PR, create a mini-section for each of them. For example: -->

#### Fixed the bug ...
#### Renamed the class ...
#### Added a forbidden-apis entry ...

<!--
In each section, please describe design decisions made, including:
 - Choice of algorithms
 - Behavioral aspects. What configuration values are acceptable? How are corner cases and error conditions handled, such as when there are insufficient resources?
 - Class organization and design (how the logic is split between classes, inheritance, composition, design patterns)
 - Method organization and design (how the logic is split between methods, parameters and return types)
 - Naming (class, method, API, configuration, HTTP endpoint, names of emitted metrics)
-->


<!-- It's good to describe an alternative design (or mention an alternative name) for every design (or naming) decision point and compare the alternatives with the designs that you've implemented (or the names you've chosen) to highlight the advantages of the chosen designs and names. -->

<!-- If there was a discussion of the design of the feature implemented in this PR elsewhere (e. g. a "Proposal" issue, any other issue, or a thread in the development mailing list), link to that discussion from this PR description and explain what have changed in your final design compared to your original proposal or the consensus version in the end of the discussion. If something hasn't changed since the original discussion, you can omit a detailed discussion of those aspects of the design here, perhaps apart from brief mentioning for the sake of readability of this PR description. -->

<!-- Some of the aspects mentioned above may be omitted for simple and small changes. -->

#### Release note
<!-- Give your best effort to summarize your changes in a couple of sentences aimed toward Druid users. 

If your change doesn't have end user impact, you can skip this section.

-->
For tips about how to write a good release note, see [Release notes](https://github.com/apache/druid/blob/master/CONTRIBUTING.md#release-notes).


<hr>

##### Key changed/added classes in this PR
 * `MyFoo`
 * `OurBar`
 * `TheirBaz`

<hr>

<!-- Check the items by putting "x" in the brackets for the done things. Not all of these items apply to every PR. Remove the items which are not done or not relevant to the PR. None of the items from the checklist below are strictly necessary, but it would be very helpful if you at least self-review the PR. -->

This PR has:

- [ ] been self-reviewed.
   - [ ] using the [concurrency checklist](https://github.com/apache/druid/blob/master/dev/code-review/concurrency.md) (Remove this item if the PR doesn't have any relation to concurrency.)
- [ ] added documentation for new or modified features or behaviors.
- [ ] a release note entry in the PR description.
- [ ] added Javadocs for most classes and all non-trivial methods. Linked related entities via Javadoc links.
- [ ] added or updated version, license, or notice information in [licenses.yaml](https://github.com/apache/druid/blob/master/dev/license.md)
- [ ] added comments explaining the "why" and the intent of the code wherever would not be obvious for an unfamiliar reader.
- [ ] added unit tests or modified existing tests to cover new code paths, ensuring the threshold for [code coverage](https://github.com/apache/druid/blob/master/dev/code-review/code-coverage.md) is met.
- [ ] added integration tests.
- [ ] been tested in a test Druid cluster.
