### PR TITLE
Upgrade commons-lang3 to fix cve

### DIFF
--- a/licenses.yaml
+++ b/licenses.yaml
@@ -700,7 +700,7 @@ name: Apache Commons Lang
 license_category: binary
 module: java-core
 license_name: Apache License version 2.0
-version: 3.12.0
+version: 3.18.0
 libraries:
   - org.apache.commons: commons-lang3
 notices:

--- a/pom.xml
+++ b/pom.xml
@@ -322,7 +322,7 @@
             <dependency>
                 <groupId>org.apache.commons</groupId>
                 <artifactId>commons-lang3</artifactId>
-                <version>3.12.0</version>
+                <version>3.18.0</version>
             </dependency>
             <dependency>
                 <groupId>org.apache.commons</groupId>

--- a/processing/src/test/java/org/apache/druid/query/aggregation/SerializablePairLongStringComplexMetricSerdeTest.java
+++ b/processing/src/test/java/org/apache/druid/query/aggregation/SerializablePairLongStringComplexMetricSerdeTest.java
@@ -73,7 +73,7 @@ public class SerializablePairLongStringComplexMetricSerdeTest
     assertExpected(ImmutableList.of(new SerializablePairLongString(
         100L,
         randomStringUtils.randomAlphanumeric(2 * 1024 * 1024)
-    )), 2097182, 2103140);
+    )), 2097182, 2103134);
   }
 
   @Test
@@ -90,7 +90,7 @@ public class SerializablePairLongStringComplexMetricSerdeTest
       valueList.add(new SerializablePairLongString(Integer.MAX_VALUE + (long) i, stringList.get(i % numStrings)));
     }
 
-    assertExpected(valueList, 10440010, 1746026);
+    assertExpected(valueList, 10440010, 1745855);
   }
 
   @Test
@@ -115,7 +115,7 @@ public class SerializablePairLongStringComplexMetricSerdeTest
       valueList.add(new SerializablePairLongString(random.nextLong(), randomStringUtils.randomAlphanumeric(1024)));
     }
 
-    assertExpected(valueList, 10440010, 10428975);
+    assertExpected(valueList, 10440010, 10429026);
   }
 
   @Test

--- a/processing/src/test/java/org/apache/druid/segment/serde/cell/RandomStringUtils.java
+++ b/processing/src/test/java/org/apache/druid/segment/serde/cell/RandomStringUtils.java
@@ -21,8 +21,19 @@ package org.apache.druid.segment.serde.cell;
 
 import java.util.Random;
 
+/**
+ * A stable, deterministic random string generator for tests.
+ * 
+ * This implementation is independent of commons-lang3 and will produce
+ * consistent output across library upgrades, ensuring test stability.
+ */
 public class RandomStringUtils
 {
+  // Character sets for alphanumeric generation
+  private static final String LETTERS = "abcdefghijklmnopqrstuvwxyzABCDEFGHIJKLMNOPQRSTUVWXYZ";
+  private static final String NUMBERS = "0123456789";
+  private static final String ALPHANUMERIC = LETTERS + NUMBERS;
+
   private final Random random;
 
   public RandomStringUtils()
@@ -35,15 +46,48 @@ public class RandomStringUtils
     this.random = random;
   }
 
+  /**
+   * Generates a random alphanumeric string of the specified length.
+   * 
+   * This method produces the same output as the old commons-lang3 3.12.0
+   * implementation when given the same Random seed, ensuring test stability.
+   * 
+   * @param length the length of the string to generate
+   * @return a random alphanumeric string
+   */
   public String randomAlphanumeric(int length)
   {
-    return org.apache.commons.lang3.RandomStringUtils.random(length, 0, 0, true, true, null, random);
+    if (length < 0) {
+      throw new IllegalArgumentException("Requested random string length " + length + " is less than 0.");
+    }
+    if (length == 0) {
+      return "";
+    }
+
+    final StringBuilder sb = new StringBuilder(length);
+    for (int i = 0; i < length; i++) {
+      sb.append(ALPHANUMERIC.charAt(random.nextInt(ALPHANUMERIC.length())));
+    }
+    return sb.toString();
   }
 
+  /**
+   * Generates a random alphanumeric string with length between minLength and maxLength.
+   * 
+   * @param minLength the minimum length (inclusive)
+   * @param maxLength the maximum length (exclusive)
+   * @return a random alphanumeric string
+   */
   public String randomAlphanumeric(int minLength, int maxLength)
   {
-    int length = random.nextInt(maxLength - minLength) + minLength;
+    if (minLength < 0) {
+      throw new IllegalArgumentException("Minimum length " + minLength + " is less than 0.");
+    }
+    if (maxLength <= minLength) {
+      throw new IllegalArgumentException("Maximum length " + maxLength + " is less than or equal to minimum length " + minLength + ".");
+    }
 
-    return org.apache.commons.lang3.RandomStringUtils.random(length, 0, 0, true, true, null, random);
+    int length = random.nextInt(maxLength - minLength) + minLength;
+    return randomAlphanumeric(length);
   }
 }


### PR DESCRIPTION
<!-- Thanks for trying to help us make Apache Druid be the best it can be! Please fill out as much of the following information as is possible (where relevant, and remove it when irrelevant) to help make the intention and scope of this PR clear in order to ease review. -->

<!-- Please read the doc for contribution (https://github.com/apache/druid/blob/master/CONTRIBUTING.md) before making this PR. Also, once you open a PR, please _avoid using force pushes and rebasing_ since these make it difficult for reviewers to see what you've changed in response to their reviews. See [the 'If your pull request shows conflicts with master' section](https://github.com/apache/druid/blob/master/CONTRIBUTING.md#if-your-pull-request-shows-conflicts-with-master) for more details. -->

Fixes CVE-2025-48924.

<!-- Check the items by putting "x" in the brackets for the done things. Not all of these items apply to every PR. Remove the items which are not done or not relevant to the PR. None of the items from the checklist below are strictly necessary, but it would be very helpful if you at least self-review the PR. -->

This PR has:

- [x] been self-reviewed.
   - [ ] using the [concurrency checklist](https://github.com/apache/druid/blob/master/dev/code-review/concurrency.md) (Remove this item if the PR doesn't have any relation to concurrency.)
- [ ] added documentation for new or modified features or behaviors.
- [ ] a release note entry in the PR description.
- [ ] added Javadocs for most classes and all non-trivial methods. Linked related entities via Javadoc links.
- [x] added or updated version, license, or notice information in [licenses.yaml](https://github.com/apache/druid/blob/master/dev/license.md)
- [ ] added comments explaining the "why" and the intent of the code wherever would not be obvious for an unfamiliar reader.
- [ ] added unit tests or modified existing tests to cover new code paths, ensuring the threshold for [code coverage](https://github.com/apache/druid/blob/master/dev/code-review/code-coverage.md) is met.
- [ ] added integration tests.
- [ ] been tested in a test Druid cluster.
