### PR TITLE
[Druid-30] OBSDATA-10784: Fix cc-druid distribution module build-time

### DIFF
--- a/distribution/pom.xml
+++ b/distribution/pom.xml
@@ -370,6 +370,7 @@
                     <plugin>
                         <groupId>org.codehaus.mojo</groupId>
                         <artifactId>exec-maven-plugin</artifactId>
+                        <version>3.1.0</version>
                         <executions>
                             <execution>
                                 <id>pull-deps-contrib-exts</id>
@@ -482,6 +483,7 @@
                     <plugin>
                         <groupId>org.codehaus.mojo</groupId>
                         <artifactId>exec-maven-plugin</artifactId>
+                        <version>3.1.0</version>
                         <executions>
                             <execution>
                                 <id>pull-deps</id>
@@ -742,6 +744,7 @@
                     <plugin>
                         <groupId>org.codehaus.mojo</groupId>
                         <artifactId>exec-maven-plugin</artifactId>
+                        <version>3.1.0</version>
                         <executions>
                             <execution>
                                 <id>pull-deps-contrib-exts</id>

--- a/distribution/pom.xml
+++ b/distribution/pom.xml
@@ -656,9 +656,7 @@
                                         <argument>-Ddruid.extensions.loadList=[]</argument>
                                         <argument>-Ddruid.extensions.directory=${project.build.directory}/extensions
                                         </argument>
-                                        <argument>
-                                            -Ddruid.extensions.hadoopDependenciesDir=${project.build.directory}/hadoop-dependencies
-                                        </argument>
+                                        <argument>--no-default-hadoop</argument>
                                         <argument>org.apache.druid.cli.Main</argument>
                                         <argument>tools</argument>
                                         <argument>pull-deps</argument>

--- a/distribution/pom.xml
+++ b/distribution/pom.xml
@@ -444,6 +444,8 @@
                                         <argument>-c</argument>
                                         <argument>org.apache.druid.extensions.contrib:druid-tdigestsketch</argument>
                                         <argument>-c</argument>
+                                        <argument>org.apache.druid.extensions.contrib:druid-ddsketch</argument>
+                                        <argument>-c</argument>
                                         <argument>org.apache.druid.extensions.contrib:gce-extensions</argument>
                                         <argument>-c</argument>
                                         <argument>org.apache.druid.extensions.contrib:aliyun-oss-extensions</argument>
@@ -684,6 +686,8 @@
                                         <argument>org.apache.druid.extensions:simple-client-sslcontext</argument>
                                         <argument>-c</argument>
                                         <argument>org.apache.druid.extensions:druid-basic-security</argument>
+                                        <argument>-c</argument>
+                                        <argument>org.apache.druid.extensions:druid-pac4j</argument>
                                         <argument>-c</argument>
                                         <argument>org.apache.druid.extensions:druid-kubernetes-extensions</argument>
                                         <argument>-c</argument>

--- a/distribution/pom.xml
+++ b/distribution/pom.xml
@@ -452,6 +452,12 @@
                                         <argument>-c</argument>
                                         <argument>org.apache.druid.extensions.contrib:druid-iceberg-extensions</argument>
                                         <argument>-c</argument>
+                                        <argument>org.apache.druid.extensions.contrib:druid-deltalake-extensions</argument>
+                                        <argument>-c</argument>
+                                        <argument>org.apache.druid.extensions.contrib:druid-spectator-histogram</argument>
+                                        <argument>-c</argument>
+                                        <argument>org.apache.druid.extensions.contrib:druid-rabbit-indexing-service</argument>
+                                        <argument>-c</argument>
                                         <argument>org.apache.druid.extensions.contrib:druid-opencensus-extensions</argument>
                                         <argument>-c</argument>
                                         <argument>io.confluent.druid.extensions:confluent-extensions</argument>

--- a/distribution/pom.xml
+++ b/distribution/pom.xml
@@ -444,8 +444,6 @@
                                         <argument>-c</argument>
                                         <argument>org.apache.druid.extensions.contrib:druid-tdigestsketch</argument>
                                         <argument>-c</argument>
-                                        <argument>org.apache.druid.extensions.contrib:druid-ddsketch</argument>
-                                        <argument>-c</argument>
                                         <argument>org.apache.druid.extensions.contrib:gce-extensions</argument>
                                         <argument>-c</argument>
                                         <argument>org.apache.druid.extensions.contrib:aliyun-oss-extensions</argument>
