### PR TITLE
OBSDATA-11108 Upgrade jackson core to resolve CVEs

### DIFF
--- a/extensions-contrib/aliyun-oss-extensions/pom.xml
+++ b/extensions-contrib/aliyun-oss-extensions/pom.xml
@@ -43,6 +43,12 @@
             <groupId>com.aliyun.oss</groupId>
             <artifactId>aliyun-sdk-oss</artifactId>
             <version>3.11.3</version>
+            <exclusions>
+                <exclusion>
+                    <groupId>javax.xml.bind</groupId>
+                    <artifactId>jaxb-api</artifactId>
+                </exclusion>
+            </exclusions>
         </dependency>
         
         <dependency>

--- a/extensions-contrib/druid-deltalake-extensions/pom.xml
+++ b/extensions-contrib/druid-deltalake-extensions/pom.xml
@@ -95,7 +95,7 @@
     <dependency>
       <groupId>com.fasterxml.jackson.core</groupId>
       <artifactId>jackson-databind</artifactId>
-      <version>2.12.7.1</version>
+      <version>${jackson.version}</version>
     </dependency>
     <dependency>
       <groupId>it.unimi.dsi</groupId>

--- a/extensions-contrib/kubernetes-overlord-extensions/pom.xml
+++ b/extensions-contrib/kubernetes-overlord-extensions/pom.xml
@@ -33,19 +33,6 @@
     <relativePath>../../pom.xml</relativePath>
   </parent>
 
-  <dependencyManagement>
-      <dependencies>
-            <!-- snakeyaml explicitly pinned to version 1.33 as it is
-             a transitive dependency of com.fasterxml.jackson.dataformat:jackson-dataformat-yaml 2.12.7
-             please remove this pin, after updating jackson-dataform-yaml to version > 2.14.3  / 2.15.0 -->
-          <dependency>
-              <groupId>org.yaml</groupId>
-              <artifactId>snakeyaml</artifactId>
-              <version>1.33</version>
-          </dependency>
-      </dependencies>
-  </dependencyManagement>
-
   <dependencies>
     <dependency>
       <groupId>org.apache.druid</groupId>

--- a/integration-tests/pom.xml
+++ b/integration-tests/pom.xml
@@ -43,19 +43,6 @@
         <hadoop.s3.impl>org.apache.hadoop.fs.s3a.S3AFileSystem</hadoop.s3.impl>
     </properties>
 
-    <dependencyManagement>
-        <dependencies>
-             <!-- snakeyaml explicitly pinned to version 1.33 as it is
-             a transitive dependency of com.fasterxml.jackson.dataformat:jackson-dataformat-yaml 2.12.7
-             please remove this pin, after updating jackson-dataform-yaml to version > 2.14.3  / 2.15.0 -->
-            <dependency>
-                <groupId>org.yaml</groupId>
-                <artifactId>snakeyaml</artifactId>
-                <version>1.33</version>
-            </dependency>
-        </dependencies>
-    </dependencyManagement>
-
     <dependencies>
         <dependency>
             <groupId>com.amazonaws</groupId>

--- a/licenses.yaml
+++ b/licenses.yaml
@@ -223,10 +223,34 @@ name: Jackson
 license_category: binary
 module: java-core
 license_name: Apache License version 2.0
