### PR TITLE
[OBSDATA-8872]Add maxInterval to kill config

### DIFF
--- a/server/src/main/java/org/apache/druid/server/coordinator/DruidCoordinatorConfig.java
+++ b/server/src/main/java/org/apache/druid/server/coordinator/DruidCoordinatorConfig.java
@@ -20,6 +20,7 @@
 package org.apache.druid.server.coordinator;
 
 import org.joda.time.Duration;
+import org.joda.time.Period;
 import org.skife.config.Config;
 import org.skife.config.Default;
 
@@ -58,6 +59,10 @@ public abstract class DruidCoordinatorConfig
   @Config("druid.coordinator.kill.maxSegments")
   @Default("100")
   public abstract int getCoordinatorKillMaxSegments();
+
+  @Config("druid.coordinator.kill.maxInterval")
+  @Default("P30D")
+  public abstract Period getCoordinatorKillMaxInterval();
 
   @Config("druid.coordinator.kill.supervisor.period")
   @Default("P1D")

--- a/server/src/main/java/org/apache/druid/server/coordinator/duty/KillUnusedSegments.java
+++ b/server/src/main/java/org/apache/druid/server/coordinator/duty/KillUnusedSegments.java
@@ -57,7 +57,7 @@ public class KillUnusedSegments implements CoordinatorDuty
   private final int maxSegmentsToKill;
   private long lastKillTime = 0;
 
-  private final Map<String, DateTime> datasourceToLastKillIntervalEnd;
+  final Map<String, DateTime> datasourceToLastKillIntervalEnd;
   private final SegmentsMetadataManager segmentsMetadataManager;
   private final IndexingServiceClient indexingServiceClient;
   private final Period maxIntervalToKill;

--- a/server/src/main/java/org/apache/druid/server/coordinator/duty/KillUnusedSegments.java
+++ b/server/src/main/java/org/apache/druid/server/coordinator/duty/KillUnusedSegments.java
@@ -57,7 +57,7 @@ public class KillUnusedSegments implements CoordinatorDuty
   private final int maxSegmentsToKill;
   private long lastKillTime = 0;
 
-  final Map<String, DateTime> datasourceToLastKillIntervalEnd;
+  public final Map<String, DateTime> datasourceToLastKillIntervalEnd;
   private final SegmentsMetadataManager segmentsMetadataManager;
   private final IndexingServiceClient indexingServiceClient;
   private final Period maxIntervalToKill;

--- a/server/src/test/java/org/apache/druid/server/coordinator/TestDruidCoordinatorConfig.java
+++ b/server/src/test/java/org/apache/druid/server/coordinator/TestDruidCoordinatorConfig.java
@@ -20,6 +20,7 @@
 package org.apache.druid.server.coordinator;
 
 import org.joda.time.Duration;
+import org.joda.time.Period;
 
 public class TestDruidCoordinatorConfig extends DruidCoordinatorConfig
 {
@@ -40,6 +41,7 @@ public class TestDruidCoordinatorConfig extends DruidCoordinatorConfig
   private final Duration coordinatorDatasourceKillPeriod;
   private final Duration coordinatorDatasourceKillDurationToRetain;
   private final int coordinatorKillMaxSegments;
+  private final Period coordinatorKillMaxInterval;
   private final boolean compactionSkipLockedIntervals;
   private final boolean coordinatorKillIgnoreDurationToRetain;
   private final String loadQueuePeonType;
@@ -72,7 +74,8 @@ public class TestDruidCoordinatorConfig extends DruidCoordinatorConfig
       Duration httpLoadQueuePeonRepeatDelay,
       Duration httpLoadQueuePeonHostTimeout,
       int httpLoadQueuePeonBatchSize,
-      int curatorLoadQueuePeonNumCallbackThreads
+      int curatorLoadQueuePeonNumCallbackThreads,
+      Period coordinatorKillMaxInterval
   )
   {
     this.coordinatorStartDelay = coordinatorStartDelay;
@@ -92,6 +95,7 @@ public class TestDruidCoordinatorConfig extends DruidCoordinatorConfig
     this.coordinatorDatasourceKillPeriod = coordinatorDatasourceKillPeriod;
     this.coordinatorDatasourceKillDurationToRetain = coordinatorDatasourceKillDurationToRetain;
     this.coordinatorKillMaxSegments = coordinatorKillMaxSegments;
+    this.coordinatorKillMaxInterval = coordinatorKillMaxInterval;
     this.compactionSkipLockedIntervals = compactionSkipLockedIntervals;
     this.coordinatorKillIgnoreDurationToRetain = coordinatorKillIgnoreDurationToRetain;
     this.loadQueuePeonType = loadQueuePeonType;
@@ -198,6 +202,12 @@ public class TestDruidCoordinatorConfig extends DruidCoordinatorConfig
   }
 
   @Override
