### PR TITLE
OBSDATA-9685 Add RDS root CA certs to Dockerfile

### DIFF
--- a/distribution/docker/Dockerfile
+++ b/distribution/docker/Dockerfile
@@ -132,4 +132,13 @@ WORKDIR /opt/druid
 # However, since Derby is not used in production, we can safely exclude it from the Druid image.
 RUN rm /opt/druid/lib/derby-10.14.2.0.jar /opt/druid/lib/derbyclient-10.14.2.0.jar /opt/druid/lib/derbynet-10.14.2.0.jar
 
+# Create directory for PostgreSQL certificates
+RUN mkdir -p /opt/druid/.postgresql
+
+# Download RDS root CA certificates for both commercial and us-gov regions
+RUN curl -s https://truststore.pki.rds.amazonaws.com/global/global-bundle.pem -o /opt/druid/.postgresql/root.crt && \
+    curl -s https://truststore.pki.rds.amazonaws.com/global/global-bundle-fedramp.pem -o /opt/druid/.postgresql/root-fedramp.crt && \
+    chmod 644 /opt/druid/.postgresql/root.crt /opt/druid/.postgresql/root-fedramp.crt && \
+    chown -R druid:druid /opt/druid/.postgresql
+
 ENTRYPOINT ["/druid.sh"]


### PR DESCRIPTION
Adds RDS root CA certificates to the Docker image

### Description

This is necessary for those setups which enforces string SSL connections with AWS RDS. 
Changes are made to Dockerfile alone. 


<hr>


<!-- Check the items by putting "x" in the brackets for the done things. Not all of these items apply to every PR. Remove the items which are not done or not relevant to the PR. None of the items from the checklist below are strictly necessary, but it would be very helpful if you at least self-review the PR. -->

This PR has:

- [ ] been self-reviewed.
   - [ ] using the [concurrency checklist](https://github.com/apache/druid/blob/master/dev/code-review/concurrency.md) (Remove this item if the PR doesn't have any relation to concurrency.)
- [ ] added documentation for new or modified features or behaviors.
- [ ] a release note entry in the PR description.
- [ ] added Javadocs for most classes and all non-trivial methods. Linked related entities via Javadoc links.
- [ ] added or updated version, license, or notice information in [licenses.yaml](https://github.com/apache/druid/blob/master/dev/license.md)
- [ ] added comments explaining the "why" and the intent of the code wherever would not be obvious for an unfamiliar reader.
- [ ] added unit tests or modified existing tests to cover new code paths, ensuring the threshold for [code coverage](https://github.com/apache/druid/blob/master/dev/code-review/code-coverage.md) is met.
- [ ] added integration tests.
- [ ] been tested in a test Druid cluster.
