### PR TITLE
OBSDATA-5342 Emit query planning time metric

### DIFF
--- a/docs/design/extensions-contrib/dropwizard.md
+++ b/docs/design/extensions-contrib/dropwizard.md
@@ -102,6 +102,14 @@ Latest default metrics mapping can be found [here] (https://github.com/apache/dr
     "type": "timer",
     "timeUnit": "MILLISECONDS"
   },
+  "query/planningTime": {
+    "dimensions": [
+      "dataSource",
+      "type"
+    ],
+    "type": "timer",
+    "timeUnit": "MILLISECONDS"
+  },
   "query/node/time": {
     "dimensions": [
       "server"

--- a/docs/operations/metrics.md
+++ b/docs/operations/metrics.md
@@ -49,6 +49,7 @@ Metrics may have additional dimensions beyond those listed above.
 |Metric|Description|Dimensions|Normal Value|
 |------|-----------|----------|------------|
 |`query/time`|Milliseconds taken to complete a query.|<p>Common: `dataSource`, `type`, `interval`, `hasFilters`, `duration`, `context`, `remoteAddress`, `id`.</p><p>Aggregation Queries: `numMetrics`, `numComplexMetrics`.</p><p>GroupBy: `numDimensions`.</p><p> TopN: `threshold`, `dimension`.</p>|< 1s|
+|`query/planningTime`|Milliseconds taken to complete query planning at Broker before query is fanned out to the Data nodes.|<p>Common: `dataSource`, `type`, `interval`, `hasFilters`, `duration`, `context`, `remoteAddress`, `id`.</p><p>Aggregation Queries: `numMetrics`, `numComplexMetrics`.</p><p>GroupBy: `numDimensions`.</p><p> TopN: `threshold`, `dimension`.</p>|< 1s|
 |`query/bytes`|The total number of bytes returned to the requesting client in the query response from the broker. Other services report the total bytes for their portion of the query. |<p>Common: `dataSource`, `type`, `interval`, `hasFilters`, `duration`, `context`, `remoteAddress`, `id`.</p><p> Aggregation Queries: `numMetrics`, `numComplexMetrics`.</p><p> GroupBy: `numDimensions`.</p><p> TopN: `threshold`, `dimension`.</p>| |
 |`query/node/time`|Milliseconds taken to query individual historical/realtime processes.|`id`, `status`, `server`|< 1s|
 |`query/node/bytes`|Number of bytes returned from querying individual historical/realtime processes.|`id`, `status`, `server`| |

--- a/extensions-contrib/ambari-metrics-emitter/src/main/resources/defaultWhiteListMap.json
+++ b/extensions-contrib/ambari-metrics-emitter/src/main/resources/defaultWhiteListMap.json
@@ -46,6 +46,10 @@
     "dataSource",
     "type"
   ],
+  "query/planningTime": [
+    "dataSource",
+    "type"
+  ],
   "query/wait/time": [
     "dataSource",
     "type"

--- a/extensions-contrib/dropwizard-emitter/src/main/resources/defaultMetricDimensions.json
+++ b/extensions-contrib/dropwizard-emitter/src/main/resources/defaultMetricDimensions.json
@@ -7,6 +7,14 @@
     "type": "timer",
     "timeUnit": "MILLISECONDS"
   },
+  "query/planningTime": {
+    "dimensions": [
+      "dataSource",
+      "type"
+    ],
+    "type": "timer",
+    "timeUnit": "MILLISECONDS"
+  },
   "query/node/time": {
     "dimensions": [
       "server"

--- a/extensions-contrib/graphite-emitter/src/main/resources/defaultWhiteListMap.json
+++ b/extensions-contrib/graphite-emitter/src/main/resources/defaultWhiteListMap.json
@@ -33,6 +33,10 @@
     "dataSource",
     "type"
   ],
+  "query/planningTime": [
+    "dataSource",
+    "type"
+  ],
   "query/wait/time": [
     "dataSource",
     "type"

--- a/extensions-contrib/prometheus-emitter/src/main/resources/defaultMetrics.json
+++ b/extensions-contrib/prometheus-emitter/src/main/resources/defaultMetrics.json
@@ -1,5 +1,6 @@
 {
   "query/time" : { "dimensions" : ["dataSource", "type"], "type" : "timer", "conversionFactor": 1000.0, "help":  "Seconds taken to complete a query."},
+"query/planningTime" : { "dimensions" : ["dataSource", "type"], "type" : "timer", "conversionFactor": 1000.0, "help":  "Seconds taken to complete query planning at Broker before query is fanned out to the Data nodes."},
   "query/bytes" : { "dimensions" : ["dataSource", "type"], "type" : "count", "help":  "Number of bytes returned in query response."},
   "query/node/time" : { "dimensions" : ["server"], "type" : "timer", "conversionFactor": 1000.0, "help": "Seconds taken to query individual historical/realtime processes."},
   "query/node/ttfb" : { "dimensions" : ["server"], "type" : "timer", "conversionFactor": 1000.0, "help":  "Time to first byte. Seconds elapsed until Broker starts receiving the response from individual historical/realtime processes."},

--- a/extensions-contrib/statsd-emitter/src/main/resources/defaultMetricDimensions.json
+++ b/extensions-contrib/statsd-emitter/src/main/resources/defaultMetricDimensions.json
@@ -1,5 +1,6 @@
 {
   "query/time" : { "dimensions" : ["dataSource", "type"], "type" : "timer"},
+  "query/planningTime" : { "dimensions" : ["dataSource", "type"], "type" : "timer"},
   "query/bytes" : { "dimensions" : ["dataSource", "type"], "type" : "count"},
   "query/node/time" : { "dimensions" : ["server"], "type" : "timer"},
   "query/node/ttfb" : { "dimensions" : ["server"], "type" : "timer"},

--- a/processing/src/main/java/org/apache/druid/query/DefaultQueryMetrics.java
+++ b/processing/src/main/java/org/apache/druid/query/DefaultQueryMetrics.java
@@ -235,6 +235,12 @@ public class DefaultQueryMetrics<QueryType extends Query<?>> implements QueryMet
   }
 
   @Override
+  public QueryMetrics<QueryType> reportQueryPlanningTime(long timeNs)
+  {
+    return reportMillisTimeMetric("query/planningTime", timeNs);
+  }
+
+  @Override
   public QueryMetrics<QueryType> reportQueryBytes(long byteCount)
   {
     return reportMetric("query/bytes", byteCount);

--- a/processing/src/main/java/org/apache/druid/query/QueryMetrics.java
+++ b/processing/src/main/java/org/apache/druid/query/QueryMetrics.java
@@ -281,6 +281,14 @@ public interface QueryMetrics<QueryType extends Query<?>>
   QueryMetrics<QueryType> reportQueryTime(long timeNs);
 
   /**
+   * Registers "query planning time" metric.
+   *
+   * Measures the time taken to plan the query. This includes time spent in determining segments for the given
+   * time interval and determining the Data nodes responsible for the segments.
+   */
+  QueryMetrics<QueryType> reportQueryPlanningTime(long timeNs);
+
+  /**
    * Registers "query bytes" metric.
    *
    * Measures the total number of bytes written by the query server thread to the response output stream.

--- a/processing/src/main/java/org/apache/druid/query/search/DefaultSearchQueryMetrics.java
+++ b/processing/src/main/java/org/apache/druid/query/search/DefaultSearchQueryMetrics.java
@@ -196,6 +196,12 @@ public class DefaultSearchQueryMetrics implements SearchQueryMetrics
   }
 
   @Override
+  public QueryMetrics reportQueryPlanningTime(long timeNs)
+  {
+    return delegateQueryMetrics.reportQueryPlanningTime(timeNs);
+  }
+
+  @Override
   public QueryMetrics reportQueryBytes(long byteCount)
   {
     return delegateQueryMetrics.reportQueryBytes(byteCount);

--- a/server/src/main/java/org/apache/druid/client/CachingClusteredClient.java
+++ b/server/src/main/java/org/apache/druid/client/CachingClusteredClient.java
@@ -86,6 +86,7 @@ import org.apache.druid.timeline.TimelineObjectHolder;
 import org.apache.druid.timeline.VersionedIntervalTimeline;
 import org.apache.druid.timeline.VersionedIntervalTimeline.PartitionChunkEntry;
 import org.apache.druid.timeline.partition.PartitionChunk;
+import org.apache.druid.utils.JvmUtils;
 import org.joda.time.Interval;
 
 import javax.annotation.Nullable;
@@ -335,6 +336,7 @@ public class CachingClusteredClient implements QuerySegmentWalker
         final boolean specificSegments
     )
     {
+      long startCpuTime = JvmUtils.getCurrentThreadCpuTime();
       final Optional<? extends TimelineLookup<String, ServerSelector>> maybeTimeline = serverView.getTimeline(
           dataSourceAnalysis
       );
@@ -371,8 +373,8 @@ public class CachingClusteredClient implements QuerySegmentWalker
       queryPlus = queryPlus.withQueryMetrics(toolChest);
       this.responseContext.put(ResponseContext.Keys.QUERY_SEGMENT_COUNT, segmentServers.size());
       queryPlus.getQueryMetrics().reportQueriedSegmentCount(segmentServers.size()).emit(emitter);
-
       final SortedMap<DruidServer, List<SegmentDescriptor>> segmentsByServer = groupSegmentsByServer(segmentServers);
+      queryPlus.getQueryMetrics().reportQueryPlanningTime(JvmUtils.getCurrentThreadCpuTime() - startCpuTime).emit(emitter);
       LazySequence<T> mergedResultSequence = new LazySequence<>(() -> {
         List<Sequence<T>> sequencesByInterval = new ArrayList<>(alreadyCachedResults.size() + segmentsByServer.size());
         addSequencesFromCache(sequencesByInterval, alreadyCachedResults);


### PR DESCRIPTION
### Description
Emit query planning time metric
This PR has:

- [x] been self-reviewed.
- [x] added documentation for new or modified features or behaviors.
- [ ] a release note entry in the PR description.
- [ ] added Javadocs for most classes and all non-trivial methods. Linked related entities via Javadoc links.
- [ ] added or updated version, license, or notice information in [licenses.yaml](https://github.com/apache/druid/blob/master/dev/license.md)
- [ ] added comments explaining the "why" and the intent of the code wherever would not be obvious for an unfamiliar reader.
- [ ] added unit tests or modified existing tests to cover new code paths, ensuring the threshold for [code coverage](https://github.com/apache/druid/blob/master/dev/code-review/code-coverage.md) is met.
- [ ] added integration tests.
- [x] been tested in a test Druid cluster.