+  public Period getCoordinatorKillMaxInterval()
+  {
+    return coordinatorKillMaxInterval;
+  }
+
+  @Override
   public Duration getLoadTimeoutDelay()
   {
     return loadTimeoutDelay == null ? super.getLoadTimeoutDelay() : loadTimeoutDelay;
@@ -255,6 +265,7 @@ public class TestDruidCoordinatorConfig extends DruidCoordinatorConfig
     private static final Duration DEFAULT_COORDINATOR_KILL_DURATION_TO_RETAION = new Duration("PT7776000s");
     private static final boolean DEFAULT_COORDINATOR_KILL_IGNORE_DURATION_TO_RETAIN = false;
     private static final int DEFAULT_COORDINATOR_KILL_MAX_SEGMENTS = 100;
+    private static final Period DEFAULT_COORDINATOR_KILL_MAX_INTERVAL = Period.parse("P30D");
     private static final Duration DEFAULT_COORDINATOR_SUPERVISOR_KILL_PERIOD = new Duration("PT86400s");
     private static final Duration DEFAULT_COORDINATOR_SUPERVISOR_KILL_DURATION_TO_RETAIN = new Duration("PT7776000s");
     private static final Duration DEFAULT_COORDINATOR_COMPACTION_KILL_PERIOD = new Duration("PT86400s");
@@ -281,6 +292,7 @@ public class TestDruidCoordinatorConfig extends DruidCoordinatorConfig
     private Duration coordinatorKillDurationToRetain;
     private Boolean coordinatorKillIgnoreDurationToRetain;
     private Integer coordinatorKillMaxSegments;
+    private Period coordinatorKillMaxInterval;
     private Duration coordinatorSupervisorKillPeriod;
     private Duration coordinatorSupervisorKillDurationToRetain;
     private Duration coordinatorCompactionKillPeriod;
@@ -347,6 +359,12 @@ public class TestDruidCoordinatorConfig extends DruidCoordinatorConfig
     public Builder withCoordinatorKillMaxSegments(int coordinatorKillMaxSegments)
     {
       this.coordinatorKillMaxSegments = coordinatorKillMaxSegments;
+      return this;
+    }
+
+    public Builder withCoordinatorKillMaxInterval(Period coordinatorKillMaxInterval)
+    {
+      this.coordinatorKillMaxInterval = coordinatorKillMaxInterval;
       return this;
     }
 
@@ -473,8 +491,8 @@ public class TestDruidCoordinatorConfig extends DruidCoordinatorConfig
           httpLoadQueuePeonHostTimeout == null ? DEFAULT_HTTP_LOAD_QUEUE_PEON_HOST_TIMEOUT : httpLoadQueuePeonHostTimeout,
           httpLoadQueuePeonBatchSize == null ? DEFAULT_HTTP_LOAD_QUEUE_PEON_BATCH_SIZE : httpLoadQueuePeonBatchSize,
           curatorLoadQueuePeonNumCallbackThreads == null ? DEFAULT_CURATOR_LOAD_QUEUE_PEON_NUM_CALLBACK_THREADS
-                                                         : curatorLoadQueuePeonNumCallbackThreads
-      );
+                                                         : curatorLoadQueuePeonNumCallbackThreads,
+          coordinatorKillMaxInterval == null ? DEFAULT_COORDINATOR_KILL_MAX_INTERVAL : coordinatorKillMaxInterval);
     }
 
   }

--- a/server/src/test/java/org/apache/druid/server/coordinator/duty/KillUnusedSegmentsTest.java
+++ b/server/src/test/java/org/apache/druid/server/coordinator/duty/KillUnusedSegmentsTest.java
@@ -64,6 +64,7 @@ public class KillUnusedSegmentsTest
   private static final String DS1 = "DS1";
   private static final String VERSION = "v1";
   private static final DateTime NOW = DateTimes.nowUtc();
+  private static final Interval FIFTEEN_DAY_OLD = new Interval(Period.days(1), NOW.minusDays(15));
   private static final Interval DAY_OLD = new Interval(Period.days(1), NOW.minusDays(1));
 
 
@@ -144,6 +145,8 @@ public class KillUnusedSegmentsTest
     target = new KillUnusedSegments(segmentsMetadataManager, indexingServiceClient, config);
   }
 
+
+
   @Test
   public void testRunWithNoIntervalShouldNotKillAnySegments()
   {
@@ -222,55 +225,6 @@ public class KillUnusedSegmentsTest
 
     // Only 1 unused segment is killed
     runAndVerifyKillInterval(yearOldSegment.getInterval());
-  }
-
-  private void createAndAddUnusedSegment(String dataSource, Interval interval, String version, DateTime endTime)
-  {
-    DataSegment segment = new DataSegment(
-            dataSource,
-            interval,
-            version,
-            new HashMap<>(),
-            new ArrayList<>(),
-            new ArrayList<>(),
-            NoneShardSpec.instance(),
-            1,
-            0
-    );
-
-    Mockito.when(segmentsMetadataManager.getUnusedSegmentIntervals(
-            ArgumentMatchers.eq(dataSource),
-            ArgumentMatchers.any(),
-            ArgumentMatchers.anyInt()
-    )).thenAnswer(invocation -> {
-      DateTime maxEndTime = invocation.getArgument(1);
-      List<Interval> unusedIntervals = new ArrayList<>();
-      if (segment.getInterval().getEnd().isBefore(maxEndTime)) {
-        unusedIntervals.add(segment.getInterval());
-      }
-      return unusedIntervals;
-    });
-  }
-
-  @Test
-  public void testRestrictKillQueryToMaxInterval()
-  {
-    Mockito.doReturn(Duration.standardHours(6)).when(config).getCoordinatorKillDurationToRetain();
-    Mockito.doReturn(Period.days(20)).when(config).getCoordinatorKillMaxInterval();
-    Mockito.doReturn(2).when(config).getCoordinatorKillMaxSegments();
-
-    target = new KillUnusedSegments(segmentsMetadataManager, indexingServiceClient, config);
-    target.run(params);
-
-    runAndVerifyKillInterval(new Interval(yearOldSegment.getInterval().getStart(), monthOldSegment.getInterval().getEnd()));
-
-    target = new KillUnusedSegments(segmentsMetadataManager, indexingServiceClient, config);
-
-    target.datasourceToLastKillIntervalEnd.put(DS1, NOW.minusDays(29));
-    target.run(params);
-
-    runAndVerifyKillInterval(fifteenDayOldSegment.getInterval());
-
   }
 
   private void runAndVerifyKillInterval(Interval expectedKillInterval)

--- a/server/src/test/java/org/apache/druid/server/coordinator/duty/KillUnusedSegmentsTest.java
+++ b/server/src/test/java/org/apache/druid/server/coordinator/duty/KillUnusedSegmentsTest.java
@@ -61,12 +61,6 @@ public class KillUnusedSegmentsTest
   private static final Duration COORDINATOR_KILL_PERIOD = Duration.standardMinutes(2);
   private static final Duration DURATION_TO_RETAIN = Duration.standardDays(1);
   private static final Duration INDEXING_PERIOD = Duration.standardMinutes(1);
-  private static final String DS1 = "DS1";
-  private static final String VERSION = "v1";
-  private static final DateTime NOW = DateTimes.nowUtc();
-  private static final Interval FIFTEEN_DAY_OLD = new Interval(Period.days(1), NOW.minusDays(15));
-  private static final Interval DAY_OLD = new Interval(Period.days(1), NOW.minusDays(1));
-
 
   @Mock
   private SegmentsMetadataManager segmentsMetadataManager;
