### PR TITLE
OBSDATA-11037 Update truststore url for fedramp

### DIFF
--- a/distribution/docker/Dockerfile
+++ b/distribution/docker/Dockerfile
@@ -137,7 +137,7 @@ RUN mkdir -p /opt/druid/.postgresql
 
 # Download RDS root CA certificates for both commercial and us-gov regions
 RUN curl -s https://truststore.pki.rds.amazonaws.com/global/global-bundle.pem -o /opt/druid/.postgresql/root.crt && \
-    curl -s https://truststore.pki.rds.amazonaws.com/global/global-bundle-fedramp.pem -o /opt/druid/.postgresql/root-fedramp.crt && \
+    curl -s https://truststore.pki.us-gov-west-1.rds.amazonaws.com/global/global-bundle.pem -o /opt/druid/.postgresql/root-fedramp.crt && \
     chmod 644 /opt/druid/.postgresql/root.crt /opt/druid/.postgresql/root-fedramp.crt && \
     chown -R druid:druid /opt/druid/.postgresql
 


### PR DESCRIPTION
Based on https://github.com/confluentinc/druid/pull/324.

This change is needed to deploy Druid 30 to us-gov clusters.