### PR TITLE
Add unit test to check infinite looping due to ingest parse failure

### DIFF
--- a/indexing-service/src/test/java/org/apache/druid/indexing/common/task/FilteringCloseableInputRowIteratorTest.java
+++ b/indexing-service/src/test/java/org/apache/druid/indexing/common/task/FilteringCloseableInputRowIteratorTest.java
@@ -352,7 +352,8 @@ public class FilteringCloseableInputRowIteratorTest
   }
 
   @Test
-  public void testNoInfiniteLoopForExceptionInHasNext() {
+  public void testNoInfiniteLoopForExceptionInHasNext()
+  {
 
     int maxAllowedParseExceptions = 3;
 
@@ -362,23 +363,26 @@ public class FilteringCloseableInputRowIteratorTest
 
     // This iterator throws ParseException always in hasNext().
     final FilteringCloseableInputRowIterator rowIterator = new FilteringCloseableInputRowIterator(
-            new CloseableIterator<InputRow>() {
-              @Override
-              public void close() {
-              }
+        new CloseableIterator<InputRow>() {
+            @Override
+            public void close() 
+            {
+            }
 
-              @Override
-              public boolean hasNext() {
-                throw new ParseException("test", "abcd", "");
-              }
+            @Override
+            public boolean hasNext() 
+            {
+              throw new ParseException("test", "abcd", "");
+            }
 
-              @Override
-              public InputRow next() {
-                return null;
-              }
-            },
-            row -> true,
-            rowIngestionMeters, mockedExceptionHandler
+            @Override
+            public InputRow next() 
+            {
+              return null;
+            }
+        },
+        row -> true,
+        rowIngestionMeters, mockedExceptionHandler
     );
 
     Assert.assertThrows(RE.class, () -> rowIterator.next());

--- a/indexing-service/src/test/java/org/apache/druid/indexing/common/task/FilteringCloseableInputRowIteratorTest.java
+++ b/indexing-service/src/test/java/org/apache/druid/indexing/common/task/FilteringCloseableInputRowIteratorTest.java
@@ -26,6 +26,7 @@ import org.apache.druid.data.input.InputRow;
 import org.apache.druid.data.input.MapBasedInputRow;
 import org.apache.druid.java.util.common.CloseableIterators;
 import org.apache.druid.java.util.common.DateTimes;
+import org.apache.druid.java.util.common.RE;
 import org.apache.druid.java.util.common.parsers.CloseableIterator;
 import org.apache.druid.java.util.common.parsers.ParseException;
 import org.apache.druid.segment.incremental.ParseExceptionHandler;
@@ -36,6 +37,7 @@ import org.junit.Assert;
 import org.junit.Before;
 import org.junit.Test;
 import org.mockito.ArgumentCaptor;
+import org.mockito.ArgumentMatchers;
 import org.mockito.Mockito;
 
 import java.io.IOException;
@@ -349,9 +351,44 @@ public class FilteringCloseableInputRowIteratorTest
     Assert.assertEquals(ROWS.size(), rowIngestionMeters.getUnparseable());
   }
 
+  @Test
+  public void testNoInfiniteLoopForExceptionInHasNext() {
+
+    int maxAllowedParseExceptions = 3;
+
+    ParseExceptionHandler exceptionHandler = new ParseExceptionHandler(rowIngestionMeters, false, maxAllowedParseExceptions, 1);
+    ParseExceptionHandler mockedExceptionHandler = Mockito.spy(exceptionHandler);
+    Mockito.doCallRealMethod().when(mockedExceptionHandler);
+
+    // This iterator throws ParseException always in hasNext().
+    final FilteringCloseableInputRowIterator rowIterator = new FilteringCloseableInputRowIterator(
+            new CloseableIterator<InputRow>() {
+              @Override
+              public void close() {
+              }
+
+              @Override
+              public boolean hasNext() {
+                throw new ParseException("test", "abcd", "");
+              }
+
+              @Override
+              public InputRow next() {
+                return null;
+              }
+            },
+            row -> true,
+            rowIngestionMeters, mockedExceptionHandler
+    );
+
+    Assert.assertThrows(RE.class, () -> rowIterator.next());
+    Mockito.verify(mockedExceptionHandler, Mockito.times(maxAllowedParseExceptions + 1)).handle(ArgumentMatchers.any(ParseException.class));
+
+  }
 
   private static InputRow newRow(DateTime timestamp, Object dim1Val, Object dim2Val)
   {
     return new MapBasedInputRow(timestamp, DIMENSIONS, ImmutableMap.of("dim1", dim1Val, "dim2", dim2Val));
   }
 }
