### PR TITLE
Add config support to control the frequency of the kubernetes pod periodic list

### DIFF
--- a/.semaphore/semaphore.yml
+++ b/.semaphore/semaphore.yml
@@ -110,7 +110,7 @@ blocks:
           commands: &run_tests
             - >
               MAVEN_OPTS="${MAVEN_OPTS} -Xmx1g" ${MVN} test -pl ${MAVEN_PROJECTS}
-              ${MAVEN_SKIP} -Dremoteresources.skip=true
+              ${MAVEN_SKIP}
 
         - name: "Server"
           env_vars:

--- a/.semaphore/semaphore.yml
+++ b/.semaphore/semaphore.yml
@@ -40,7 +40,7 @@ blocks:
             - cache clear
             - >
               MAVEN_OPTS="${MAVEN_OPTS} -Xmx3000m" ${MVN} clean install
-              -q -ff ${MAVEN_SKIP} ${MAVEN_SKIP_TESTS} -T1C -U
+              -q -ff ${MAVEN_SKIP} ${MAVEN_SKIP_TESTS} -T1C
             # downstream tests depend on artifacts installed by mvn install into .m2
             # also cache target to avoid the cost of recompiling tests
             - tar zcf cache-post-install.tgz .m2 target

--- a/.semaphore/semaphore.yml
+++ b/.semaphore/semaphore.yml
@@ -39,7 +39,7 @@ blocks:
             - rm ~/.m2/settings.xml
             - >
               MAVEN_OPTS="${MAVEN_OPTS} -Xmx3000m" ${MVN} clean install
-              -q -ff ${MAVEN_SKIP} ${MAVEN_SKIP_TESTS} -T1C
+              -q -ff ${MAVEN_SKIP} ${MAVEN_SKIP_TESTS} -T1C -U
             # downstream tests depend on artifacts installed by mvn install into .m2
             # also cache target to avoid the cost of recompiling tests
             - tar zcf cache-post-install.tgz .m2 target
@@ -110,7 +110,7 @@ blocks:
           commands: &run_tests
             - >
               MAVEN_OPTS="${MAVEN_OPTS} -Xmx1g" ${MVN} test -pl ${MAVEN_PROJECTS}
-              ${MAVEN_SKIP}
+              ${MAVEN_SKIP} -Dremoteresources.skip=true
 
         - name: "Server"
           env_vars:

--- a/docs/development/extensions-core/kubernetes.md
+++ b/docs/development/extensions-core/kubernetes.md
@@ -52,6 +52,7 @@ Additionally, this extension has following configuration.
 |`druid.discovery.k8s.leaseDuration`|`Duration`|Lease duration used by Leader Election algorithm. Candidates wait for this time before taking over previous Leader.|PT60S|No|
 |`druid.discovery.k8s.renewDeadline`|`Duration`|Lease renewal period used by Leader.|PT17S|No|
 |`druid.discovery.k8s.retryPeriod`|`Duration`|Retry wait used by Leader Election algorithm on failed operations.|PT5S|No|
+|`druid.discovery.k8s.periodicListInterval`|`Duration`|Interval between periodic pod listings for node discovery.|PT1M|No|
 
 ### Gotchas
 

--- a/extensions-core/kubernetes-extensions/src/main/java/org/apache/druid/k8s/discovery/K8sDiscoveryConfig.java
+++ b/extensions-core/kubernetes-extensions/src/main/java/org/apache/druid/k8s/discovery/K8sDiscoveryConfig.java
@@ -63,6 +63,9 @@ public class K8sDiscoveryConfig
   @JsonProperty
   private final Duration terminatingStateCheckDuration;
 
