### PR TITLE
OBSDATA-5893: Upgrade netty version to fix CVE 

### DIFF
--- a/licenses.yaml
+++ b/licenses.yaml
@@ -1249,7 +1249,7 @@ name: Netty
 license_category: binary
 module: java-core
 license_name: Apache License version 2.0
-version: 4.1.108.Final
+version: 4.1.115.Final
 libraries:
   - io.netty: netty-buffer
   - io.netty: netty-codec

--- a/pom.xml
+++ b/pom.xml
@@ -104,7 +104,7 @@
         <mysql.version>5.1.49</mysql.version>
         <mariadb.version>2.7.3</mariadb.version>
         <netty3.version>3.10.6.Final</netty3.version>
-        <netty4.version>4.1.108.Final</netty4.version>
+        <netty4.version>4.1.115.Final</netty4.version>
         <postgresql.version>42.7.2</postgresql.version>
         <protobuf.version>3.25.5</protobuf.version>
         <resilience4j.version>1.3.1</resilience4j.version>


### PR DESCRIPTION
OBSDATA-5893 Upgrading Netty from version `4.1.108.Final` to `4.1.115.Final` to fix CVE-2024-47535.

Refer: https://avd.aquasec.com/nvd/cve-2024-47535
(netty: Denial of Service attack on windows app using Netty)