### PR TITLE
[OBSDATA-8872]Add maxInterval to kill config and make kill tasks efficient

### DIFF
--- a/server/src/main/java/org/apache/druid/server/coordinator/config/CoordinatorKillConfigs.java
+++ b/server/src/main/java/org/apache/druid/server/coordinator/config/CoordinatorKillConfigs.java
@@ -23,11 +23,12 @@ import com.fasterxml.jackson.annotation.JsonCreator;
 import com.fasterxml.jackson.annotation.JsonProperty;
 import org.apache.druid.common.config.Configs;
 import org.joda.time.Duration;
+import org.joda.time.Period;
 
 public class CoordinatorKillConfigs
 {
   public static CoordinatorKillConfigs DEFAULT
-      = new CoordinatorKillConfigs(null, null, null, null, null, null, null, null, null, null, null, null, null);
+      = new CoordinatorKillConfigs(null, null, null, null, null, null, null, null, null, null, null, null, null, null);
 
   @JsonProperty("supervisor")
   private final MetadataCleanupConfig supervisors;
@@ -70,6 +71,9 @@ public class CoordinatorKillConfigs
   @JsonProperty("maxSegments")
   private final Integer killUnusedMaxSegments;
 
+  @JsonProperty("maxInterval")
+  private final Period killUnusedMaxInterval;
+
   @JsonCreator
   public CoordinatorKillConfigs(
       @JsonProperty("pendingSegments") MetadataCleanupConfig pendingSegments,
@@ -85,7 +89,8 @@ public class CoordinatorKillConfigs
       @JsonProperty("durationToRetain") Duration killUnusedDurationToRetain,
       @JsonProperty("ignoreDurationToRetain") Boolean killUnusedIgnoreDurationToRetain,
       @JsonProperty("bufferPeriod") Duration killUnusedBufferPeriod,
-      @JsonProperty("maxSegments") Integer killUnusedMaxSegments
+      @JsonProperty("maxSegments") Integer killUnusedMaxSegments,
+      @JsonProperty("maxInterval") Period killUnusedMaxInterval
   )
   {
     this.pendingSegments = Configs.valueOrDefault(pendingSegments, MetadataCleanupConfig.DEFAULT);
@@ -102,6 +107,7 @@ public class CoordinatorKillConfigs
     this.killUnusedBufferPeriod = killUnusedBufferPeriod;
     this.killUnusedIgnoreDurationToRetain = killUnusedIgnoreDurationToRetain;
     this.killUnusedMaxSegments = killUnusedMaxSegments;
+    this.killUnusedMaxInterval = killUnusedMaxInterval;
   }
 
   public MetadataCleanupConfig auditLogs()
@@ -151,7 +157,8 @@ public class CoordinatorKillConfigs
         killUnusedDurationToRetain,
         killUnusedIgnoreDurationToRetain,
         killUnusedBufferPeriod,
-        killUnusedMaxSegments
+        killUnusedMaxSegments,
+        killUnusedMaxInterval
     );
   }
 }

--- a/server/src/main/java/org/apache/druid/server/coordinator/config/KillUnusedSegmentsConfig.java
+++ b/server/src/main/java/org/apache/druid/server/coordinator/config/KillUnusedSegmentsConfig.java
@@ -23,6 +23,8 @@ import org.apache.druid.common.config.Configs;
 import org.joda.time.Duration;
 import org.joda.time.Period;
 