+  @JsonProperty
+  private final Duration periodicListInterval;
+
   @JsonCreator
   public K8sDiscoveryConfig(
       @JsonProperty("clusterIdentifier") String clusterIdentifier,
@@ -73,7 +76,8 @@ public class K8sDiscoveryConfig
       @JsonProperty("leaseDuration") Duration leaseDuration,
       @JsonProperty("renewDeadline") Duration renewDeadline,
       @JsonProperty("retryPeriod") Duration retryPeriod,
-      @JsonProperty("terminatingStateCheckDuration") Duration terminatingStateCheckDuration
+      @JsonProperty("terminatingStateCheckDuration") Duration terminatingStateCheckDuration,
+      @JsonProperty("periodicListInterval") Duration periodicListInterval
   )
   {
     Preconditions.checkArgument(clusterIdentifier != null && !clusterIdentifier.isEmpty(), "null/empty clusterIdentifier");
@@ -102,6 +106,7 @@ public class K8sDiscoveryConfig
     this.renewDeadline = renewDeadline == null ? Duration.millis(17000) : renewDeadline;
     this.retryPeriod = retryPeriod == null ? Duration.millis(5000) : retryPeriod;
     this.terminatingStateCheckDuration = terminatingStateCheckDuration == null ? Duration.standardSeconds(30) : terminatingStateCheckDuration;
+    this.periodicListInterval = periodicListInterval == null ? Duration.standardMinutes(1) : periodicListInterval;
   }
 
   @JsonProperty
@@ -158,6 +163,12 @@ public class K8sDiscoveryConfig
     return terminatingStateCheckDuration;
   }
 
+  @JsonProperty
+  public Duration getPeriodicListInterval()
+  {
+    return periodicListInterval;
+  }
+
   @Override
   public String toString()
   {
@@ -171,6 +182,7 @@ public class K8sDiscoveryConfig
            ", renewDeadline=" + renewDeadline +
            ", retryPeriod=" + retryPeriod +
            ", terminatingStateCheckDuration=" + terminatingStateCheckDuration +
+           ", periodicListInterval=" + periodicListInterval +
            '}';
   }
 
@@ -198,7 +210,8 @@ public class K8sDiscoveryConfig
            Objects.equals(leaseDuration, that.leaseDuration) &&
            Objects.equals(renewDeadline, that.renewDeadline) &&
            Objects.equals(retryPeriod, that.retryPeriod) &&
-           Objects.equals(terminatingStateCheckDuration, that.terminatingStateCheckDuration);
+           Objects.equals(terminatingStateCheckDuration, that.terminatingStateCheckDuration) &&
+           Objects.equals(periodicListInterval, that.periodicListInterval);
   }
 
   @Override
@@ -213,7 +226,8 @@ public class K8sDiscoveryConfig
         leaseDuration,
         renewDeadline,
         retryPeriod,
-        terminatingStateCheckDuration
+        terminatingStateCheckDuration,
+        periodicListInterval
     );
   }
 }

--- a/extensions-core/kubernetes-extensions/src/main/java/org/apache/druid/k8s/discovery/K8sDruidNodeDiscoveryProvider.java
+++ b/extensions-core/kubernetes-extensions/src/main/java/org/apache/druid/k8s/discovery/K8sDruidNodeDiscoveryProvider.java
@@ -246,7 +246,7 @@ public class K8sDruidNodeDiscoveryProvider extends DruidNodeDiscoveryProvider
         catch (Throwable ex) {
           LOGGER.error(ex, "Error during periodic pod listing for NodeRole [%s]", nodeRole);
         }
