### PR TITLE
OBSDATA-9613 Run "services" tests separately on semaphore

### DIFF
--- a/.semaphore/semaphore.yml
+++ b/.semaphore/semaphore.yml
@@ -146,6 +146,8 @@ blocks:
           env_vars:
             - name: MAVEN_PROJECTS
               value: services
+            - name: MAVEN_OPTS
+              value: "-Xmx1g"
           commands: *run_tests
 
         - name: "Other Tests"

--- a/.semaphore/semaphore.yml
+++ b/.semaphore/semaphore.yml
@@ -147,7 +147,7 @@ blocks:
             - name: MAVEN_PROJECTS
               value: services
             - name: MAVEN_OPTS
-              value: "${MAVEN_OPTS} -DforkCount=1 -DreuseForks=false"
+              value: "-DforkCount=1 -DreuseForks=false"
           commands: *run_tests
 
         - name: "Other Tests"

--- a/.semaphore/semaphore.yml
+++ b/.semaphore/semaphore.yml
@@ -146,8 +146,9 @@ blocks:
           env_vars:
             - name: MAVEN_PROJECTS
               value: services
-          commands:
-            - mvn test -pl ${MAVEN_PROJECTS} -DforkCount=1 -DreuseForks=false
+            - name: MAVEN_OPTS
+              value: "${MAVEN_OPTS} -DforkCount=1 -DreuseForks=false"
+          commands: *run_tests
 
         - name: "Other Tests"
           env_vars:

--- a/.semaphore/semaphore.yml
+++ b/.semaphore/semaphore.yml
@@ -147,7 +147,7 @@ blocks:
             - name: MAVEN_PROJECTS
               value: services
           commands:
-            - mvn clean install -pl ${MAVEN_PROJECTS}
+            - mvn test -pl ${MAVEN_PROJECTS} -DforkCount=1 -DreuseForks=false
 
         - name: "Other Tests"
           env_vars:

--- a/.semaphore/semaphore.yml
+++ b/.semaphore/semaphore.yml
@@ -142,8 +142,14 @@ blocks:
               value: web-console
           commands: *run_tests
 
+        - name: "Services"
+          env_vars:
+            - name: MAVEN_PROJECTS
+              value: services
+          commands: *run_tests
+
         - name: "Other Tests"
           env_vars:
             - name: MAVEN_PROJECTS
-              value: '!server,!processing,!indexing-service,!extensions-core/kafka-indexing-service,!extensions-contrib/confluent-extensions,!integration-tests-ex/cases,!web-console'
+              value: '!server,!processing,!indexing-service,!extensions-core/kafka-indexing-service,!extensions-contrib/confluent-extensions,!integration-tests-ex/cases,!web-console,!services'
           commands: *run_tests

--- a/.semaphore/semaphore.yml
+++ b/.semaphore/semaphore.yml
@@ -146,9 +146,8 @@ blocks:
           env_vars:
             - name: MAVEN_PROJECTS
               value: services
-            - name: MAVEN_OPTS
-              value: "-Xmx1g"
-          commands: *run_tests
+          commands:
+            - mvn clean install -pl ${MAVEN_PROJECTS}
 
         - name: "Other Tests"
           env_vars:


### PR DESCRIPTION
<!-- Replace XXXX with the id of the issue fixed in this PR. Remove this section if there is no corresponding issue. Don't reference the issue in the title of this pull-request. -->

<!-- If you are a committer, follow the PR action item checklist for committers:
https://github.com/apache/druid/blob/master/dev/committer-instructions.md#pr-and-issue-action-item-checklist-for-committers. -->

### Description

<!-- Describe the goal of this PR, what problem are you fixing. If there is a corresponding issue (referenced above), it's not necessary to repeat the description here, however, you may choose to keep one summary sentence. -->

<!-- Describe your patch: what did you change in code? How did you fix the problem? -->

<!-- If there are several relatively logically separate changes in this PR, create a mini-section for each of them. For example: -->

#### Problem
* Druid-30 build was passing on semaphore in the latest commit (Feb-17).
* However, Due to recent changes in semaphore, The build is failing on semaphore.
* UTs of druid-services is failing in “Other Tests” in semaphore
* The tests are running without any error on local.

#### Root Cause
* Some tests in "services" package are setting System.property and when the tests runs in parallel, wrong config is picked.

#### Fix
* Separated out "services" to run independently on semaphore.
* Running the tests of "services" sequentially.


<!--
In each section, please describe design decisions made, including:
 - Choice of algorithms
 - Behavioral aspects. What configuration values are acceptable? How are corner cases and error conditions handled, such as when there are insufficient resources?
 - Class organization and design (how the logic is split between classes, inheritance, composition, design patterns)
 - Method organization and design (how the logic is split between methods, parameters and return types)
 - Naming (class, method, API, configuration, HTTP endpoint, names of emitted metrics)
-->


<!-- It's good to describe an alternative design (or mention an alternative name) for every design (or naming) decision point and compare the alternatives with the designs that you've implemented (or the names you've chosen) to highlight the advantages of the chosen designs and names. -->

<!-- If there was a discussion of the design of the feature implemented in this PR elsewhere (e. g. a "Proposal" issue, any other issue, or a thread in the development mailing list), link to that discussion from this PR description and explain what have changed in your final design compared to your original proposal or the consensus version in the end of the discussion. If something hasn't changed since the original discussion, you can omit a detailed discussion of those aspects of the design here, perhaps apart from brief mentioning for the sake of readability of this PR description. -->

<!-- Some of the aspects mentioned above may be omitted for simple and small changes. -->

#### Release note
<!-- Give your best effort to summarize your changes in a couple of sentences aimed toward Druid users. 

If your change doesn't have end user impact, you can skip this section.

-->
For tips about how to write a good release note, see [Release notes](https://github.com/apache/druid/blob/master/CONTRIBUTING.md#release-notes).


<hr>

##### Key changed/added classes in this PR
 * `semaphore.yml`

<hr>

<!-- Check the items by putting "x" in the brackets for the done things. Not all of these items apply to every PR. Remove the items which are not done or not relevant to the PR. None of the items from the checklist below are strictly necessary, but it would be very helpful if you at least self-review the PR. -->

This PR has:

- [x] been self-reviewed.
   - [ ] using the [concurrency checklist](https://github.com/apache/druid/blob/master/dev/code-review/concurrency.md) (Remove this item if the PR doesn't have any relation to concurrency.)
- [ ] added documentation for new or modified features or behaviors.
- [ ] a release note entry in the PR description.
- [ ] added Javadocs for most classes and all non-trivial methods. Linked related entities via Javadoc links.
- [ ] added or updated version, license, or notice information in [licenses.yaml](https://github.com/apache/druid/blob/master/dev/license.md)
- [ ] added comments explaining the "why" and the intent of the code wherever would not be obvious for an unfamiliar reader.
- [ ] added unit tests or modified existing tests to cover new code paths, ensuring the threshold for [code coverage](https://github.com/apache/druid/blob/master/dev/code-review/code-coverage.md) is met.
- [ ] added integration tests.
- [ ] been tested in a test Druid cluster.
