### PR TITLE
OBSDATA-5211 At Brokers emit a single metric that tells total CPU consumed by all components include Brokers/Indexers/Historicals

### DIFF
--- a/processing/src/main/java/org/apache/druid/query/CPUTimeMetricQueryRunner.java
+++ b/processing/src/main/java/org/apache/druid/query/CPUTimeMetricQueryRunner.java
@@ -64,6 +64,7 @@ public class CPUTimeMetricQueryRunner<T> implements QueryRunner<T>
     final Sequence<T> baseSequence = delegate.run(queryWithMetrics, responseContext);
 
     cpuTimeAccumulator.addAndGet(JvmUtils.getCurrentThreadCpuTime() - startRun);
+    responseContext.addCpuNanos(JvmUtils.getCurrentThreadCpuTime() - startRun);
 
     return Sequences.wrap(
         baseSequence,
@@ -78,6 +79,7 @@ public class CPUTimeMetricQueryRunner<T> implements QueryRunner<T>
             }
             finally {
               cpuTimeAccumulator.addAndGet(JvmUtils.getCurrentThreadCpuTime() - start);
+              responseContext.addCpuNanos(JvmUtils.getCurrentThreadCpuTime() - start);
             }
           }
 
@@ -87,7 +89,6 @@ public class CPUTimeMetricQueryRunner<T> implements QueryRunner<T>
             if (report) {
               final long cpuTimeNs = cpuTimeAccumulator.get();
               if (cpuTimeNs > 0) {
-                responseContext.addCpuNanos(cpuTimeNs);
                 queryWithMetrics.getQueryMetrics().reportCpuTime(cpuTimeNs).emit(emitter);
               }
             }

--- a/server/src/main/java/org/apache/druid/client/DirectDruidClient.java
+++ b/server/src/main/java/org/apache/druid/client/DirectDruidClient.java
@@ -256,7 +256,8 @@ public class DirectDruidClient<T> implements QueryRunner<T>
             if (response.headers().get(QueryResource.QUERY_CPU_TIME) != null) {
               try {
                 cpuTime = Long.parseLong(response.headers().get(QueryResource.QUERY_CPU_TIME));
-              } catch (NumberFormatException ex) {
+              }
+              catch (NumberFormatException ex) {
                 log.warn("Unexpected Cpu-Time header [%s] in response from url [%s] for query [%s]. Exception: [%s]",
                         response.headers().get(QueryResource.QUERY_CPU_TIME),
                         url,

--- a/server/src/main/java/org/apache/druid/client/DirectDruidClient.java
+++ b/server/src/main/java/org/apache/druid/client/DirectDruidClient.java
@@ -84,6 +84,7 @@ import java.util.concurrent.atomic.AtomicLong;
 import java.util.concurrent.atomic.AtomicReference;
 
 /**
+ * This class is called by Broker to send queries to Data nodes and process response from them.
  */
 public class DirectDruidClient<T> implements QueryRunner<T>
 {
@@ -251,6 +252,21 @@ public class DirectDruidClient<T> implements QueryRunner<T>
             if (responseContext != null) {
               context.merge(ResponseContext.deserialize(responseContext, objectMapper));
             }
+            long cpuTime = 0;
+            if (response.headers().get(QueryResource.QUERY_CPU_TIME) != null) {
+              try {
+                cpuTime = Long.parseLong(response.headers().get(QueryResource.QUERY_CPU_TIME));
+              } catch (NumberFormatException ex) {
+                log.warn("Unexpected Cpu-Time header [%s] in response from url [%s] for query [%s]. Exception: [%s]",
+                        response.headers().get(QueryResource.QUERY_CPU_TIME),
+                        url,
+                        query.getId(),
+                        ex.getMessage());
+              }
+            }
+
+            // Add Cpu time at Data nodes.
+            context.addCpuNanos(cpuTime);
             continueReading = enqueue(response.getContent(), 0L);
           }
           catch (final IOException e) {


### PR DESCRIPTION
OBSDATA-5211 At Brokers emit a single metric that tells total CPU consumed by all components include Brokers/Indexers/Historicals


### Description
OBSDATA-5211 At Brokers emit a single metric that tells total CPU consumed by all components include Brokers/Indexers/Historicals


This PR has:

- [x ] been self-reviewed.   
- [ ] added documentation for new or modified features or behaviors.
- [ ] a release note entry in the PR description.
- [ ] added Javadocs for most classes and all non-trivial methods. Linked related entities via Javadoc links.
- [ ] added or updated version, license, or notice information in [licenses.yaml](https://github.com/apache/druid/blob/master/dev/license.md)
- [x ] added comments explaining the "why" and the intent of the code wherever would not be obvious for an unfamiliar reader.
- [ ] added unit tests or modified existing tests to cover new code paths, ensuring the threshold for [code coverage](https://github.com/apache/druid/blob/master/dev/code-review/code-coverage.md) is met.
- [ ] added integration tests.
- [x ] been tested in a test Druid cluster.