-      }, 2, 1, TimeUnit.MINUTES);
+      }, 120000, discoveryConfig.getPeriodicListInterval().getMillis(), TimeUnit.MILLISECONDS);
 
       while (lifecycleLock.awaitStarted(1, TimeUnit.MILLISECONDS)) {
         try {

--- a/extensions-core/kubernetes-extensions/src/test/java/org/apache/druid/k8s/discovery/K8sAnnouncerAndDiscoveryIntTest.java
+++ b/extensions-core/kubernetes-extensions/src/test/java/org/apache/druid/k8s/discovery/K8sAnnouncerAndDiscoveryIntTest.java
@@ -52,7 +52,7 @@ public class K8sAnnouncerAndDiscoveryIntTest
 
   private final PodInfo podInfo = new PodInfo("busybox", "default");
 
-  private final K8sDiscoveryConfig discoveryConfig = new K8sDiscoveryConfig("druid-cluster", null, null, null, null, null, null, null, null);
+  private final K8sDiscoveryConfig discoveryConfig = new K8sDiscoveryConfig("druid-cluster", null, null, null, null, null, null, null, null, null);
 
   @Test(timeout = 30000L)
   public void testAnnouncementAndDiscoveryWorkflow() throws Exception

--- a/extensions-core/kubernetes-extensions/src/test/java/org/apache/druid/k8s/discovery/K8sDiscoveryConfigTest.java
+++ b/extensions-core/kubernetes-extensions/src/test/java/org/apache/druid/k8s/discovery/K8sDiscoveryConfigTest.java
@@ -34,7 +34,7 @@ public class K8sDiscoveryConfigTest
   {
     testSerde(
         "{\"clusterIdentifier\": \"test-cluster\"}\n",
-        new K8sDiscoveryConfig("test-cluster", null, null, null, null, null, null, null, null)
+        new K8sDiscoveryConfig("test-cluster", null, null, null, null, null, null, null, null, null)
     );
   }
 
@@ -52,7 +52,8 @@ public class K8sDiscoveryConfigTest
         + "  \"renewDeadline\": \"PT2S\",\n"
         + "  \"retryPeriod\": \"PT1S\",\n"
         + "  \"terminatingStateCheckDuration\": \"PT30S\"\n"
-                + "\n}",
+        + "  \"periodicListInterval\": \"PT20S\"\n"
+        + "\n}",
         new K8sDiscoveryConfig(
             "test-cluster",
             "PODNAMETEST",
@@ -62,7 +63,8 @@ public class K8sDiscoveryConfigTest
             Duration.millis(3000),
             Duration.millis(2000),
             Duration.millis(1000),
-                Duration.millis(30000)
+                Duration.millis(30000),
+                Duration.millis(20000)
         )
     );
   }

--- a/extensions-core/kubernetes-extensions/src/test/java/org/apache/druid/k8s/discovery/K8sDiscoveryConfigTest.java
+++ b/extensions-core/kubernetes-extensions/src/test/java/org/apache/druid/k8s/discovery/K8sDiscoveryConfigTest.java
@@ -51,7 +51,7 @@ public class K8sDiscoveryConfigTest
         + "  \"leaseDuration\": \"PT3S\",\n"
         + "  \"renewDeadline\": \"PT2S\",\n"
         + "  \"retryPeriod\": \"PT1S\",\n"
-        + "  \"terminatingStateCheckDuration\": \"PT30S\"\n"
+        + "  \"terminatingStateCheckDuration\": \"PT30S\",\n"
         + "  \"periodicListInterval\": \"PT20S\"\n"
         + "\n}",
         new K8sDiscoveryConfig(

--- a/extensions-core/kubernetes-extensions/src/test/java/org/apache/druid/k8s/discovery/K8sDruidLeaderElectionIntTest.java
+++ b/extensions-core/kubernetes-extensions/src/test/java/org/apache/druid/k8s/discovery/K8sDruidLeaderElectionIntTest.java
@@ -54,7 +54,7 @@ public class K8sDruidLeaderElectionIntTest
   );
 
   private final K8sDiscoveryConfig discoveryConfig = new K8sDiscoveryConfig("druid-cluster", null, null, "default", "default",
-                                                                            Duration.millis(10_000), Duration.millis(7_000), Duration.millis(3_000), null);
+                                                                            Duration.millis(10_000), Duration.millis(7_000), Duration.millis(3_000), null, null);
 
   private final ApiClient k8sApiClient;
 

--- a/extensions-core/kubernetes-extensions/src/test/java/org/apache/druid/k8s/discovery/K8sDruidLeaderSelectorTest.java
+++ b/extensions-core/kubernetes-extensions/src/test/java/org/apache/druid/k8s/discovery/K8sDruidLeaderSelectorTest.java
@@ -38,7 +38,7 @@ public class K8sDruidLeaderSelectorTest
   );
 
   private final K8sDiscoveryConfig discoveryConfig = new K8sDiscoveryConfig("druid-cluster", null, null,
-                                                                            "default", "default", Duration.millis(10_000), Duration.millis(7_000), Duration.millis(3_000), null);
+                                                                            "default", "default", Duration.millis(10_000), Duration.millis(7_000), Duration.millis(3_000), null, null);
 
   private final String lockResourceName = "druid-leader-election";
 