+import java.util.Objects;
+
 public class KillUnusedSegmentsConfig extends MetadataCleanupConfig
 {
   private final int maxSegments;
@@ -69,6 +71,28 @@ public class KillUnusedSegmentsConfig extends MetadataCleanupConfig
   public Period getMaxInterval()
   {
     return maxInterval;
+  }
+
+  @Override
+  public boolean equals(Object o)
+  {
+    if (o == null || getClass() != o.getClass()) {
+      return false;
+    }
+    if (!super.equals(o)) {
+      return false;
+    }
+    KillUnusedSegmentsConfig that = (KillUnusedSegmentsConfig) o;
+    return maxSegments == that.maxSegments
+            && ignoreDurationToRetain == that.ignoreDurationToRetain
+            && Objects.equals(maxInterval, that.maxInterval)
+            && Objects.equals(bufferPeriod, that.bufferPeriod);
+  }
+
+  @Override
+  public int hashCode()
+  {
+    return Objects.hash(super.hashCode(), maxSegments, maxInterval, ignoreDurationToRetain, bufferPeriod);
   }
 
   public static Builder builder()

--- a/server/src/main/java/org/apache/druid/server/coordinator/config/KillUnusedSegmentsConfig.java
+++ b/server/src/main/java/org/apache/druid/server/coordinator/config/KillUnusedSegmentsConfig.java
@@ -21,12 +21,14 @@ package org.apache.druid.server.coordinator.config;
 
 import org.apache.druid.common.config.Configs;
 import org.joda.time.Duration;
+import org.joda.time.Period;
 
 public class KillUnusedSegmentsConfig extends MetadataCleanupConfig
 {
   private final int maxSegments;
   private final boolean ignoreDurationToRetain;
   private final Duration bufferPeriod;
+  private final Period maxInterval;
 
   public KillUnusedSegmentsConfig(
       Boolean cleanupEnabled,
@@ -34,7 +36,8 @@ public class KillUnusedSegmentsConfig extends MetadataCleanupConfig
       Duration durationToRetain,
       Boolean ignoreDurationToRetain,
       Duration bufferPeriod,
-      Integer maxSegments
+      Integer maxSegments,
+      Period maxInterval
   )
   {
     super(
@@ -45,6 +48,7 @@ public class KillUnusedSegmentsConfig extends MetadataCleanupConfig
     this.ignoreDurationToRetain = Configs.valueOrDefault(ignoreDurationToRetain, false);
     this.bufferPeriod = Configs.valueOrDefault(bufferPeriod, Duration.standardDays(30));
     this.maxSegments = Configs.valueOrDefault(maxSegments, 100);
+    this.maxInterval = Configs.valueOrDefault(maxInterval, Period.days(30));
   }
 
   public int getMaxSegments()
@@ -62,6 +66,11 @@ public class KillUnusedSegmentsConfig extends MetadataCleanupConfig
     return ignoreDurationToRetain;
   }
 
+  public Period getMaxInterval()
+  {
+    return maxInterval;
+  }
+
   public static Builder builder()
   {
     return new Builder();
@@ -74,6 +83,7 @@ public class KillUnusedSegmentsConfig extends MetadataCleanupConfig
     private Boolean ignoreDurationToRetain;
     private Duration bufferPeriod;
     private Integer maxSegments;
+    private Period maxInterval;
 
     private Builder()
     {
@@ -88,7 +98,8 @@ public class KillUnusedSegmentsConfig extends MetadataCleanupConfig
           durationToRetain,
           ignoreDurationToRetain,
           bufferPeriod,
-          maxSegments
+          maxSegments,
+          maxInterval
       );
     }
 
@@ -119,6 +130,12 @@ public class KillUnusedSegmentsConfig extends MetadataCleanupConfig
     public Builder withBufferPeriod(Duration bufferPeriod)
     {
       this.bufferPeriod = bufferPeriod;
+      return this;
+    }
+
+    public Builder withMaxIntervalToKill(Period maxInterval)
+    {
+      this.maxInterval = maxInterval;
       return this;
     }
   }

--- a/server/src/main/java/org/apache/druid/server/coordinator/duty/KillUnusedSegments.java
+++ b/server/src/main/java/org/apache/druid/server/coordinator/duty/KillUnusedSegments.java
@@ -38,6 +38,7 @@ import org.apache.druid.utils.CollectionUtils;
 import org.joda.time.DateTime;
 import org.joda.time.Duration;
 import org.joda.time.Interval;
+import org.joda.time.Period;
 
 import javax.annotation.Nullable;
 import java.util.ArrayList;
@@ -83,6 +84,7 @@ public class KillUnusedSegments implements CoordinatorDuty
   private final Map<String, DateTime> datasourceToLastKillIntervalEnd;
   private DateTime lastKillTime;
   private final Duration bufferPeriod;
+  private final Period maxIntervalToKill;
 
   private final SegmentsMetadataManager segmentsMetadataManager;
   private final OverlordClient overlordClient;
@@ -98,6 +100,7 @@ public class KillUnusedSegments implements CoordinatorDuty
     this.maxSegmentsToKill = killConfig.getMaxSegments();
     this.ignoreDurationToRetain = killConfig.isIgnoreDurationToRetain();
     this.durationToRetain = killConfig.getDurationToRetain();
+    this.maxIntervalToKill = killConfig.getMaxInterval();
     if (this.ignoreDurationToRetain) {
       log.info(
           "druid.coordinator.kill.durationToRetain[%s] will be ignored when discovering segments to kill "
@@ -230,9 +233,23 @@ public class KillUnusedSegments implements CoordinatorDuty
       final CoordinatorRunStats stats
   )
   {
-    final DateTime maxEndTime = ignoreDurationToRetain
-                                ? DateTimes.COMPARE_DATE_AS_STRING_MAX
-                                : DateTimes.nowUtc().minus(durationToRetain);
+
+    final DateTime minStartTime = datasourceToLastKillIntervalEnd.get(dataSource);
+
+    // Once the first segment from a datasource is killed, we have a valid minStartTime.
+    // Restricting the upper bound to scan segments metadata while running the kill task results in a efficient SQL query.
+    final DateTime maxEndTime;
+    if (ignoreDurationToRetain) {
+      maxEndTime = DateTimes.COMPARE_DATE_AS_STRING_MAX;
+    } else if (minStartTime == null) {
+      maxEndTime = DateTimes.nowUtc().minus(durationToRetain);
+    } else {
+      // If we have already killed a segment, limit the kill interval based on the minStartTime
+      maxEndTime = DateTimes.min(
+              DateTimes.nowUtc().minus(durationToRetain),
+              minStartTime.plus(maxIntervalToKill)
+      );
+    }
 
     final List<Interval> unusedSegmentIntervals = segmentsMetadataManager.getUnusedSegmentIntervals(
         dataSource,

--- a/server/src/main/java/org/apache/druid/server/coordinator/duty/KillUnusedSegments.java
+++ b/server/src/main/java/org/apache/druid/server/coordinator/duty/KillUnusedSegments.java
@@ -113,11 +113,12 @@ public class KillUnusedSegments implements CoordinatorDuty
     datasourceToLastKillIntervalEnd = new ConcurrentHashMap<>();
 
     log.info(
-        "Kill task scheduling enabled with period[%s], durationToRetain[%s], bufferPeriod[%s], maxSegmentsToKill[%s]",
+        "Kill task scheduling enabled with period[%s], durationToRetain[%s], bufferPeriod[%s], maxSegmentsToKill[%s] ,maxIntervalToKill[%s]",
         this.period,
         this.ignoreDurationToRetain ? "IGNORING" : this.durationToRetain,
         this.bufferPeriod,
-        this.maxSegmentsToKill
+        this.maxSegmentsToKill,
+        this.maxIntervalToKill
     );
 
     this.segmentsMetadataManager = segmentsMetadataManager;

--- a/server/src/test/java/org/apache/druid/server/coordinator/DruidCoordinatorConfigTest.java
+++ b/server/src/test/java/org/apache/druid/server/coordinator/DruidCoordinatorConfigTest.java
@@ -168,7 +168,8 @@ public class DruidCoordinatorConfigTest
         Period.parse("PT12H").toStandardDuration(),
         true,
         Period.parse("PT60M").toStandardDuration(),
-        500
+        500,
+        Period.parse("P30D")
     );
     CoordinatorKillConfigs killConfigs = createKillConfig().unusedSegments(inputConfig).build();
 
@@ -179,6 +180,7 @@ public class DruidCoordinatorConfigTest
     Assert.assertEquals(Duration.standardMinutes(60), config.getBufferPeriod());
     Assert.assertEquals(Duration.standardHours(12), config.getDurationToRetain());
     Assert.assertEquals(500, config.getMaxSegments());
+    Assert.assertEquals(Period.days(30), config.getMaxInterval());
   }
 
   @Test
@@ -542,7 +544,8 @@ public class DruidCoordinatorConfigTest
           unusedSegments == null ? null : unusedSegments.getDurationToRetain(),
           unusedSegments == null ? null : unusedSegments.isIgnoreDurationToRetain(),
           unusedSegments == null ? null : unusedSegments.getBufferPeriod(),
-          unusedSegments == null ? null : unusedSegments.getMaxSegments()
+          unusedSegments == null ? null : unusedSegments.getMaxSegments(),
+          unusedSegments == null ? null : unusedSegments.getMaxInterval()
       );
     }
   }