-version: 2.12.7
+version: 2.18.4.1
+libraries:
+  - com.fasterxml.jackson.core: jackson-core
+notice: |
+# Jackson JSON processor
+Jackson is a high-performance, Free/Open Source JSON processing library.
+It was originally written by Tatu Saloranta (tatu.saloranta@iki.fi), and has
+been in development since 2007.
+It is currently developed by a community of developers, as well as supported
+commercially by FasterXML.com.
+## Licensing
+Jackson core and extension components may licensed under different licenses.
+To find the details that apply to this artifact see the accompanying LICENSE file.
+For more information, including possible other licensing options, contact
+FasterXML.com (http://fasterxml.com).
+## Credits
+A list of contributors may be found from CREDITS file, which is included
+in some artifacts (usually source distributions); but is always available
+from the source code management (SCM) system project uses.
+---
+
+name: Jackson
+license_category: binary
+module: java-core
+license_name: Apache License version 2.0
+version: 2.18.4
 libraries:
   - com.fasterxml.jackson.core: jackson-annotations
-  - com.fasterxml.jackson.core: jackson-core
   - com.fasterxml.jackson.dataformat: jackson-dataformat-cbor
   - com.fasterxml.jackson.dataformat: jackson-dataformat-smile
   - com.fasterxml.jackson.dataformat: jackson-dataformat-xml
@@ -264,9 +288,9 @@ notice: |
 
 name: Jackson
 license_category: binary
-module: java-core
+module: extensions-contrib/druid-deltalake-extensions
 license_name: Apache License version 2.0
-version: 2.12.7.1
+version: 2.18.4
 libraries:
   - com.fasterxml.jackson.core: jackson-databind
 notice: |
@@ -2793,7 +2817,7 @@ libraries:
 ---
 
 name: Jackson Dataformat Yaml
-version: 2.12.7
+version: 2.18.4
 license_category: binary
 module: extensions/druid-avro-extensions
 license_name: Apache License version 2.0

--- a/pom.xml
+++ b/pom.xml
@@ -101,7 +101,8 @@
         <hamcrest.version>1.3</hamcrest.version>
         <jetty.version>9.4.57.v20241219</jetty.version>
         <jersey.version>1.19.4</jersey.version>
-        <jackson.version>2.12.7.20221012</jackson.version>
+        <jackson.core.version>2.18.4.1</jackson.core.version>
+        <jackson.version>2.18.4</jackson.version>
         <codehaus.jackson.version>1.9.13</codehaus.jackson.version>
         <log4j.version>2.22.1</log4j.version>
         <mysql.version>8.2.0</mysql.version>
@@ -606,7 +607,7 @@
             <dependency>
                 <groupId>com.fasterxml.jackson</groupId>
                 <artifactId>jackson-bom</artifactId>
-                <version>${jackson.version}</version>
+                <version>${jackson.core.version}</version>
                 <scope>import</scope>
                 <type>pom</type>
             </dependency>
@@ -1364,6 +1365,28 @@
               </exclusion>
             </exclusions>
           </dependency>
+          <dependency>
+                <groupId>com.fasterxml.jackson.jaxrs</groupId>
+                <artifactId>jackson-jaxrs-json-provider</artifactId>
+                <version>${jackson.version}</version>
+                <exclusions>
+                    <exclusion>
+                        <groupId>javax.xml.bind</groupId>
+                        <artifactId>jaxb-api</artifactId>
+                    </exclusion>
+                </exclusions>
+            </dependency>
+            <dependency>
+                <groupId>com.fasterxml.jackson.jaxrs</groupId>
+                <artifactId>jackson-jaxrs-smile-provider</artifactId>
+                <version>${jackson.version}</version>
+                <exclusions>
+                    <exclusion>
+                        <groupId>javax.xml.bind</groupId>
+                        <artifactId>jaxb-api</artifactId>
+                    </exclusion>
+                </exclusions>
+            </dependency>
             <dependency>
                 <groupId>io.opentelemetry.proto</groupId>
                 <artifactId>opentelemetry-proto</artifactId>
@@ -1641,6 +1664,8 @@
                                     <excludes>
                                         <!--LGPL licenced library-->
                                         <exclude>com.google.code.findbugs:annotations</exclude>
+                                        <!-- See https://github.com/apache/druid/pull/17370 -->
+                                        <exclude>javax.xml.bind:jaxb-api</exclude>
                                     </excludes>
                                 </bannedDependencies>
                             </rules>

--- a/processing/src/main/java/org/apache/druid/jackson/JodaStuff.java
+++ b/processing/src/main/java/org/apache/druid/jackson/JodaStuff.java
@@ -117,7 +117,8 @@ class JodaStuff
         // make sure to preserve time zone information when parsing timestamps
         return DateTimes.ISO_DATE_OR_TIME_WITH_OFFSET.parse(str);
       }
-      throw ctxt.mappingException(getValueClass());
+      ctxt.reportWrongTokenException(handledType(), JsonToken.VALUE_NUMBER_INT, "expected int or string token");
+      return null; // unreachable ... required for compiler, but ctxt.reportWrongTokenException always throws
     }
   }
 }

--- a/server/src/test/java/org/apache/druid/server/QuerySchedulerTest.java
+++ b/server/src/test/java/org/apache/druid/server/QuerySchedulerTest.java
@@ -497,7 +497,7 @@ public class QuerySchedulerTest
         "Unable to provision, see the following errors:\n"
         + "\n"
         + "1) Problem parsing object at prefix[druid.query.scheduler]: Cannot construct instance of `org.apache.druid.server.scheduling.HiLoQueryLaningStrategy`, problem: maxLowPercent must be set\n"
-        + " at [Source: UNKNOWN; line: -1, column: -1] (through reference chain: org.apache.druid.server.QuerySchedulerProvider[\"laning\"]).\n"
+        + " at [Source: UNKNOWN; byte offset: #UNKNOWN] (through reference chain: org.apache.druid.server.QuerySchedulerProvider[\"laning\"]).\n"
         + "\n"
         + "1 error",
         t.getMessage()
@@ -554,7 +554,7 @@ public class QuerySchedulerTest
         "Unable to provision, see the following errors:\n"
         + "\n"
         + "1) Problem parsing object at prefix[druid.query.scheduler]: Cannot construct instance of `org.apache.druid.server.scheduling.ThresholdBasedQueryPrioritizationStrategy`, problem: periodThreshold, durationThreshold, or segmentCountThreshold must be set\n"
-        + " at [Source: UNKNOWN; line: -1, column: -1] (through reference chain: org.apache.druid.server.QuerySchedulerProvider[\"prioritization\"]).\n"
+        + " at [Source: UNKNOWN; byte offset: #UNKNOWN] (through reference chain: org.apache.druid.server.QuerySchedulerProvider[\"prioritization\"]).\n"
         + "\n"
         + "1 error",
         t.getMessage()


### PR DESCRIPTION
Fixes OBSDATA-11108.

This PR has:

- [x] been self-reviewed.
   - [ ] using the [concurrency checklist](https://github.com/apache/druid/blob/master/dev/code-review/concurrency.md) (Remove this item if the PR doesn't have any relation to concurrency.)
- [ ] added documentation for new or modified features or behaviors.
- [ ] a release note entry in the PR description.
- [ ] added Javadocs for most classes and all non-trivial methods. Linked related entities via Javadoc links.
- [x] added or updated version, license, or notice information in [licenses.yaml](https://github.com/apache/druid/blob/master/dev/license.md)
- [ ] added comments explaining the "why" and the intent of the code wherever would not be obvious for an unfamiliar reader.
- [ ] added unit tests or modified existing tests to cover new code paths, ensuring the threshold for [code coverage](https://github.com/apache/druid/blob/master/dev/code-review/code-coverage.md) is met.
- [ ] added integration tests.
- [ ] been tested in a test Druid cluster.