@@ -453,12 +451,6 @@
                                         <argument>org.apache.druid.extensions.contrib:opentelemetry-emitter</argument>
                                         <argument>-c</argument>
                                         <argument>org.apache.druid.extensions.contrib:druid-iceberg-extensions</argument>
-                                        <argument>-c</argument>
-                                        <argument>org.apache.druid.extensions.contrib:druid-deltalake-extensions</argument>
-                                        <argument>-c</argument>
-                                        <argument>org.apache.druid.extensions.contrib:druid-spectator-histogram</argument>
-                                        <argument>-c</argument>
-                                        <argument>org.apache.druid.extensions.contrib:druid-rabbit-indexing-service</argument>
                                         <argument>-c</argument>
                                         <argument>org.apache.druid.extensions.contrib:druid-opencensus-extensions</argument>
                                         <argument>-c</argument>
@@ -656,7 +648,7 @@
                                         <argument>-Ddruid.extensions.loadList=[]</argument>
                                         <argument>-Ddruid.extensions.directory=${project.build.directory}/extensions
                                         </argument>
-                                        <argument>--no-default-hadoop</argument>
+                                        <argument>-Ddruid.extensions.hadoopDependenciesDir=${project.build.directory}/hadoop-dependencies</argument>
                                         <argument>org.apache.druid.cli.Main</argument>
                                         <argument>tools</argument>
                                         <argument>pull-deps</argument>
@@ -665,8 +657,7 @@
                                         <argument>${project.parent.version}</argument>
                                         <argument>-l</argument>
                                         <argument>${settings.localRepository}</argument>
-                                        <argument>-h</argument>
-                                        <argument>org.apache.hadoop:hadoop-client:${hadoop.compile.version}</argument>
+                                        <argument>--no-default-hadoop</argument>
                                         <argument>-c</argument>
                                         <argument>org.apache.druid.extensions:druid-datasketches</argument>
                                         <argument>-c</argument>
@@ -687,8 +678,6 @@
                                         <argument>org.apache.druid.extensions:simple-client-sslcontext</argument>
                                         <argument>-c</argument>
                                         <argument>org.apache.druid.extensions:druid-basic-security</argument>
-                                        <argument>-c</argument>
-                                        <argument>org.apache.druid.extensions:druid-pac4j</argument>
                                         <argument>-c</argument>
                                         <argument>org.apache.druid.extensions:druid-kubernetes-extensions</argument>
                                         <argument>-c</argument>


### PR DESCRIPTION
### Description

Druid build times in `confluentinc/cc-druid` for `Build And Test For Commercial` had regressed to 75mins. Most of this was spent in building the distribution module which took around 48mins.

Logs : `[INFO] distribution ....................................... SUCCESS [48:39 min]`

Updates :

- Explicitly use [exec-maven-plugin >3.1.0](https://mvnrepository.com/artifact/org.codehaus.mojo/exec-maven-plugin) (earlier build versions used 1.6.0)
- Pass the flag `--no-default-hadoop` which doesn't pull down the default hadoop version. This is tested earlier in Druid-28 clusters.

The build time for distribution is down to 2mins.

Logs : `[INFO] distribution ....................................... SUCCESS [01:39 min]`
Test semaphore job-id : https://semaphore.ci.confluent.io/jobs/5abbb9d6-a6a6-4ebf-9e39-4ac2b3fa5cf7

Total build time for `Build And Test For Commercial` is down to 23mins.

This PR has:

- [x] been self-reviewed.
   - [ ] using the [concurrency checklist](https://github.com/apache/druid/blob/master/dev/code-review/concurrency.md) (Remove this item if the PR doesn't have any relation to concurrency.)
- [ ] added documentation for new or modified features or behaviors.
- [ ] a release note entry in the PR description.
- [ ] added Javadocs for most classes and all non-trivial methods. Linked related entities via Javadoc links.
- [ ] added or updated version, license, or notice information in [licenses.yaml](https://github.com/apache/druid/blob/master/dev/license.md)
- [ ] added comments explaining the "why" and the intent of the code wherever would not be obvious for an unfamiliar reader.
- [ ] added unit tests or modified existing tests to cover new code paths, ensuring the threshold for [code coverage](https://github.com/apache/druid/blob/master/dev/code-review/code-coverage.md) is met.
- [ ] added integration tests.
- [ ] been tested in a test Druid cluster.
