### PR TITLE
[Druid-25] OBSDATA-10784: Fix cc-druid distribution module build-time

### DIFF
--- a/distribution/pom.xml
+++ b/distribution/pom.xml
@@ -198,8 +198,7 @@
                                         <argument>${project.parent.version}</argument>
                                         <argument>-l</argument>
                                         <argument>${settings.localRepository}</argument>
-                                        <argument>-h</argument>
-                                        <argument>org.apache.hadoop:hadoop-client:${hadoop.compile.version}</argument>
+                                        <argument>--no-default-hadoop</argument>
                                         <argument>-c</argument>
                                         <argument>org.apache.druid.extensions:druid-avro-extensions</argument>
                                         <argument>-c</argument>
@@ -839,8 +838,7 @@
                                         <argument>${project.parent.version}</argument>
                                         <argument>-l</argument>
                                         <argument>${settings.localRepository}</argument>
-                                        <argument>-h</argument>
-                                        <argument>org.apache.hadoop:hadoop-client:${hadoop.compile.version}</argument>
+                                        <argument>--no-default-hadoop</argument>
                                         <argument>-c</argument>
                                         <argument>org.apache.druid.extensions:druid-datasketches</argument>
                                         <argument>-c</argument>

--- a/distribution/pom.xml
+++ b/distribution/pom.xml
@@ -682,7 +682,8 @@
                                         <argument>${project.parent.version}</argument>
                                         <argument>-l</argument>
                                         <argument>${settings.localRepository}</argument>
-                                        <argument>--no-default-hadoop</argument>
+                                        <argument>-h</argument>
+                                        <argument>org.apache.hadoop:hadoop-client:${hadoop.compile.version}</argument>
                                         <argument>-c</argument>
                                         <argument>org.apache.druid.extensions:druid-avro-extensions</argument>
                                         <argument>-c</argument>

--- a/distribution/pom.xml
+++ b/distribution/pom.xml
@@ -555,6 +555,7 @@
                     <plugin>
                         <groupId>org.codehaus.mojo</groupId>
                         <artifactId>exec-maven-plugin</artifactId>
+                        <version>3.1.0</version>
                         <executions>
                             <execution>
                                 <id>pull-deps-contrib-exts</id>
@@ -657,6 +658,7 @@
                     <plugin>
                         <groupId>org.codehaus.mojo</groupId>
                         <artifactId>exec-maven-plugin</artifactId>
+                        <version>3.1.0</version>
                         <executions>
                             <execution>
                                 <id>pull-deps</id>
@@ -672,9 +674,7 @@
                                         <argument>-Ddruid.extensions.loadList=[]</argument>
                                         <argument>-Ddruid.extensions.directory=${project.build.directory}/extensions
                                         </argument>
-                                        <argument>
-                                            -Ddruid.extensions.hadoopDependenciesDir=${project.build.directory}/hadoop-dependencies
-                                        </argument>
+                                        <argument>-Ddruid.extensions.hadoopDependenciesDir=${project.build.directory}/hadoop-dependencies</argument>
                                         <argument>org.apache.druid.cli.Main</argument>
                                         <argument>tools</argument>
                                         <argument>pull-deps</argument>
@@ -683,8 +683,7 @@
                                         <argument>${project.parent.version}</argument>
                                         <argument>-l</argument>
                                         <argument>${settings.localRepository}</argument>
-                                        <argument>-h</argument>
-                                        <argument>org.apache.hadoop:hadoop-client:${hadoop.compile.version}</argument>
+                                        <argument>--no-default-hadoop</argument>
                                         <argument>-c</argument>
                                         <argument>org.apache.druid.extensions:druid-avro-extensions</argument>
                                         <argument>-c</argument>
@@ -915,6 +914,7 @@
                     <plugin>
                         <groupId>org.codehaus.mojo</groupId>
                         <artifactId>exec-maven-plugin</artifactId>
+                        <version>3.1.0</version>
                         <executions>
                             <execution>
                                 <id>pull-deps-contrib-exts</id>


### PR DESCRIPTION
### Description

Druid build times in `confluentinc/cc-druid` for `Build And Test For Commercial` had regressed to 62mins for `druid-v25.01` branch. Most of this was spent in building the distribution module which took around 40mins.

Logs : `[INFO] distribution ....................................... SUCCESS [39:52 min]`

Updates :

Explicitly use [exec-maven-plugin >3.1.0](https://mvnrepository.com/artifact/org.codehaus.mojo/exec-maven-plugin) (earlier build versions used 1.6.0)
Pass the flag --no-default-hadoop which doesn't pull down the default hadoop version. This is tested earlier in Druid-28 clusters.
The build time for distribution is down to 6mins.

Logs : `[INFO] distribution ....................................... SUCCESS [05:39 min]`
Test semaphore job-id : https://semaphore.ci.confluent.io/jobs/c9a4c756-1858-44c2-b149-ec799363af52

Total build time for Build And Test For Commercial is down to 27mins.

This PR has:

- [x] been self-reviewed.
   - [ ] using the [concurrency checklist](https://github.com/apache/druid/blob/master/dev/code-review/concurrency.md) (Remove this item if the PR doesn't have any relation to concurrency.)
- [ ] added documentation for new or modified features or behaviors.
- [ ] a release note entry in the PR description.
- [ ] added Javadocs for most classes and all non-trivial methods. Linked related entities via Javadoc links.
- [ ] added or updated version, license, or notice information in [licenses.yaml](https://github.com/apache/druid/blob/master/dev/license.md)
- [ ] added comments explaining the "why" and the intent of the code wherever would not be obvious for an unfamiliar reader.
- [ ] added unit tests or modified existing tests to cover new code paths, ensuring the threshold for [code coverage](https://github.com/apache/druid/blob/master/dev/code-review/code-coverage.md) is met.
- [ ] added integration tests.
- [ ] been tested in a test Druid cluster.