--- a/extensions-core/kubernetes-extensions/src/test/java/org/apache/druid/k8s/discovery/K8sDruidNodeAnnouncerTest.java
+++ b/extensions-core/kubernetes-extensions/src/test/java/org/apache/druid/k8s/discovery/K8sDruidNodeAnnouncerTest.java
@@ -47,7 +47,7 @@ public class K8sDruidNodeAnnouncerTest
 
   private final PodInfo podInfo = new PodInfo("testpod", "testns");
 
-  private final K8sDiscoveryConfig discoveryConfig = new K8sDiscoveryConfig("druid-cluster", null, null, null, null, null, null, null, null);
+  private final K8sDiscoveryConfig discoveryConfig = new K8sDiscoveryConfig("druid-cluster", null, null, null, null, null, null, null, null, null);
 
   @Test
   public void testAnnounce() throws Exception

--- a/extensions-core/kubernetes-extensions/src/test/java/org/apache/druid/k8s/discovery/K8sDruidNodeDiscoveryProviderTest.java
+++ b/extensions-core/kubernetes-extensions/src/test/java/org/apache/druid/k8s/discovery/K8sDruidNodeDiscoveryProviderTest.java
@@ -77,7 +77,7 @@ public class K8sDruidNodeDiscoveryProviderTest
 
   private final PodInfo podInfo = new PodInfo("testpod", "testns");
 
-  private final K8sDiscoveryConfig discoveryConfig = new K8sDiscoveryConfig("druid-cluster", null, null, null, null, null, null, null, null);
+  private final K8sDiscoveryConfig discoveryConfig = new K8sDiscoveryConfig("druid-cluster", null, null, null, null, null, null, null, null, null);
 
   @Test(timeout = 60_000)
   public void testGetForNodeRole() throws Exception


### PR DESCRIPTION

<!-- Replace XXXX with the id of the issue fixed in this PR. Remove this section if there is no corresponding issue. Don't reference the issue in the title of this pull-request. -->

<!-- If you are a committer, follow the PR action item checklist for committers:
https://github.com/apache/druid/blob/master/dev/committer-instructions.md#pr-and-issue-action-item-checklist-for-committers. -->

### Description
- Add config support to control the frequency of the kubernetes pod periodic list
- With the configs we can have different frequencies per component
- Have a higher poll period for the datanodes and more frequency for the master nodes and brokers

<!-- Describe the goal of this PR, what problem are you fixing. If there is a corresponding issue (referenced above), it's not necessary to repeat the description here, however, you may choose to keep one summary sentence. -->

<!-- Describe your patch: what did you change in code? How did you fix the problem? -->

<!-- If there are several relatively logically separate changes in this PR, create a mini-section for each of them. For example: -->

<hr>

<!-- Check the items by putting "x" in the brackets for the done things. Not all of these items apply to every PR. Remove the items which are not done or not relevant to the PR. None of the items from the checklist below are strictly necessary, but it would be very helpful if you at least self-review the PR. -->

This PR has:

- [ ] been self-reviewed.
   - [ ] using the [concurrency checklist](https://github.com/apache/druid/blob/master/dev/code-review/concurrency.md) (Remove this item if the PR doesn't have any relation to concurrency.)
- [ ] added documentation for new or modified features or behaviors.
- [ ] a release note entry in the PR description.
- [ ] added Javadocs for most classes and all non-trivial methods. Linked related entities via Javadoc links.
- [ ] added or updated version, license, or notice information in [licenses.yaml](https://github.com/apache/druid/blob/master/dev/license.md)
- [ ] added comments explaining the "why" and the intent of the code wherever would not be obvious for an unfamiliar reader.
- [ ] added unit tests or modified existing tests to cover new code paths, ensuring the threshold for [code coverage](https://github.com/apache/druid/blob/master/dev/code-review/code-coverage.md) is met.
- [ ] added integration tests.
- [ ] been tested in a test Druid cluster.