@@ -97,8 +91,6 @@ public class KillUnusedSegmentsTest
     Mockito.doReturn(DURATION_TO_RETAIN).when(config).getCoordinatorKillDurationToRetain();
     Mockito.doReturn(INDEXING_PERIOD).when(config).getCoordinatorIndexingPeriod();
     Mockito.doReturn(MAX_SEGMENTS_TO_KILL).when(config).getCoordinatorKillMaxSegments();
-    Mockito.doReturn(MAX_KILL_INTERVAL).when(config).getCoordinatorKillMaxInterval();
-
 
     Mockito.doReturn(Collections.singleton("DS1"))
            .when(coordinatorDynamicConfig).getSpecificDataSourcesToKillUnusedSegmentsIn();
@@ -141,8 +133,6 @@ public class KillUnusedSegmentsTest
 
     target = new KillUnusedSegments(segmentsMetadataManager, indexingServiceClient, config);
   }
-
-
 
   @Test
   public void testRunWithNoIntervalShouldNotKillAnySegments()

--- a/server/src/test/java/org/apache/druid/server/coordinator/duty/KillUnusedSegmentsTest.java
+++ b/server/src/test/java/org/apache/druid/server/coordinator/duty/KillUnusedSegmentsTest.java
@@ -64,6 +64,7 @@ public class KillUnusedSegmentsTest
   private static final String DS1 = "DS1";
   private static final String VERSION = "v1";
   private static final DateTime NOW = DateTimes.nowUtc();
+  private static final Interval DAY_OLD = new Interval(Period.days(1), NOW.minusDays(1));
 
 
   @Mock
@@ -81,6 +82,7 @@ public class KillUnusedSegmentsTest
   private DataSegment yearOldSegment;
   private DataSegment monthOldSegment;
   private DataSegment dayOldSegment;
+  private DataSegment fifteenDayOldSegment;
   private DataSegment hourOldSegment;
   private DataSegment nextDaySegment;
   private DataSegment nextMonthSegment;
@@ -105,6 +107,7 @@ public class KillUnusedSegmentsTest
 
     yearOldSegment = createSegmentWithEnd(now.minusDays(365));
     monthOldSegment = createSegmentWithEnd(now.minusDays(30));
+    fifteenDayOldSegment = createSegmentWithEnd(now.minusDays(15));
     dayOldSegment = createSegmentWithEnd(now.minusDays(1));
     hourOldSegment = createSegmentWithEnd(now.minusHours(1));
     nextDaySegment = createSegmentWithEnd(now.plusDays(1));
@@ -113,6 +116,7 @@ public class KillUnusedSegmentsTest
     final List<DataSegment> unusedSegments = ImmutableList.of(
         yearOldSegment,
         monthOldSegment,
+        fifteenDayOldSegment,
         dayOldSegment,
         hourOldSegment,
         nextDaySegment,
@@ -249,49 +253,24 @@ public class KillUnusedSegmentsTest
   }
 
   @Test
-  public void testMaxIntervalToKill()
+  public void testRestrictKillQueryToMaxInterval()
   {
-    Mockito.doReturn(Duration.standardDays(10)).when(config).getCoordinatorKillDurationToRetain();
-    Mockito.doReturn(Period.days(5)).when(config).getCoordinatorKillMaxInterval();
+    Mockito.doReturn(Duration.standardHours(6)).when(config).getCoordinatorKillDurationToRetain();
+    Mockito.doReturn(Period.days(20)).when(config).getCoordinatorKillMaxInterval();
+    Mockito.doReturn(2).when(config).getCoordinatorKillMaxSegments();
+
+    target = new KillUnusedSegments(segmentsMetadataManager, indexingServiceClient, config);
+    target.run(params);
+
+    runAndVerifyKillInterval(new Interval(yearOldSegment.getInterval().getStart(), monthOldSegment.getInterval().getEnd()));
+
     target = new KillUnusedSegments(segmentsMetadataManager, indexingServiceClient, config);
 
-    DateTime now = DateTimes.nowUtc();
-    DataSegment firstSegment = createSegmentWithEnd(now.minusDays(20));
-
-    createAndAddUnusedSegment(DS1, firstSegment.getInterval(), VERSION, firstSegment.getInterval().getEnd());
-
-
+    target.datasourceToLastKillIntervalEnd.put(DS1, NOW.minusDays(29));
     target.run(params);
-    Mockito.verify(indexingServiceClient, Mockito.times(1)).killUnusedSegments(
-            anyString(),
-            ArgumentMatchers.eq(DS1),
-            ArgumentMatchers.eq(firstSegment.getInterval())
-    );
 
-    DataSegment secondSegment = createSegmentWithEnd(now.minusDays(16));
+    runAndVerifyKillInterval(fifteenDayOldSegment.getInterval());
 
-
-    createAndAddUnusedSegment(DS1, secondSegment.getInterval(), VERSION, secondSegment.getInterval().getEnd());
-
-    DateTime minStartTimeTest = firstSegment.getInterval().getEnd();
-
-    target.run(params);
-    Interval expectedKillInterval = new Interval(minStartTimeTest, secondSegment.getInterval().getEnd());
-    Mockito.verify(indexingServiceClient, Mockito.times(1)).killUnusedSegments(
-            anyString(),
-            ArgumentMatchers.eq(DS1),
-            ArgumentMatchers.eq(expectedKillInterval)
-    );
-
-    DataSegment thirdSegment = createSegmentWithEnd(now.minusDays(12));
-    createAndAddUnusedSegment(DS1, thirdSegment.getInterval(), VERSION, thirdSegment.getInterval().getEnd());
-    expectedKillInterval = new Interval(minStartTimeTest, thirdSegment.getInterval().getEnd());
-    target.run(params);
-    Mockito.verify(indexingServiceClient, Mockito.times(1)).killUnusedSegments(
-            anyString(),
-            ArgumentMatchers.eq(DS1),
-            ArgumentMatchers.eq(expectedKillInterval)
-    );
   }
 
   private void runAndVerifyKillInterval(Interval expectedKillInterval)