--- a/server/src/test/java/org/apache/druid/server/coordinator/duty/KillUnusedSegmentsTest.java
+++ b/server/src/test/java/org/apache/druid/server/coordinator/duty/KillUnusedSegmentsTest.java
@@ -73,6 +73,7 @@ public class KillUnusedSegmentsTest
   private static final DateTime NOW = DateTimes.nowUtc();
   private static final Interval YEAR_OLD = new Interval(Period.days(1), NOW.minusDays(365));
   private static final Interval MONTH_OLD = new Interval(Period.days(1), NOW.minusDays(30));
+  private static final Interval FIFTEEN_DAY_OLD = new Interval(Period.days(1), NOW.minusDays(15));
   private static final Interval DAY_OLD = new Interval(Period.days(1), NOW.minusDays(1));
   private static final Interval HOUR_OLD = new Interval(Period.days(1), NOW.minusHours(1));
   private static final Interval NEXT_DAY = new Interval(Period.days(1), NOW.plusDays(1));
@@ -699,6 +700,55 @@ public class KillUnusedSegmentsTest
     Assert.assertEquals(3, stats.get(Stats.Kill.ELIGIBLE_UNUSED_SEGMENTS, DS1_STAT_KEY));
 
     validateLastKillStateAndReset(DS1, YEAR_OLD);
