### PR TITLE
Fix licenses.yaml

### DIFF
--- a/licenses.yaml
+++ b/licenses.yaml
@@ -227,21 +227,21 @@ version: 2.18.4.1
 libraries:
   - com.fasterxml.jackson.core: jackson-core
 notice: |
-# Jackson JSON processor
-Jackson is a high-performance, Free/Open Source JSON processing library.
-It was originally written by Tatu Saloranta (tatu.saloranta@iki.fi), and has
-been in development since 2007.
-It is currently developed by a community of developers, as well as supported
-commercially by FasterXML.com.
-## Licensing
-Jackson core and extension components may licensed under different licenses.
-To find the details that apply to this artifact see the accompanying LICENSE file.
-For more information, including possible other licensing options, contact
-FasterXML.com (http://fasterxml.com).
-## Credits
-A list of contributors may be found from CREDITS file, which is included
-in some artifacts (usually source distributions); but is always available
-from the source code management (SCM) system project uses.
+  # Jackson JSON processor
+  Jackson is a high-performance, Free/Open Source JSON processing library.
+  It was originally written by Tatu Saloranta (tatu.saloranta@iki.fi), and has
+  been in development since 2007.
+  It is currently developed by a community of developers, as well as supported
+  commercially by FasterXML.com.
+  ## Licensing
+  Jackson core and extension components may licensed under different licenses.
+  To find the details that apply to this artifact see the accompanying LICENSE file.
+  For more information, including possible other licensing options, contact
+  FasterXML.com (http://fasterxml.com).
+  ## Credits
+  A list of contributors may be found from CREDITS file, which is included
+  in some artifacts (usually source distributions); but is always available
+  from the source code management (SCM) system project uses.
 ---
 
 name: Jackson


### PR DESCRIPTION
Fixes [this](https://semaphore.ci.confluent.io/jobs/871a7187-9bbc-4bf0-a75a-75c641cfcce3) cc-druid build failure.