--- a/server/src/test/java/org/apache/druid/server/coordinator/duty/KillUnusedSegmentsTest.java
+++ b/server/src/test/java/org/apache/druid/server/coordinator/duty/KillUnusedSegmentsTest.java
@@ -57,7 +57,6 @@ import static org.mockito.ArgumentMatchers.anyString;
 public class KillUnusedSegmentsTest
 {
   private static final int MAX_SEGMENTS_TO_KILL = 10;
-  private static final Period MAX_KILL_INTERVAL = Period.days(30);
   private static final Duration COORDINATOR_KILL_PERIOD = Duration.standardMinutes(2);
   private static final Duration DURATION_TO_RETAIN = Duration.standardDays(1);
   private static final Duration INDEXING_PERIOD = Duration.standardMinutes(1);

--- a/server/src/test/java/org/apache/druid/server/coordinator/duty/KillUnusedSegmentsTest.java
+++ b/server/src/test/java/org/apache/druid/server/coordinator/duty/KillUnusedSegmentsTest.java
@@ -83,7 +83,6 @@ public class KillUnusedSegmentsTest
   private DataSegment yearOldSegment;
   private DataSegment monthOldSegment;
   private DataSegment dayOldSegment;
-  private DataSegment fifteenDayOldSegment;
   private DataSegment hourOldSegment;
   private DataSegment nextDaySegment;
   private DataSegment nextMonthSegment;
@@ -108,7 +107,6 @@ public class KillUnusedSegmentsTest
 
     yearOldSegment = createSegmentWithEnd(now.minusDays(365));
     monthOldSegment = createSegmentWithEnd(now.minusDays(30));
-    fifteenDayOldSegment = createSegmentWithEnd(now.minusDays(15));
     dayOldSegment = createSegmentWithEnd(now.minusDays(1));
     hourOldSegment = createSegmentWithEnd(now.minusHours(1));
     nextDaySegment = createSegmentWithEnd(now.plusDays(1));
@@ -117,7 +115,6 @@ public class KillUnusedSegmentsTest
     final List<DataSegment> unusedSegments = ImmutableList.of(
         yearOldSegment,
         monthOldSegment,
-        fifteenDayOldSegment,
         dayOldSegment,
         hourOldSegment,
         nextDaySegment,

--- a/server/src/test/java/org/apache/druid/server/coordinator/duty/killSegmentsMaxIntervalTest.java
+++ b/server/src/test/java/org/apache/druid/server/coordinator/duty/killSegmentsMaxIntervalTest.java
@@ -1,3 +1,22 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
 package org.apache.druid.server.coordinator.duty;
 
 import com.google.common.collect.ImmutableList;
@@ -15,10 +34,12 @@ import org.joda.time.Interval;
 import org.joda.time.Period;
 import org.junit.Before;
 import org.junit.Test;
+import org.junit.runner.RunWith;
 import org.mockito.Answers;
 import org.mockito.ArgumentMatchers;
 import org.mockito.Mock;
 import org.mockito.Mockito;
+import org.mockito.junit.MockitoJUnitRunner;
 
 import java.util.ArrayList;
 import java.util.Collections;
@@ -26,199 +47,130 @@ import java.util.HashMap;
 import java.util.List;
 import java.util.stream.Collectors;
 
-public class killSegmentsMaxIntervalTest {
+@RunWith(MockitoJUnitRunner.class)
+public class killSegmentsMaxIntervalTest
+{
 
-    private static final int MAX_SEGMENTS_TO_KILL = 10;
-    private static final Period MAX_KILL_INTERVAL = Period.days(30);
-    private static final Duration COORDINATOR_KILL_PERIOD = Duration.standardMinutes(2);
-    private static final Duration DURATION_TO_RETAIN = Duration.standardDays(1);
-    private static final Duration INDEXING_PERIOD = Duration.standardMinutes(1);
-    private static final String DS1 = "DS1";
-    private static final String VERSION = "v1";
-    private static final DateTime NOW = DateTimes.nowUtc();
-    private static final Interval FIFTEEN_DAY_OLD = new Interval(Period.days(1), NOW.minusDays(15));
-    private static final Interval DAY_OLD = new Interval(Period.days(1), NOW.minusDays(1));
+  private static final int MAX_SEGMENTS_TO_KILL = 10;
+  private static final Period MAX_KILL_INTERVAL = Period.days(30);
+  private static final Duration COORDINATOR_KILL_PERIOD = Duration.standardMinutes(2);
+  private static final Duration DURATION_TO_RETAIN = Duration.standardDays(1);
+  private static final Duration INDEXING_PERIOD = Duration.standardMinutes(1);
 
+  @Mock
+  private SegmentsMetadataManager segmentsMetadataManager;
+  @Mock
+  private IndexingServiceClient indexingServiceClient;
+  @Mock(answer = Answers.RETURNS_DEEP_STUBS)
+  private DruidCoordinatorConfig config;
 
-    @Mock
-    private SegmentsMetadataManager segmentsMetadataManager;
-    @Mock
-    private IndexingServiceClient indexingServiceClient;
-    @Mock(answer = Answers.RETURNS_DEEP_STUBS)
-    private DruidCoordinatorConfig config;
+  @Mock
+  private DruidCoordinatorRuntimeParams params;
+  @Mock
+  private CoordinatorDynamicConfig coordinatorDynamicConfig;
 
-    @Mock
-    private DruidCoordinatorRuntimeParams params;
-    @Mock
-    private CoordinatorDynamicConfig coordinatorDynamicConfig;
+  private DataSegment monthOldSegment;
+  private DataSegment fivedayOldSegment;
+  private DataSegment fifteenDayOldSegment;
 
-    private DataSegment yearOldSegment;
-    private DataSegment monthOldSegment;
-    private DataSegment dayOldSegment;
-    private DataSegment fifteenDayOldSegment;
-    private DataSegment hourOldSegment;
-    private DataSegment nextDaySegment;
-    private DataSegment nextMonthSegment;
+  private KillUnusedSegments target;
 
-    private KillUnusedSegments target;
-
-    @Before
-    public void setup() {
-        Mockito.doReturn(coordinatorDynamicConfig).when(params).getCoordinatorDynamicConfig();
-        Mockito.doReturn(COORDINATOR_KILL_PERIOD).when(config).getCoordinatorKillPeriod();
-        Mockito.doReturn(DURATION_TO_RETAIN).when(config).getCoordinatorKillDurationToRetain();
-        Mockito.doReturn(INDEXING_PERIOD).when(config).getCoordinatorIndexingPeriod();
-        Mockito.doReturn(MAX_SEGMENTS_TO_KILL).when(config).getCoordinatorKillMaxSegments();
-        Mockito.doReturn(MAX_KILL_INTERVAL).when(config).getCoordinatorKillMaxInterval();
+  @Before
+  public void setup()
+  {
+    Mockito.doReturn(coordinatorDynamicConfig).when(params).getCoordinatorDynamicConfig();
+    Mockito.doReturn(COORDINATOR_KILL_PERIOD).when(config).getCoordinatorKillPeriod();
+    Mockito.doReturn(DURATION_TO_RETAIN).when(config).getCoordinatorKillDurationToRetain();
+    Mockito.doReturn(INDEXING_PERIOD).when(config).getCoordinatorIndexingPeriod();
+    Mockito.doReturn(MAX_SEGMENTS_TO_KILL).when(config).getCoordinatorKillMaxSegments();
+    Mockito.doReturn(MAX_KILL_INTERVAL).when(config).getCoordinatorKillMaxInterval();
 
 
-        Mockito.doReturn(Collections.singleton("DS1"))
-                .when(coordinatorDynamicConfig).getSpecificDataSourcesToKillUnusedSegmentsIn();
+    Mockito.doReturn(Collections.singleton("DS1"))
+            .when(coordinatorDynamicConfig).getSpecificDataSourcesToKillUnusedSegmentsIn();
 
-        final DateTime now = DateTimes.nowUtc();
+    final DateTime now = DateTimes.nowUtc();
 
-        yearOldSegment = createSegmentWithEnd(now.minusDays(365));
-        monthOldSegment = createSegmentWithEnd(now.minusDays(30));
-        fifteenDayOldSegment = createSegmentWithEnd(now.minusDays(15));
-        dayOldSegment = createSegmentWithEnd(now.minusDays(1));
-        hourOldSegment = createSegmentWithEnd(now.minusHours(1));
-        nextDaySegment = createSegmentWithEnd(now.plusDays(1));
-        nextMonthSegment = createSegmentWithEnd(now.plusDays(30));
+    monthOldSegment = createSegmentWithEnd(now.minusDays(30));
+    fifteenDayOldSegment = createSegmentWithEnd(now.minusDays(15));
+    fivedayOldSegment = createSegmentWithEnd(now.minusDays(5));
 
-        final List<DataSegment> unusedSegments = ImmutableList.of(
-                yearOldSegment,
-                monthOldSegment,
-                fifteenDayOldSegment,
-                dayOldSegment,
-                hourOldSegment,
-                nextDaySegment,
-                nextMonthSegment
-        );
+    final List<DataSegment> unusedSegments = ImmutableList.of(
+            fifteenDayOldSegment,
+            fivedayOldSegment
+    );
 
-        Mockito.when(
-                segmentsMetadataManager.getUnusedSegmentIntervals(
-                        ArgumentMatchers.anyString(),
-                        ArgumentMatchers.any(),
-                        ArgumentMatchers.anyInt()
-                )
-        ).thenAnswer(invocation -> {
-            DateTime maxEndTime = invocation.getArgument(1);
-            List<Interval> unusedIntervals =
-                    unusedSegments.stream()
-                            .map(DataSegment::getInterval)
-                            .filter(i -> i.getEnd().isBefore(maxEndTime))
-                            .collect(Collectors.toList());
-
-            int limit = invocation.getArgument(2);
-            return unusedIntervals.size() <= limit ? unusedIntervals : unusedIntervals.subList(0, limit);
-        });
-
-        target = new KillUnusedSegments(segmentsMetadataManager, indexingServiceClient, config);
-    }
-
-
-    @Test
-    public void testMaxIntervalToKillWithMinStartTime() {
-        // Set up the configuration to have maxIntervalToKill less than retainDuration
-        Mockito.doReturn(Duration.standardDays(30)).when(config).getCoordinatorKillDurationToRetain();
-        Mockito.doReturn(Period.days(10)).when(config).getCoordinatorKillMaxInterval();
-        target = new KillUnusedSegments(segmentsMetadataManager, indexingServiceClient, config);
-
-        // Create segments with specific intervals
-        DateTime now = DateTimes.nowUtc();
-        DataSegment segmentWithinMaxInterval = createSegmentWithEnd(now.minusDays(5));
-        DataSegment segmentOutsideMaxInterval = createSegmentWithEnd(now.minusDays(20));
-
-        List<DataSegment> unusedSegments = ImmutableList.of(segmentWithinMaxInterval, segmentOutsideMaxInterval);
-
-        // Mock the behavior of segmentsMetadataManager to return these segments
-        Mockito.when(
-                segmentsMetadataManager.getUnusedSegmentIntervals(
-                        ArgumentMatchers.anyString(),
-                        ArgumentMatchers.any(),
-                        ArgumentMatchers.anyInt()
-                )
-        ).thenAnswer(invocation -> {
-            DateTime maxEndTime = invocation.getArgument(1);
-            List<Interval> unusedIntervals =
-                    unusedSegments.stream()
-                            .map(DataSegment::getInterval)
-                            .filter(i -> i.getEnd().isBefore(maxEndTime))
-                            .collect(Collectors.toList());
-
-            int limit = invocation.getArgument(2);
-            return unusedIntervals.size() <= limit ? unusedIntervals : unusedIntervals.subList(0, limit);
-        });
-
-        target.datasourceToLastKillIntervalEnd.put("DS1", segmentWithinMaxInterval.getInterval().getEnd());
-        // Run the KillUnusedSegments duty for the first time
-        target.run(params);
-
-
-        // Verify that only the segment within the maxIntervalToKill range is considered for killing
-        Interval expectedKillInterval = segmentWithinMaxInterval.getInterval();
-        Mockito.verify(indexingServiceClient, Mockito.times(1)).killUnusedSegments(
+    Mockito.when(
+        segmentsMetadataManager.getUnusedSegmentIntervals(
                 ArgumentMatchers.anyString(),
-                ArgumentMatchers.eq("DS1"),
-                ArgumentMatchers.eq(expectedKillInterval)
-        );
+                ArgumentMatchers.any(),
+                ArgumentMatchers.anyInt()
+        )
+    ).thenAnswer(invocation -> {
+      DateTime maxEndTime = invocation.getArgument(1);
+      List<Interval> unusedIntervals =
+               unusedSegments.stream()
+                .map(DataSegment::getInterval)
+                .filter(i -> i.getEnd().isBefore(maxEndTime))
+                .collect(Collectors.toList());
+      int limit = invocation.getArgument(2);
+      return unusedIntervals.size() <= limit ? unusedIntervals : unusedIntervals.subList(0, limit);
+    });
 
-        // Initialize minStartTime to the end of the first killed segment
+    target = new KillUnusedSegments(segmentsMetadataManager, indexingServiceClient, config);
+  }
 
-        // Run the KillUnusedSegments duty again
-        target.run(params);
+  @Test
+  public void testRestrictKillQueryToMaxInterval()
+  {
+    Mockito.doReturn(Duration.standardHours(6)).when(config).getCoordinatorKillDurationToRetain();
+    Mockito.doReturn(Period.days(20)).when(config).getCoordinatorKillMaxInterval();
+    Mockito.doReturn(2).when(config).getCoordinatorKillMaxSegments();
 
+    target = new KillUnusedSegments(segmentsMetadataManager, indexingServiceClient, config);
+    target.datasourceToLastKillIntervalEnd.put("DS1", monthOldSegment.getInterval().getEnd());
 
-        // Verify that the segment outside the maxIntervalToKill range is not considered for killing
-        Mockito.verify(indexingServiceClient, Mockito.never()).killUnusedSegments(
-                ArgumentMatchers.anyString(),
-                ArgumentMatchers.eq("DS1"),
-                ArgumentMatchers.eq(segmentOutsideMaxInterval.getInterval())
-        );
-    }
+    target.run(params);
 
-    @Test
-    public void testRestrictKillQueryToMaxInterval()
-    {
-        Mockito.doReturn(Duration.standardHours(6)).when(config).getCoordinatorKillDurationToRetain();
-        Mockito.doReturn(Period.days(20)).when(config).getCoordinatorKillMaxInterval();
-        Mockito.doReturn(2).when(config).getCoordinatorKillMaxSegments();
+    runAndVerifyKillInterval(fifteenDayOldSegment.getInterval());
+  }
 
-        target = new KillUnusedSegments(segmentsMetadataManager, indexingServiceClient, config);
-        target.run(params);
+  @Test
+  public void testDurationToRetainOverridesMaxKillInterval()
+  {
+    Mockito.doReturn(Period.days(3).toStandardDuration()).when(config).getCoordinatorKillDurationToRetain();
+    Mockito.doReturn(Period.days(28)).when(config).getCoordinatorKillMaxInterval();
 
-        runAndVerifyKillInterval(new Interval(yearOldSegment.getInterval().getStart(), monthOldSegment.getInterval().getEnd()));
+    target = new KillUnusedSegments(segmentsMetadataManager, indexingServiceClient, config);
+    target.datasourceToLastKillIntervalEnd.put("DS1", monthOldSegment.getInterval().getEnd());
 
-        target = new KillUnusedSegments(segmentsMetadataManager, indexingServiceClient, config);
+    target.run(params);
 
-        target.run(params);
+    runAndVerifyKillInterval(new Interval(fifteenDayOldSegment.getInterval().getStart(), fivedayOldSegment.getInterval().getEnd()));
+  }
 
-        runAndVerifyKillInterval(fifteenDayOldSegment.getInterval());
+  private void runAndVerifyKillInterval(Interval expectedKillInterval)
+  {
+    target.run(params);
+    Mockito.verify(indexingServiceClient, Mockito.times(1)).killUnusedSegments(
+            ArgumentMatchers.anyString(),
+            ArgumentMatchers.eq("DS1"),
+            ArgumentMatchers.eq(expectedKillInterval)
+    );
+  }
 
-    }
-
-    private void runAndVerifyKillInterval(Interval expectedKillInterval)
-    {
-        target.run(params);
-        Mockito.verify(indexingServiceClient, Mockito.times(1)).killUnusedSegments(
-                ArgumentMatchers.anyString(),
-                ArgumentMatchers.eq("DS1"),
-                ArgumentMatchers.eq(expectedKillInterval)
-        );
-    }
-
-    private DataSegment createSegmentWithEnd(DateTime endTime)
-    {
-        return new DataSegment(
-                "DS1",
-                new Interval(Period.days(1), endTime),
-                DateTimes.nowUtc().toString(),
-                new HashMap<>(),
-                new ArrayList<>(),
-                new ArrayList<>(),
-                NoneShardSpec.instance(),
-                1,
-                0
-        );
-    }
+  private DataSegment createSegmentWithEnd(DateTime endTime)
+  {
+    return new DataSegment(
+            "DS1",
+            new Interval(Period.days(1), endTime),
+            DateTimes.nowUtc().toString(),
+            new HashMap<>(),
+            new ArrayList<>(),
+            new ArrayList<>(),
+            NoneShardSpec.instance(),
+            1,
+            0
+    );
+  }
 }

--- a/server/src/test/java/org/apache/druid/server/coordinator/duty/killSegmentsMaxIntervalTest.java
+++ b/server/src/test/java/org/apache/druid/server/coordinator/duty/killSegmentsMaxIntervalTest.java
@@ -1,0 +1,224 @@
+package org.apache.druid.server.coordinator.duty;
+
+import com.google.common.collect.ImmutableList;
+import org.apache.druid.client.indexing.IndexingServiceClient;
+import org.apache.druid.java.util.common.DateTimes;
+import org.apache.druid.metadata.SegmentsMetadataManager;
+import org.apache.druid.server.coordinator.CoordinatorDynamicConfig;
+import org.apache.druid.server.coordinator.DruidCoordinatorConfig;
+import org.apache.druid.server.coordinator.DruidCoordinatorRuntimeParams;
+import org.apache.druid.timeline.DataSegment;
+import org.apache.druid.timeline.partition.NoneShardSpec;
+import org.joda.time.DateTime;
+import org.joda.time.Duration;
+import org.joda.time.Interval;
+import org.joda.time.Period;
+import org.junit.Before;
+import org.junit.Test;
+import org.mockito.Answers;
+import org.mockito.ArgumentMatchers;
+import org.mockito.Mock;
+import org.mockito.Mockito;
+
+import java.util.ArrayList;
+import java.util.Collections;
+import java.util.HashMap;
+import java.util.List;
+import java.util.stream.Collectors;
+
+public class killSegmentsMaxIntervalTest {
+
+    private static final int MAX_SEGMENTS_TO_KILL = 10;
+    private static final Period MAX_KILL_INTERVAL = Period.days(30);
+    private static final Duration COORDINATOR_KILL_PERIOD = Duration.standardMinutes(2);
+    private static final Duration DURATION_TO_RETAIN = Duration.standardDays(1);
+    private static final Duration INDEXING_PERIOD = Duration.standardMinutes(1);
+    private static final String DS1 = "DS1";
+    private static final String VERSION = "v1";
+    private static final DateTime NOW = DateTimes.nowUtc();
+    private static final Interval FIFTEEN_DAY_OLD = new Interval(Period.days(1), NOW.minusDays(15));
+    private static final Interval DAY_OLD = new Interval(Period.days(1), NOW.minusDays(1));
+
+
+    @Mock
+    private SegmentsMetadataManager segmentsMetadataManager;
+    @Mock
+    private IndexingServiceClient indexingServiceClient;
+    @Mock(answer = Answers.RETURNS_DEEP_STUBS)
+    private DruidCoordinatorConfig config;
+
+    @Mock
+    private DruidCoordinatorRuntimeParams params;
+    @Mock
+    private CoordinatorDynamicConfig coordinatorDynamicConfig;
+
+    private DataSegment yearOldSegment;
+    private DataSegment monthOldSegment;
+    private DataSegment dayOldSegment;
+    private DataSegment fifteenDayOldSegment;
+    private DataSegment hourOldSegment;
+    private DataSegment nextDaySegment;
+    private DataSegment nextMonthSegment;
+
+    private KillUnusedSegments target;
+
+    @Before
+    public void setup() {
+        Mockito.doReturn(coordinatorDynamicConfig).when(params).getCoordinatorDynamicConfig();
+        Mockito.doReturn(COORDINATOR_KILL_PERIOD).when(config).getCoordinatorKillPeriod();
+        Mockito.doReturn(DURATION_TO_RETAIN).when(config).getCoordinatorKillDurationToRetain();
+        Mockito.doReturn(INDEXING_PERIOD).when(config).getCoordinatorIndexingPeriod();
+        Mockito.doReturn(MAX_SEGMENTS_TO_KILL).when(config).getCoordinatorKillMaxSegments();
+        Mockito.doReturn(MAX_KILL_INTERVAL).when(config).getCoordinatorKillMaxInterval();
+
+
+        Mockito.doReturn(Collections.singleton("DS1"))
+                .when(coordinatorDynamicConfig).getSpecificDataSourcesToKillUnusedSegmentsIn();
+
+        final DateTime now = DateTimes.nowUtc();
+
+        yearOldSegment = createSegmentWithEnd(now.minusDays(365));
+        monthOldSegment = createSegmentWithEnd(now.minusDays(30));
+        fifteenDayOldSegment = createSegmentWithEnd(now.minusDays(15));
+        dayOldSegment = createSegmentWithEnd(now.minusDays(1));
+        hourOldSegment = createSegmentWithEnd(now.minusHours(1));
+        nextDaySegment = createSegmentWithEnd(now.plusDays(1));
+        nextMonthSegment = createSegmentWithEnd(now.plusDays(30));
+
+        final List<DataSegment> unusedSegments = ImmutableList.of(
+                yearOldSegment,
+                monthOldSegment,
+                fifteenDayOldSegment,
+                dayOldSegment,
+                hourOldSegment,
+                nextDaySegment,
+                nextMonthSegment
+        );
+
+        Mockito.when(
+                segmentsMetadataManager.getUnusedSegmentIntervals(
+                        ArgumentMatchers.anyString(),
+                        ArgumentMatchers.any(),
+                        ArgumentMatchers.anyInt()
+                )
+        ).thenAnswer(invocation -> {
+            DateTime maxEndTime = invocation.getArgument(1);
+            List<Interval> unusedIntervals =
+                    unusedSegments.stream()
+                            .map(DataSegment::getInterval)
+                            .filter(i -> i.getEnd().isBefore(maxEndTime))
+                            .collect(Collectors.toList());
+
+            int limit = invocation.getArgument(2);
+            return unusedIntervals.size() <= limit ? unusedIntervals : unusedIntervals.subList(0, limit);
+        });
+
+        target = new KillUnusedSegments(segmentsMetadataManager, indexingServiceClient, config);
+    }
+
+
+    @Test
+    public void testMaxIntervalToKillWithMinStartTime() {
+        // Set up the configuration to have maxIntervalToKill less than retainDuration
+        Mockito.doReturn(Duration.standardDays(30)).when(config).getCoordinatorKillDurationToRetain();
+        Mockito.doReturn(Period.days(10)).when(config).getCoordinatorKillMaxInterval();
+        target = new KillUnusedSegments(segmentsMetadataManager, indexingServiceClient, config);
+
+        // Create segments with specific intervals
+        DateTime now = DateTimes.nowUtc();
+        DataSegment segmentWithinMaxInterval = createSegmentWithEnd(now.minusDays(5));
+        DataSegment segmentOutsideMaxInterval = createSegmentWithEnd(now.minusDays(20));
+
+        List<DataSegment> unusedSegments = ImmutableList.of(segmentWithinMaxInterval, segmentOutsideMaxInterval);
+
+        // Mock the behavior of segmentsMetadataManager to return these segments
+        Mockito.when(
+                segmentsMetadataManager.getUnusedSegmentIntervals(
+                        ArgumentMatchers.anyString(),
+                        ArgumentMatchers.any(),
+                        ArgumentMatchers.anyInt()
+                )
+        ).thenAnswer(invocation -> {
+            DateTime maxEndTime = invocation.getArgument(1);
+            List<Interval> unusedIntervals =
+                    unusedSegments.stream()
+                            .map(DataSegment::getInterval)
+                            .filter(i -> i.getEnd().isBefore(maxEndTime))
+                            .collect(Collectors.toList());
+
+            int limit = invocation.getArgument(2);
+            return unusedIntervals.size() <= limit ? unusedIntervals : unusedIntervals.subList(0, limit);
+        });
+
+        target.datasourceToLastKillIntervalEnd.put("DS1", segmentWithinMaxInterval.getInterval().getEnd());
+        // Run the KillUnusedSegments duty for the first time
+        target.run(params);
+
+
+        // Verify that only the segment within the maxIntervalToKill range is considered for killing
+        Interval expectedKillInterval = segmentWithinMaxInterval.getInterval();
+        Mockito.verify(indexingServiceClient, Mockito.times(1)).killUnusedSegments(
+                ArgumentMatchers.anyString(),
+                ArgumentMatchers.eq("DS1"),
+                ArgumentMatchers.eq(expectedKillInterval)
+        );
+
+        // Initialize minStartTime to the end of the first killed segment
+
+        // Run the KillUnusedSegments duty again
+        target.run(params);
+
+
+        // Verify that the segment outside the maxIntervalToKill range is not considered for killing
+        Mockito.verify(indexingServiceClient, Mockito.never()).killUnusedSegments(
+                ArgumentMatchers.anyString(),
+                ArgumentMatchers.eq("DS1"),
+                ArgumentMatchers.eq(segmentOutsideMaxInterval.getInterval())
+        );
+    }
+
+    @Test
+    public void testRestrictKillQueryToMaxInterval()
+    {
+        Mockito.doReturn(Duration.standardHours(6)).when(config).getCoordinatorKillDurationToRetain();
+        Mockito.doReturn(Period.days(20)).when(config).getCoordinatorKillMaxInterval();
+        Mockito.doReturn(2).when(config).getCoordinatorKillMaxSegments();
+
+        target = new KillUnusedSegments(segmentsMetadataManager, indexingServiceClient, config);
+        target.run(params);
+
+        runAndVerifyKillInterval(new Interval(yearOldSegment.getInterval().getStart(), monthOldSegment.getInterval().getEnd()));
+
+        target = new KillUnusedSegments(segmentsMetadataManager, indexingServiceClient, config);
+
+        target.run(params);
+
+        runAndVerifyKillInterval(fifteenDayOldSegment.getInterval());
+
+    }
+
+    private void runAndVerifyKillInterval(Interval expectedKillInterval)
+    {
+        target.run(params);
+        Mockito.verify(indexingServiceClient, Mockito.times(1)).killUnusedSegments(
+                ArgumentMatchers.anyString(),
+                ArgumentMatchers.eq("DS1"),
+                ArgumentMatchers.eq(expectedKillInterval)
+        );
+    }
+
+    private DataSegment createSegmentWithEnd(DateTime endTime)
+    {
+        return new DataSegment(
+                "DS1",
+                new Interval(Period.days(1), endTime),
+                DateTimes.nowUtc().toString(),
+                new HashMap<>(),
+                new ArrayList<>(),
+                new ArrayList<>(),
+                NoneShardSpec.instance(),
+                1,
+                0
+        );
+    }
+}

--- a/server/src/test/java/org/apache/druid/server/coordinator/duty/killSegmentsMaxIntervalTest.java
+++ b/server/src/test/java/org/apache/druid/server/coordinator/duty/killSegmentsMaxIntervalTest.java
@@ -121,7 +121,7 @@ public class killSegmentsMaxIntervalTest
   }
 
   @Test
-  public void testRestrictKillQueryToMaxInterval()
+  public void testMaxKillIntervalOverridesDurationToRetain()
   {
     Mockito.doReturn(Duration.standardHours(6)).when(config).getCoordinatorKillDurationToRetain();
     Mockito.doReturn(Period.days(20)).when(config).getCoordinatorKillMaxInterval();


### PR DESCRIPTION
<!-- Thanks for trying to help us make Apache Druid be the best it can be! Please fill out as much of the following information as is possible (where relevant, and remove it when irrelevant) to help make the intention and scope of this PR clear in order to ease review. -->

<!-- Please read the doc for contribution (https://github.com/apache/druid/blob/master/CONTRIBUTING.md) before making this PR. Also, once you open a PR, please _avoid using force pushes and rebasing_ since these make it difficult for reviewers to see what you've changed in response to their reviews. See [the 'If your pull request shows conflicts with master' section](https://github.com/apache/druid/blob/master/CONTRIBUTING.md#if-your-pull-request-shows-conflicts-with-master) for more details. -->

Fixes high ingest handoff time during kill tasks and increasing deep storage due to kill task lagging in killing segments. For more https://github.com/apache/druid/pull/17770#issue-2890211040 and https://github.com/apache/druid/pull/17680

**Why unit tests in a new file?** 

In the original Pr on apache druid, the tests are in `killUnusedSegmentsTest` class only, in this version it was not possible to add this test in the same file as they were breaking other tests. We will remove this file once we update to druid-30, [PR for druid-30.
](https://github.com/confluentinc/druid/pull/309)

<!-- Replace XXXX with the id of the issue fixed in this PR. Remove this section if there is no corresponding issue. Don't reference the issue in the title of this pull-request. -->

<hr>

##### Key changed/added classes in this PR
 * `killUnusedSegments`

<hr>

<!-- Check the items by putting "x" in the brackets for the done things. Not all of these items apply to every PR. Remove the items which are not done or not relevant to the PR. None of the items from the checklist below are strictly necessary, but it would be very helpful if you at least self-review the PR. -->

This PR has:

- [ ] been self-reviewed.
   - [ ] using the [concurrency checklist](https://github.com/apache/druid/blob/master/dev/code-review/concurrency.md) (Remove this item if the PR doesn't have any relation to concurrency.)
- [ ] added documentation for new or modified features or behaviors.
- [ ] a release note entry in the PR description.
- [ ] added Javadocs for most classes and all non-trivial methods. Linked related entities via Javadoc links.
- [ ] added or updated version, license, or notice information in [licenses.yaml](https://github.com/apache/druid/blob/master/dev/license.md)
- [ ] added comments explaining the "why" and the intent of the code wherever would not be obvious for an unfamiliar reader.
- [ ] added unit tests or modified existing tests to cover new code paths, ensuring the threshold for [code coverage](https://github.com/apache/druid/blob/master/dev/code-review/code-coverage.md) is met.
- [ ] added integration tests.
- [ ] been tested in a test Druid cluster.