+  }
+
+  @Test
+  public void testMaxIntervalToKillOverridesDurationToRetain()
+  {
+    configBuilder.withDurationToRetain(Period.hours(6).toStandardDuration())
+            .withMaxIntervalToKill(Period.days(20));
+
+    initDuty();
+
+    createAndAddUnusedSegment(DS1, MONTH_OLD, VERSION, NOW.minusDays(29));
+    CoordinatorRunStats newDatasourceStats = runDutyAndGetStats();
+
+    // For a new datasource, the duration to retain is used to determine kill interval
+    Assert.assertEquals(1, newDatasourceStats.get(Stats.Kill.ELIGIBLE_UNUSED_SEGMENTS, DS1_STAT_KEY));
+    validateLastKillStateAndReset(DS1, MONTH_OLD);
+
+    // For a datasource where kill has already happened, maxIntervalToKill is used
+    // if it leads to a smaller kill interval than durationToRetain
+    createAndAddUnusedSegment(DS1, FIFTEEN_DAY_OLD, VERSION, NOW.minusDays(14));
+    createAndAddUnusedSegment(DS1, DAY_OLD, VERSION, NOW.minusHours(2));
+    CoordinatorRunStats oldDatasourceStats = runDutyAndGetStats();
+
+    Assert.assertEquals(2, oldDatasourceStats.get(Stats.Kill.ELIGIBLE_UNUSED_SEGMENTS, DS1_STAT_KEY));
+    validateLastKillStateAndReset(DS1, FIFTEEN_DAY_OLD);
+  }
+
+  @Test
+  public void testDurationToRetainOverridesMaxIntervalToKill()
+  {
+    configBuilder.withDurationToRetain(Period.days(20).toStandardDuration())
+            .withMaxIntervalToKill(Period.days(350));
+
+    initDuty();
+
+    createAndAddUnusedSegment(DS1, YEAR_OLD, VERSION, NOW.minusDays(29));
+    CoordinatorRunStats newDatasourceStats = runDutyAndGetStats();
+
+    Assert.assertEquals(1, newDatasourceStats.get(Stats.Kill.ELIGIBLE_UNUSED_SEGMENTS, DS1_STAT_KEY));
+    validateLastKillStateAndReset(DS1, YEAR_OLD);
+
+    // For a datasource where (now - durationToRetain) < (lastKillTime(year old segment) + maxInterval)
+    // Fifteen day old segment will be rejected
+    createAndAddUnusedSegment(DS1, MONTH_OLD, VERSION, NOW.minusDays(29));
+    createAndAddUnusedSegment(DS1, FIFTEEN_DAY_OLD, VERSION, NOW.minusDays(14));
+    CoordinatorRunStats oldDatasourceStats = runDutyAndGetStats();
+
+    Assert.assertEquals(2, oldDatasourceStats.get(Stats.Kill.ELIGIBLE_UNUSED_SEGMENTS, DS1_STAT_KEY));
+    validateLastKillStateAndReset(DS1, MONTH_OLD);
   }
 
   private void validateLastKillStateAndReset(final String dataSource, @Nullable final Interval expectedKillInterval)


