### PR TITLE
Install druid-kubernetes-overlord-extension

### DIFF
--- a/distribution/pom.xml
+++ b/distribution/pom.xml
@@ -691,6 +691,8 @@
                                         <argument>org.apache.druid.extensions:druid-pac4j</argument>
                                         <argument>-c</argument>
                                         <argument>org.apache.druid.extensions:druid-kubernetes-extensions</argument>
+                                        <argument>-c</argument>
+                                        <argument>org.apache.druid.extensions:druid-kubernetes-overlord-extensions</argument>
                                         <argument>--clean</argument>
                                     </arguments>
                                 </configuration>


### PR DESCRIPTION
- Adds the extension `druid-kubernetes-overlord-extension` to the Maven profile `dist-used`
- This would download and install the above mentioned extension to Druid 

### Description
- This is required for using mm-less Druid as mentioned [here](https://druid.apache.org/docs/30.0.0/development/extensions-contrib/k8s-jobs/#migrationkubernetes-and-worker-task-runner)


This PR has:

- [x] been self-reviewed.
   - [x] using the [concurrency checklist](https://github.com/apache/druid/blob/master/dev/code-review/concurrency.md) (Remove this item if the PR doesn't have any relation to concurrency.)
- [ ] added documentation for new or modified features or behaviors.
- [ ] a release note entry in the PR description.
- [ ] added Javadocs for most classes and all non-trivial methods. Linked related entities via Javadoc links.
- [ ] added or updated version, license, or notice information in [licenses.yaml](https://github.com/apache/druid/blob/master/dev/license.md)
- [ ] added comments explaining the "why" and the intent of the code wherever would not be obvious for an unfamiliar reader.
- [ ] added unit tests or modified existing tests to cover new code paths, ensuring the threshold for [code coverage](https://github.com/apache/druid/blob/master/dev/code-review/code-coverage.md) is met.
- [ ] added integration tests.
- [ ] been tested in a test Druid cluster.
