### PR TITLE
OBSDATA-4174 Fix core-js vulnerability

### DIFF
--- a/web-console/package-lock.json
+++ b/web-console/package-lock.json
@@ -17,7 +17,7 @@
         "axios": "^0.26.1",
         "classnames": "^2.2.6",
         "copy-to-clipboard": "^3.2.0",
-        "core-js": "^3.10.1",
+        "core-js": "^3.38.1",
         "d3-array": "^2.12.1",
         "d3-axis": "^2.1.0",
         "d3-scale": "^3.3.0",
@@ -9050,10 +9050,9 @@
       }
     },
     "node_modules/core-js": {
-      "version": "3.10.1",
-      "resolved": "https://registry.npmjs.org/core-js/-/core-js-3.10.1.tgz",
-      "integrity": "sha512-pwCxEXnj27XG47mu7SXAwhLP3L5CrlvCB91ANUkIz40P27kUcvNfSdvyZJ9CLHiVoKSp+TTChMQMSKQEH/IQxA==",
-      "deprecated": "core-js@<3.23.3 is no longer maintained and not recommended for usage due to the number of issues. Because of the V8 engine whims, feature detection in old core-js versions could cause a slowdown up to 100x even if nothing is polyfilled. Some versions have web compatibility issues. Please, upgrade your dependencies to the actual version of core-js.",
+      "version": "3.38.1",
+      "resolved": "https://registry.npmjs.org/core-js/-/core-js-3.38.1.tgz",
+      "integrity": "sha512-OP35aUorbU3Zvlx7pjsFdu1rGNnD4pgw/CWoYzRY3t2EzoVT7shKHY1dlAy3f41cGIO7ZDPQimhGFTlEYkG/Hw==",
       "hasInstallScript": true,
       "funding": {
         "type": "opencollective",
@@ -34293,9 +34292,9 @@
       }
     },
     "core-js": {
-      "version": "3.10.1",
-      "resolved": "https://registry.npmjs.org/core-js/-/core-js-3.10.1.tgz",
-      "integrity": "sha512-pwCxEXnj27XG47mu7SXAwhLP3L5CrlvCB91ANUkIz40P27kUcvNfSdvyZJ9CLHiVoKSp+TTChMQMSKQEH/IQxA=="
+      "version": "3.38.1",
+      "resolved": "https://registry.npmjs.org/core-js/-/core-js-3.38.1.tgz",
+      "integrity": "sha512-OP35aUorbU3Zvlx7pjsFdu1rGNnD4pgw/CWoYzRY3t2EzoVT7shKHY1dlAy3f41cGIO7ZDPQimhGFTlEYkG/Hw=="
     },
     "core-js-compat": {
       "version": "3.14.0",

--- a/web-console/package.json
+++ b/web-console/package.json
@@ -73,7 +73,7 @@
     "axios": "^0.26.1",
     "classnames": "^2.2.6",
     "copy-to-clipboard": "^3.2.0",
-    "core-js": "^3.10.1",
+    "core-js": "^3.38.1",
     "d3-array": "^2.12.1",
     "d3-axis": "^2.1.0",
     "d3-scale": "^3.3.0",


### PR DESCRIPTION
### Description
* upgraded core-js dependency to latest version.
* why ? - core-js@<3.23.3 is no longer maintained and not recommended for usage

### Testing
* Deployed Druid cluster on local using Docker
* Deplyed web console app by using:
  * npm install
  * npm run compile 
  * npm start
 * Sanity tested the local web console

This PR has:

- [X] been self-reviewed.
   - [ ] using the [concurrency checklist](https://github.com/apache/druid/blob/master/dev/code-review/concurrency.md) (Remove this item if the PR doesn't have any relation to concurrency.)
- [ ] added documentation for new or modified features or behaviors.
- [ ] a release note entry in the PR description.
- [ ] added Javadocs for most classes and all non-trivial methods. Linked related entities via Javadoc links.
- [ ] added or updated version, license, or notice information in [licenses.yaml](https://github.com/apache/druid/blob/master/dev/license.md)
- [ ] added comments explaining the "why" and the intent of the code wherever would not be obvious for an unfamiliar reader.
- [ ] added unit tests or modified existing tests to cover new code paths, ensuring the threshold for [code coverage](https://github.com/apache/druid/blob/master/dev/code-review/code-coverage.md) is met.
- [ ] added integration tests.
- [X] been tested in a test Druid cluster.