### PR DESCRIPTION
### Description

TL;DR 
Kill tasks on cordinators are lagging, causing deep storage to increase rapidly and ingest handoff time spikes. This PR is to fix that.

For more description, please [follow](https://github.com/apache/druid/pull/17770#issue-2890211040)
 

<!-- It's good to describe an alternative design (or mention an alternative name) for every design (or naming) decision point and compare the alternatives with the designs that you've implemented (or the names you've chosen) to highlight the advantages of the chosen designs and names. -->

<!-- If there was a discussion of the design of the feature implemented in this PR elsewhere (e. g. a "Proposal" issue, any other issue, or a thread in the development mailing list), link to that discussion from this PR description and explain what have changed in your final design compared to your original proposal or the consensus version in the end of the discussion. If something hasn't changed since the original discussion, you can omit a detailed discussion of those aspects of the design here, perhaps apart from brief mentioning for the sake of readability of this PR description. -->

<!-- Some of the aspects mentioned above may be omitted for simple and small changes. -->

#### Release note
<!-- Give your best effort to summarize your changes in a couple of sentences aimed toward Druid users. 

If your change doesn't have end user impact, you can skip this section.

-->
For tips about how to write a good release note, see [Release notes](https://github.com/apache/druid/blob/master/CONTRIBUTING.md#release-notes).


<hr>

##### Key changed/added classes in this PR
 * `KillUnusedSegments`

<hr>

<!-- Check the items by putting "x" in the brackets for the done things. Not all of these items apply to every PR. Remove the items which are not done or not relevant to the PR. None of the items from the checklist below are strictly necessary, but it would be very helpful if you at least self-review the PR. -->

This PR has:

- [ ] been self-reviewed.
   - [ ] using the [concurrency checklist](https://github.com/apache/druid/blob/master/dev/code-review/concurrency.md) (Remove this item if the PR doesn't have any relation to concurrency.)
- [ ] added documentation for new or modified features or behaviors.
- [ ] a release note entry in the PR description.
- [ ] added Javadocs for most classes and all non-trivial methods. Linked related entities via Javadoc links.
- [ ] added or updated version, license, or notice information in [licenses.yaml](https://github.com/apache/druid/blob/master/dev/license.md)
- [ ] added comments explaining the "why" and the intent of the code wherever would not be obvious for an unfamiliar reader.
- [ ] added unit tests or modified existing tests to cover new code paths, ensuring the threshold for [code coverage](https://github.com/apache/druid/blob/master/dev/code-review/code-coverage.md) is met.
- [ ] added integration tests.
- [ ] been tested in a test Druid cluster.