+


### PR DESCRIPTION
Adds a unit test in `FilteringCloseableRowIteratorTest` which checks whether there's an infinite looping when an exception raises from ingest parse failures. 

<!-- Replace XXXX with the id of the issue fixed in this PR. Remove this section if there is no corresponding issue. Don't reference the issue in the title of this pull-request. -->

<!-- If you are a committer, follow the PR action item checklist for committers:
https://github.com/apache/druid/blob/master/dev/committer-instructions.md#pr-and-issue-action-item-checklist-for-committers. -->

### Description

<!-- Describe the goal of this PR, what problem are you fixing. If there is a corresponding issue (referenced above), it's not necessary to repeat the description here, however, you may choose to keep one summary sentence. -->

<!-- Describe your patch: what did you change in code? How did you fix the problem? -->

<!-- If there are several relatively logically separate changes in this PR, create a mini-section for each of them. For example: -->
A bug related to iterator looping infinitely and thereby halting ingestion was fixed in https://github.com/confluentinc/druid/pull/222 . Corresponding unit test is being added here to prevent ingestion from halting when a parse exception occurs beyond the set threshold. 

<!--
In each section, please describe design decisions made, including:
 - Choice of algorithms
 - Behavioral aspects. What configuration values are acceptable? How are corner cases and error conditions handled, such as when there are insufficient resources?
 - Class organization and design (how the logic is split between classes, inheritance, composition, design patterns)
 - Method organization and design (how the logic is split between methods, parameters and return types)
 - Naming (class, method, API, configuration, HTTP endpoint, names of emitted metrics)
-->


<!-- It's good to describe an alternative design (or mention an alternative name) for every design (or naming) decision point and compare the alternatives with the designs that you've implemented (or the names you've chosen) to highlight the advantages of the chosen designs and names. -->

<!-- If there was a discussion of the design of the feature implemented in this PR elsewhere (e. g. a "Proposal" issue, any other issue, or a thread in the development mailing list), link to that discussion from this PR description and explain what have changed in your final design compared to your original proposal or the consensus version in the end of the discussion. If something hasn't changed since the original discussion, you can omit a detailed discussion of those aspects of the design here, perhaps apart from brief mentioning for the sake of readability of this PR description. -->

<!-- Some of the aspects mentioned above may be omitted for simple and small changes. -->

#### Release note
<!-- Give your best effort to summarize your changes in a couple of sentences aimed toward Druid users. 

If your change doesn't have end user impact, you can skip this section.

-->
For tips about how to write a good release note, see [Release notes](https://github.com/apache/druid/blob/master/CONTRIBUTING.md#release-notes).


<hr>

##### Key changed/added classes in this PR
 * `MyFoo`
 * `OurBar`
 * `TheirBaz`

<hr>

<!-- Check the items by putting "x" in the brackets for the done things. Not all of these items apply to every PR. Remove the items which are not done or not relevant to the PR. None of the items from the checklist below are strictly necessary, but it would be very helpful if you at least self-review the PR. -->

This PR has:

- [x] been self-reviewed.
   - [x] using the [concurrency checklist](https://github.com/apache/druid/blob/master/dev/code-review/concurrency.md) (Remove this item if the PR doesn't have any relation to concurrency.)
- [ ] added documentation for new or modified features or behaviors.
- [ ] a release note entry in the PR description.
- [ ] added Javadocs for most classes and all non-trivial methods. Linked related entities via Javadoc links.
- [ ] added or updated version, license, or notice information in [licenses.yaml](https://github.com/apache/druid/blob/master/dev/license.md)
- [ ] added comments explaining the "why" and the intent of the code wherever would not be obvious for an unfamiliar reader.
- [x] added unit tests or modified existing tests to cover new code paths, ensuring the threshold for [code coverage](https://github.com/apache/druid/blob/master/dev/code-review/code-coverage.md) is met.
- [ ] added integration tests.
- [ ] been tested in a test Druid cluster.
