### PR TITLE
Rename headerBasedFilterConfig config to headerBasedInclusionConfig

### DIFF
--- a/docs/ingestion/kafka-ingestion.md
+++ b/docs/ingestion/kafka-ingestion.md
@@ -125,7 +125,7 @@ For configuration properties shared across all streaming ingestion methods, refe
 |`consumerProperties`|String, Object|A map of properties to pass to the Kafka consumer. See [Consumer properties](#consumer-properties) for details.|Yes. At the minimum, you must set the `bootstrap.servers` property to establish the initial connection to the Kafka cluster.||
 |`pollTimeout`|Long|The length of time to wait for the Kafka consumer to poll records, in milliseconds.|No|100|
 |`useEarliestOffset`|Boolean|If a supervisor manages a datasource for the first time, it obtains a set of starting offsets from Kafka. This flag determines whether it retrieves the earliest or latest offsets in Kafka. Under normal circumstances, subsequent tasks start from where the previous segments ended. Druid only uses `useEarliestOffset` on the first run.|No|`false`|
-|`headerBasedFilteringConfig`|Object|Configuration for filtering Kafka records based on their headers before ingestion. See [Header-based filtering](#header-based-filtering) for more details.|No|null|
+|`headerBasedInclusionConfig`|Object|Configuration for including Kafka records based on their headers before ingestion. See [Header-based inclusion filtering](#header-based-inclusion-filtering) for more details.|No|null|
 |`idleConfig`|Object|Defines how and when the Kafka supervisor can become idle. See [Idle configuration](#idle-configuration) for more details.|No|null|
 
 #### Ingest from multiple topics
@@ -244,11 +244,11 @@ The following example shows a supervisor spec with idle configuration enabled:
 ```
 </details>
 
-#### Header-based filtering
+#### Header-based inclusion filtering
 
-Header-based filtering allows you to filter Kafka records based on their headers before ingestion, reducing the amount of data processed and improving ingestion performance. This is particularly useful when you want to ingest only a subset of records from a Kafka topic based on header values.
+Header-based inclusion filtering allows you to include only specific Kafka records based on their headers before ingestion, reducing the amount of data processed and improving ingestion performance. This is particularly useful when you want to ingest only a subset of records from a Kafka topic based on header values.
 
-The following table outlines the configuration options for `headerBasedFilteringConfig`:
+The following table outlines the configuration options for `headerBasedInclusionConfig`:
 
 |Property|Type|Description|Required|Default|
 |--------|----|-----------|--------|-------|
@@ -256,9 +256,9 @@ The following table outlines the configuration options for `headerBasedFiltering
 |`encoding`|String|The character encoding used to decode header values. Supported encodings include `UTF-8`, `UTF-16`, `ISO-8859-1`, `US-ASCII`, `UTF-16BE`, and `UTF-16LE`.|No|`UTF-8`|
 |`stringDecodingCacheSize`|Integer|The maximum number of decoded header strings to cache in memory. Set to a higher value for better performance when processing many unique header values.|No|10000|
 
-##### Header-based filtering example
+##### Header-based inclusion filtering example
 
-The following example shows how to configure header-based filtering to ingest only records where the `environment` header has the value `production` or `staging`:
+The following example shows how to configure header-based inclusion filtering to ingest only records where the `environment` header has the value `production` or `staging`:
 
 <details>
   <summary>Click to view the example</summary>
@@ -305,7 +305,7 @@ The following example shows how to configure header-based filtering to ingest on
       "consumerProperties": {
         "bootstrap.servers": "localhost:9092"
       },
-      "headerBasedFilteringConfig": {
+      "headerBasedInclusionConfig": {
         "filter": {
           "type": "in",
           "dimension": "environment",
@@ -334,14 +334,14 @@ In this example:
 
 ##### Performance considerations
 
-Header-based filtering provides several performance benefits:
+Header-based inclusion filtering provides several performance benefits:
 
 - **Reduced ingestion load**: Records are filtered before being processed by the ingestion pipeline
 - **Lower memory usage**: Filtered records don't consume memory in the ingestion process
 - **Improved throughput**: Less data to process means higher effective throughput
 - **String decoding cache**: Frequently accessed header values are cached to avoid repeated decoding
 
-Filtered events are tracked using the standard Druid ingestion metrics. The `ingest/events/filtered` metric reports the number of events rejected by header-based filtering. For more information about ingestion metrics, see [Ingestion metrics](../operations/metrics.md#other-ingestion-metrics).
+Filtered events are tracked using the standard Druid ingestion metrics. The `ingest/events/filtered` metric reports the number of events rejected by header-based inclusion filtering. For more information about ingestion metrics, see [Ingestion metrics](../operations/metrics.md#other-ingestion-metrics).
 
 #### Data format
 

--- a/extensions-core/kafka-indexing-service/src/main/java/org/apache/druid/indexing/kafka/KafkaHeaderBasedFilterEvaluator.java
+++ b/extensions-core/kafka-indexing-service/src/main/java/org/apache/druid/indexing/kafka/KafkaHeaderBasedFilterEvaluator.java
@@ -21,7 +21,7 @@ package org.apache.druid.indexing.kafka;
 
 import com.github.benmanes.caffeine.cache.Cache;
 import com.github.benmanes.caffeine.cache.Caffeine;
-import org.apache.druid.indexing.kafka.supervisor.KafkaHeaderBasedFilteringConfig;
+import org.apache.druid.indexing.kafka.supervisor.KafkaHeaderBasedInclusionConfig;
 import org.apache.druid.java.util.common.logger.Logger;
 import org.apache.druid.query.filter.Filter;
 import org.apache.druid.query.filter.InDimFilter;
@@ -45,23 +45,23 @@ public class KafkaHeaderBasedFilterEvaluator
   private final Charset encoding;
   private final Cache<ByteBuffer, String> stringDecodingCache;
 
-  public KafkaHeaderBasedFilterEvaluator(KafkaHeaderBasedFilteringConfig headerBasedFilteringConfig)
+  public KafkaHeaderBasedFilterEvaluator(KafkaHeaderBasedInclusionConfig headerBasedInclusionConfig)
   {
-    this.encoding = Charset.forName(headerBasedFilteringConfig.getEncoding());
+    this.encoding = Charset.forName(headerBasedInclusionConfig.getEncoding());
     this.stringDecodingCache = Caffeine.newBuilder()
-        .maximumSize(headerBasedFilteringConfig.getStringDecodingCacheSize())
+        .maximumSize(headerBasedInclusionConfig.getStringDecodingCacheSize())
         .build();
 
-    this.filter = headerBasedFilteringConfig.getFilter().toFilter();
+    this.filter = headerBasedInclusionConfig.getFilter().toFilter();
     if (!(filter instanceof InDimFilter)) {
       // Only InDimFilter supported
       throw new IllegalStateException("Unsupported filter type: " + filter.getClass().getSimpleName());
     }
 
     log.info("Initialized Kafka header filter with encoding [%s] - direct evaluation for [%s] with Caffeine string cache (max %d entries)",
-             headerBasedFilteringConfig.getEncoding(),
+             headerBasedInclusionConfig.getEncoding(),
              this.filter.getClass().getSimpleName(),
-             headerBasedFilteringConfig.getStringDecodingCacheSize());
+             headerBasedInclusionConfig.getStringDecodingCacheSize());
   }
 
 

--- a/extensions-core/kafka-indexing-service/src/main/java/org/apache/druid/indexing/kafka/KafkaIndexTask.java
+++ b/extensions-core/kafka-indexing-service/src/main/java/org/apache/druid/indexing/kafka/KafkaIndexTask.java
@@ -116,7 +116,7 @@ public class KafkaIndexTask extends SeekableStreamIndexTask<KafkaTopicPartition,
               configMapper,
               kafkaIndexTaskIOConfig.getConfigOverrides(),
               kafkaIndexTaskIOConfig.isMultiTopic(),
-              kafkaIndexTaskIOConfig.getHeaderBasedFilteringConfig()
+              kafkaIndexTaskIOConfig.getheaderBasedInclusionConfig()
           );
 
       if (toolbox.getMonitorScheduler() != null) {

--- a/extensions-core/kafka-indexing-service/src/main/java/org/apache/druid/indexing/kafka/KafkaIndexTaskIOConfig.java
+++ b/extensions-core/kafka-indexing-service/src/main/java/org/apache/druid/indexing/kafka/KafkaIndexTaskIOConfig.java
@@ -24,7 +24,7 @@ import com.fasterxml.jackson.annotation.JsonProperty;
 import com.google.common.base.Preconditions;
 import org.apache.druid.data.input.InputFormat;
 import org.apache.druid.data.input.kafka.KafkaTopicPartition;
-import org.apache.druid.indexing.kafka.supervisor.KafkaHeaderBasedFilteringConfig;
+import org.apache.druid.indexing.kafka.supervisor.KafkaHeaderBasedInclusionConfig;
 import org.apache.druid.indexing.kafka.supervisor.KafkaSupervisorIOConfig;
 import org.apache.druid.indexing.seekablestream.SeekableStreamEndSequenceNumbers;
 import org.apache.druid.indexing.seekablestream.SeekableStreamIndexTaskIOConfig;
@@ -41,7 +41,7 @@ public class KafkaIndexTaskIOConfig extends SeekableStreamIndexTaskIOConfig<Kafk
   private final Map<String, Object> consumerProperties;
   private final long pollTimeout;
   private final KafkaConfigOverrides configOverrides;
-  private final KafkaHeaderBasedFilteringConfig headerBasedFilteringConfig;
+  private final KafkaHeaderBasedInclusionConfig headerBasedInclusionConfig;
 
   private final boolean multiTopic;
 
@@ -66,7 +66,7 @@ public class KafkaIndexTaskIOConfig extends SeekableStreamIndexTaskIOConfig<Kafk
       @JsonProperty("maximumMessageTime") DateTime maximumMessageTime,
       @JsonProperty("inputFormat") @Nullable InputFormat inputFormat,
       @JsonProperty("configOverrides") @Nullable KafkaConfigOverrides configOverrides,
-      @JsonProperty("headerBasedFilteringConfig") @Nullable KafkaHeaderBasedFilteringConfig headerBasedFilteringConfig,
+      @JsonProperty("headerBasedInclusionConfig") @Nullable KafkaHeaderBasedInclusionConfig headerBasedInclusionConfig,
       @JsonProperty("multiTopic") @Nullable Boolean multiTopic
   )
   {
@@ -86,7 +86,7 @@ public class KafkaIndexTaskIOConfig extends SeekableStreamIndexTaskIOConfig<Kafk
     this.consumerProperties = Preconditions.checkNotNull(consumerProperties, "consumerProperties");
     this.pollTimeout = pollTimeout != null ? pollTimeout : KafkaSupervisorIOConfig.DEFAULT_POLL_TIMEOUT_MILLIS;
     this.configOverrides = configOverrides;
-    this.headerBasedFilteringConfig = headerBasedFilteringConfig;
+    this.headerBasedInclusionConfig = headerBasedInclusionConfig;
     this.multiTopic = multiTopic != null ? multiTopic : KafkaSupervisorIOConfig.DEFAULT_IS_MULTI_TOPIC;
 
     final SeekableStreamEndSequenceNumbers<KafkaTopicPartition, Long> myEndSequenceNumbers = getEndSequenceNumbers();
@@ -113,7 +113,7 @@ public class KafkaIndexTaskIOConfig extends SeekableStreamIndexTaskIOConfig<Kafk
       DateTime maximumMessageTime,
       InputFormat inputFormat,
       KafkaConfigOverrides configOverrides,
-      KafkaHeaderBasedFilteringConfig headerBasedFilteringConfig
+      KafkaHeaderBasedInclusionConfig headerBasedInclusionConfig
   )
   {
     this(
@@ -130,7 +130,7 @@ public class KafkaIndexTaskIOConfig extends SeekableStreamIndexTaskIOConfig<Kafk
         maximumMessageTime,
         inputFormat,
         configOverrides,
-        headerBasedFilteringConfig,
+        headerBasedInclusionConfig,
         KafkaSupervisorIOConfig.DEFAULT_IS_MULTI_TOPIC
     );
   }
@@ -190,9 +190,9 @@ public class KafkaIndexTaskIOConfig extends SeekableStreamIndexTaskIOConfig<Kafk
 
   @JsonProperty
   @Nullable
-  public KafkaHeaderBasedFilteringConfig getHeaderBasedFilteringConfig()
+  public KafkaHeaderBasedInclusionConfig getheaderBasedInclusionConfig()
   {
-    return headerBasedFilteringConfig;
+    return headerBasedInclusionConfig;
   }
 
   @Override
@@ -209,7 +209,7 @@ public class KafkaIndexTaskIOConfig extends SeekableStreamIndexTaskIOConfig<Kafk
            ", minimumMessageTime=" + getMinimumMessageTime() +
            ", maximumMessageTime=" + getMaximumMessageTime() +
            ", configOverrides=" + getConfigOverrides() +
-           ", headerBasedFilteringConfig=" + getHeaderBasedFilteringConfig() +
+           ", headerBasedInclusionConfig=" + getheaderBasedInclusionConfig() +
            ", multiTopic=" + multiTopic +
            '}';
   }

--- a/extensions-core/kafka-indexing-service/src/main/java/org/apache/druid/indexing/kafka/KafkaIndexTaskModule.java
+++ b/extensions-core/kafka-indexing-service/src/main/java/org/apache/druid/indexing/kafka/KafkaIndexTaskModule.java
@@ -26,7 +26,7 @@ import com.google.common.collect.ImmutableList;
 import com.google.inject.Binder;
 import org.apache.druid.data.input.kafka.KafkaTopicPartition;
 import org.apache.druid.data.input.kafkainput.KafkaInputFormat;
-import org.apache.druid.indexing.kafka.supervisor.KafkaHeaderBasedFilteringConfig;
+import org.apache.druid.indexing.kafka.supervisor.KafkaHeaderBasedInclusionConfig;
 import org.apache.druid.indexing.kafka.supervisor.KafkaSupervisorSpec;
 import org.apache.druid.indexing.kafka.supervisor.KafkaSupervisorTuningConfig;
 import org.apache.druid.initialization.DruidModule;
@@ -53,7 +53,7 @@ public class KafkaIndexTaskModule implements DruidModule
                 new NamedType(KafkaSupervisorSpec.class, SCHEME),
                 new NamedType(KafkaSamplerSpec.class, SCHEME),
                 new NamedType(KafkaInputFormat.class, SCHEME),
-                new NamedType(KafkaHeaderBasedFilteringConfig.class, SCHEME)
+                new NamedType(KafkaHeaderBasedInclusionConfig.class, SCHEME)
             )
             .addKeySerializer(KafkaTopicPartition.class, new KafkaTopicPartition.KafkaTopicPartitionKeySerializer())
     );

--- a/extensions-core/kafka-indexing-service/src/main/java/org/apache/druid/indexing/kafka/KafkaRecordSupplier.java
+++ b/extensions-core/kafka-indexing-service/src/main/java/org/apache/druid/indexing/kafka/KafkaRecordSupplier.java
@@ -27,7 +27,7 @@ import org.apache.druid.data.input.kafka.KafkaRecordEntity;
 import org.apache.druid.data.input.kafka.KafkaTopicPartition;
 import org.apache.druid.error.DruidException;
 import org.apache.druid.error.InvalidInput;
-import org.apache.druid.indexing.kafka.supervisor.KafkaHeaderBasedFilteringConfig;
+import org.apache.druid.indexing.kafka.supervisor.KafkaHeaderBasedInclusionConfig;
 import org.apache.druid.indexing.kafka.supervisor.KafkaSupervisorIOConfig;
 import org.apache.druid.indexing.seekablestream.common.OrderedPartitionableRecord;
 import org.apache.druid.indexing.seekablestream.common.OrderedSequenceNumber;
@@ -87,7 +87,7 @@ public class KafkaRecordSupplier implements RecordSupplier<KafkaTopicPartition, 
       boolean multiTopic
   )
   {
-    this(getKafkaConsumer(sortingMapper, consumerProperties, configOverrides), multiTopic, (KafkaHeaderBasedFilteringConfig) null);
+    this(getKafkaConsumer(sortingMapper, consumerProperties, configOverrides), multiTopic, (KafkaHeaderBasedInclusionConfig) null);
   }
 
   public KafkaRecordSupplier(
@@ -95,30 +95,30 @@ public class KafkaRecordSupplier implements RecordSupplier<KafkaTopicPartition, 
       ObjectMapper sortingMapper,
       KafkaConfigOverrides configOverrides,
       boolean multiTopic,
-      @Nullable KafkaHeaderBasedFilteringConfig headerBasedFilteringConfig
+      @Nullable KafkaHeaderBasedInclusionConfig headerBasedInclusionConfig
   )
   {
-    this(getKafkaConsumer(sortingMapper, consumerProperties, configOverrides), multiTopic, headerBasedFilteringConfig);
+    this(getKafkaConsumer(sortingMapper, consumerProperties, configOverrides), multiTopic, headerBasedInclusionConfig);
   }
 
   @VisibleForTesting
   public KafkaRecordSupplier(KafkaConsumer<byte[], byte[]> consumer, boolean multiTopic)
   {
-    this(consumer, multiTopic, (KafkaHeaderBasedFilteringConfig) null);
+    this(consumer, multiTopic, (KafkaHeaderBasedInclusionConfig) null);
   }
 
   @VisibleForTesting
   public KafkaRecordSupplier(
       KafkaConsumer<byte[], byte[]> consumer,
       boolean multiTopic,
-      @Nullable KafkaHeaderBasedFilteringConfig headerBasedFilteringConfig
+      @Nullable KafkaHeaderBasedInclusionConfig headerBasedInclusionConfig
   )
   {
     this.consumer = consumer;
     this.multiTopic = multiTopic;
     this.monitor = new KafkaConsumerMonitor(consumer);
-    this.headerFilterEvaluator = headerBasedFilteringConfig != null ?
-        new KafkaHeaderBasedFilterEvaluator(headerBasedFilteringConfig) : null;
+    this.headerFilterEvaluator = headerBasedInclusionConfig != null ?
+        new KafkaHeaderBasedFilterEvaluator(headerBasedInclusionConfig) : null;
   }
 
   @Override

--- a/extensions-core/kafka-indexing-service/src/main/java/org/apache/druid/indexing/kafka/supervisor/KafkaHeaderBasedInclusionConfig.java
+++ b/extensions-core/kafka-indexing-service/src/main/java/org/apache/druid/indexing/kafka/supervisor/KafkaHeaderBasedInclusionConfig.java
@@ -36,7 +36,7 @@ import java.nio.charset.StandardCharsets;
  * Kafka-specific implementation of header-based filtering.
  * Allows filtering Kafka records based on message headers before deserialization.
  */
-public class KafkaHeaderBasedFilteringConfig
+public class KafkaHeaderBasedInclusionConfig
 {
   private static final ImmutableSet<Class<? extends DimFilter>> SUPPORTED_FILTER_TYPES = ImmutableSet.of(
       InDimFilter.class
@@ -47,7 +47,7 @@ public class KafkaHeaderBasedFilteringConfig
   private final int stringDecodingCacheSize;
 
   @JsonCreator
-  public KafkaHeaderBasedFilteringConfig(
+  public KafkaHeaderBasedInclusionConfig(
       @JsonProperty("filter") DimFilter filter,
       @JsonProperty("encoding") @Nullable String encoding,
       @JsonProperty("stringDecodingCacheSize") @Nullable Integer stringDecodingCacheSize
@@ -110,7 +110,7 @@ public class KafkaHeaderBasedFilteringConfig
     if (o == null || getClass() != o.getClass()) {
       return false;
     }
-    KafkaHeaderBasedFilteringConfig that = (KafkaHeaderBasedFilteringConfig) o;
+    KafkaHeaderBasedInclusionConfig that = (KafkaHeaderBasedInclusionConfig) o;
     return stringDecodingCacheSize == that.stringDecodingCacheSize &&
            filter.equals(that.filter) &&
            encoding.equals(that.encoding);
@@ -128,7 +128,7 @@ public class KafkaHeaderBasedFilteringConfig
   @Override
   public String toString()
   {
-    return "KafkaHeaderBasedFilteringConfig{" +
+    return "KafkaheaderBasedInclusionConfig{" +
            "filter=" + filter +
            ", encoding='" + encoding + '\'' +
            ", stringDecodingCacheSize=" + stringDecodingCacheSize +

--- a/extensions-core/kafka-indexing-service/src/main/java/org/apache/druid/indexing/kafka/supervisor/KafkaSupervisor.java
+++ b/extensions-core/kafka-indexing-service/src/main/java/org/apache/druid/indexing/kafka/supervisor/KafkaSupervisor.java
@@ -139,7 +139,7 @@ public class KafkaSupervisor extends SeekableStreamSupervisor<KafkaTopicPartitio
         sortingMapper,
         spec.getIoConfig().getConfigOverrides(),
         spec.getIoConfig().isMultiTopic(),
-        spec.getIoConfig().getHeaderBasedFilteringConfig()
+        spec.getIoConfig().getheaderBasedInclusionConfig()
     );
   }
 
@@ -220,7 +220,7 @@ public class KafkaSupervisor extends SeekableStreamSupervisor<KafkaTopicPartitio
         maximumMessageTime,
         ioConfig.getInputFormat(),
         kafkaIoConfig.getConfigOverrides(),
-        kafkaIoConfig.getHeaderBasedFilteringConfig(),
+        kafkaIoConfig.getheaderBasedInclusionConfig(),
         kafkaIoConfig.isMultiTopic()
     );
   }

--- a/extensions-core/kafka-indexing-service/src/main/java/org/apache/druid/indexing/kafka/supervisor/KafkaSupervisorIOConfig.java
+++ b/extensions-core/kafka-indexing-service/src/main/java/org/apache/druid/indexing/kafka/supervisor/KafkaSupervisorIOConfig.java
@@ -52,7 +52,7 @@ public class KafkaSupervisorIOConfig extends SeekableStreamSupervisorIOConfig
   private final KafkaConfigOverrides configOverrides;
   private final String topic;
   private final String topicPattern;
-  private final KafkaHeaderBasedFilteringConfig headerBasedFilteringConfig;
+  private final KafkaHeaderBasedInclusionConfig headerBasedInclusionConfig;
 
   @JsonCreator
   public KafkaSupervisorIOConfig(
@@ -73,7 +73,7 @@ public class KafkaSupervisorIOConfig extends SeekableStreamSupervisorIOConfig
       @JsonProperty("earlyMessageRejectionPeriod") Period earlyMessageRejectionPeriod,
       @JsonProperty("lateMessageRejectionStartDateTime") DateTime lateMessageRejectionStartDateTime,
       @JsonProperty("configOverrides") KafkaConfigOverrides configOverrides,
-      @JsonProperty("headerBasedFilteringConfig") KafkaHeaderBasedFilteringConfig headerBasedFilteringConfig,
+      @JsonProperty("headerBasedInclusionConfig") KafkaHeaderBasedInclusionConfig headerBasedInclusionConfig,
       @JsonProperty("idleConfig") IdleConfig idleConfig,
       @JsonProperty("stopTaskCount") Integer stopTaskCount
   )
@@ -96,7 +96,7 @@ public class KafkaSupervisorIOConfig extends SeekableStreamSupervisorIOConfig
         stopTaskCount
     );
 
-    this.headerBasedFilteringConfig = headerBasedFilteringConfig;
+    this.headerBasedInclusionConfig = headerBasedInclusionConfig;
     this.consumerProperties = Preconditions.checkNotNull(consumerProperties, "consumerProperties");
     Preconditions.checkNotNull(
         consumerProperties.get(BOOTSTRAP_SERVERS_KEY),
@@ -157,9 +157,9 @@ public class KafkaSupervisorIOConfig extends SeekableStreamSupervisorIOConfig
 
   @JsonProperty
   @Nullable
-  public KafkaHeaderBasedFilteringConfig getHeaderBasedFilteringConfig()
+  public KafkaHeaderBasedInclusionConfig getheaderBasedInclusionConfig()
   {
-    return headerBasedFilteringConfig;
+    return headerBasedInclusionConfig;
   }
 
 
@@ -183,7 +183,7 @@ public class KafkaSupervisorIOConfig extends SeekableStreamSupervisorIOConfig
            ", lateMessageRejectionPeriod=" + getLateMessageRejectionPeriod() +
            ", lateMessageRejectionStartDateTime=" + getLateMessageRejectionStartDateTime() +
            ", configOverrides=" + getConfigOverrides() +
-           ", headerBasedFilteringConfig=" + headerBasedFilteringConfig +
+           ", headerBasedInclusionConfig=" + headerBasedInclusionConfig +
            ", idleConfig=" + getIdleConfig() +
            ", stopTaskCount=" + getStopTaskCount() +
            '}';

--- a/extensions-core/kafka-indexing-service/src/test/java/org/apache/druid/indexing/kafka/KafkaHeaderBasedInclusionConfigEvaluatorTest.java
+++ b/extensions-core/kafka-indexing-service/src/test/java/org/apache/druid/indexing/kafka/KafkaHeaderBasedInclusionConfigEvaluatorTest.java
@@ -20,7 +20,7 @@
 package org.apache.druid.indexing.kafka;
 
 import org.apache.druid.common.config.NullHandling;
-import org.apache.druid.indexing.kafka.supervisor.KafkaHeaderBasedFilteringConfig;
+import org.apache.druid.indexing.kafka.supervisor.KafkaHeaderBasedInclusionConfig;
 import org.apache.druid.query.filter.InDimFilter;
 import org.apache.kafka.clients.consumer.ConsumerRecord;
 import org.apache.kafka.common.header.internals.RecordHeader;
@@ -35,7 +35,7 @@ import java.nio.charset.StandardCharsets;
 import java.util.Arrays;
 import java.util.Collections;
 
-public class KafkaHeaderBasedFilteringConfigEvaluatorTest
+public class KafkaHeaderBasedInclusionConfigEvaluatorTest
 {
   private KafkaHeaderBasedFilterEvaluator evaluator;
   private ConsumerRecord<byte[], byte[]> record;
@@ -78,7 +78,7 @@ public class KafkaHeaderBasedFilteringConfigEvaluatorTest
   public void testInFilterSingleValueMatch()
   {
     InDimFilter filter = new InDimFilter("environment", Collections.singletonList("production"), null);
-    evaluator = new KafkaHeaderBasedFilterEvaluator(new KafkaHeaderBasedFilteringConfig(filter, null, null));
+    evaluator = new KafkaHeaderBasedFilterEvaluator(new KafkaHeaderBasedInclusionConfig(filter, null, null));
 
     Assert.assertTrue(evaluator.shouldIncludeRecord(record));
   }
@@ -87,7 +87,7 @@ public class KafkaHeaderBasedFilteringConfigEvaluatorTest
   public void testInFilterSingleValueNoMatch()
   {
     InDimFilter filter = new InDimFilter("environment", Collections.singletonList("staging"), null);
-    evaluator = new KafkaHeaderBasedFilterEvaluator(new KafkaHeaderBasedFilteringConfig(filter, null, null));
+    evaluator = new KafkaHeaderBasedFilterEvaluator(new KafkaHeaderBasedInclusionConfig(filter, null, null));
 
     Assert.assertFalse(evaluator.shouldIncludeRecord(record));
   }
@@ -96,7 +96,7 @@ public class KafkaHeaderBasedFilteringConfigEvaluatorTest
   public void testInFilterMultipleValuesMatch()
   {
     InDimFilter filter = new InDimFilter("environment", Arrays.asList("staging", "production", "development"), null);
-    evaluator = new KafkaHeaderBasedFilterEvaluator(new KafkaHeaderBasedFilteringConfig(filter, null, null));
+    evaluator = new KafkaHeaderBasedFilterEvaluator(new KafkaHeaderBasedInclusionConfig(filter, null, null));
 
     Assert.assertTrue(evaluator.shouldIncludeRecord(record));
   }
@@ -105,7 +105,7 @@ public class KafkaHeaderBasedFilteringConfigEvaluatorTest
   public void testInFilterMultipleValuesNoMatch()
   {
     InDimFilter filter = new InDimFilter("environment", Arrays.asList("staging", "development"), null);
-    evaluator = new KafkaHeaderBasedFilterEvaluator(new KafkaHeaderBasedFilteringConfig(filter, null, null));
+    evaluator = new KafkaHeaderBasedFilterEvaluator(new KafkaHeaderBasedInclusionConfig(filter, null, null));
 
     Assert.assertFalse(evaluator.shouldIncludeRecord(record));
   }
@@ -114,7 +114,7 @@ public class KafkaHeaderBasedFilteringConfigEvaluatorTest
   public void testInFilterMissingHeader()
   {
     InDimFilter filter = new InDimFilter("missing-header", Collections.singletonList("value"), null);
-    evaluator = new KafkaHeaderBasedFilterEvaluator(new KafkaHeaderBasedFilteringConfig(filter, null, null));
+    evaluator = new KafkaHeaderBasedFilterEvaluator(new KafkaHeaderBasedInclusionConfig(filter, null, null));
 
     // With permissive filtering, missing headers should result in inclusion
     Assert.assertTrue("InDimFilter with missing header should include record (permissive)", evaluator.shouldIncludeRecord(record));
@@ -145,7 +145,7 @@ public class KafkaHeaderBasedFilteringConfigEvaluatorTest
     }
 
     InDimFilter filter = new InDimFilter("null-header", Collections.singletonList("value"), null);
-    evaluator = new KafkaHeaderBasedFilterEvaluator(new KafkaHeaderBasedFilteringConfig(filter, null, null));
+    evaluator = new KafkaHeaderBasedFilterEvaluator(new KafkaHeaderBasedInclusionConfig(filter, null, null));
 
     Assert.assertTrue(evaluator.shouldIncludeRecord(nullRecord));
   }
@@ -154,7 +154,7 @@ public class KafkaHeaderBasedFilteringConfigEvaluatorTest
   public void testInFilterWithDifferentServices()
   {
     InDimFilter filter = new InDimFilter("service", Arrays.asList("user-service", "payment-service"), null);
-    evaluator = new KafkaHeaderBasedFilterEvaluator(new KafkaHeaderBasedFilteringConfig(filter, null, null));
+    evaluator = new KafkaHeaderBasedFilterEvaluator(new KafkaHeaderBasedInclusionConfig(filter, null, null));
 
     Assert.assertTrue(evaluator.shouldIncludeRecord(record)); // matches "user-service"
   }
@@ -163,7 +163,7 @@ public class KafkaHeaderBasedFilteringConfigEvaluatorTest
   public void testInFilterWithDifferentServicesNoMatch()
   {
     InDimFilter filter = new InDimFilter("service", Arrays.asList("payment-service", "notification-service"), null);
-    evaluator = new KafkaHeaderBasedFilterEvaluator(new KafkaHeaderBasedFilteringConfig(filter, null, null));
+    evaluator = new KafkaHeaderBasedFilterEvaluator(new KafkaHeaderBasedInclusionConfig(filter, null, null));
 
     Assert.assertFalse(evaluator.shouldIncludeRecord(record)); // doesn't match "user-service"
   }
@@ -172,7 +172,7 @@ public class KafkaHeaderBasedFilteringConfigEvaluatorTest
   public void testRepeatedEvaluations()
   {
     InDimFilter filter = new InDimFilter("environment", Collections.singletonList("production"), null);
-    evaluator = new KafkaHeaderBasedFilterEvaluator(new KafkaHeaderBasedFilteringConfig(filter, null, null));
+    evaluator = new KafkaHeaderBasedFilterEvaluator(new KafkaHeaderBasedInclusionConfig(filter, null, null));
 
     // Test multiple evaluations to verify consistent behavior
     boolean result1 = evaluator.shouldIncludeRecord(record); // should match
@@ -210,7 +210,7 @@ public class KafkaHeaderBasedFilteringConfigEvaluatorTest
     }
 
     InDimFilter filter = new InDimFilter("text", Collections.singletonList(testValue), null);
-    evaluator = new KafkaHeaderBasedFilterEvaluator(new KafkaHeaderBasedFilteringConfig(filter, "ISO-8859-1", null));
+    evaluator = new KafkaHeaderBasedFilterEvaluator(new KafkaHeaderBasedInclusionConfig(filter, "ISO-8859-1", null));
 
     Assert.assertTrue(evaluator.shouldIncludeRecord(encodedRecord));
   }
@@ -240,7 +240,7 @@ public class KafkaHeaderBasedFilteringConfigEvaluatorTest
     }
 
     InDimFilter filter = new InDimFilter("environment", Collections.singletonList("production"), null);
-    evaluator = new KafkaHeaderBasedFilterEvaluator(new KafkaHeaderBasedFilteringConfig(filter, null, null));
+    evaluator = new KafkaHeaderBasedFilterEvaluator(new KafkaHeaderBasedInclusionConfig(filter, null, null));
 
     // Missing header should result in inclusion (permissive behavior)
     Assert.assertTrue(evaluator.shouldIncludeRecord(noHeaderRecord));
@@ -273,12 +273,12 @@ public class KafkaHeaderBasedFilteringConfigEvaluatorTest
 
     // Filter should match "production" (the last value), not "staging" (the first value)
     InDimFilter prodFilter = new InDimFilter("environment", Collections.singletonList("production"), null);
-    evaluator = new KafkaHeaderBasedFilterEvaluator(new KafkaHeaderBasedFilteringConfig(prodFilter, null, null));
+    evaluator = new KafkaHeaderBasedFilterEvaluator(new KafkaHeaderBasedInclusionConfig(prodFilter, null, null));
     Assert.assertTrue("Should match last header value 'production'", evaluator.shouldIncludeRecord(multiHeaderRecord));
 
     // Filter should NOT match "staging" (the first value)
     InDimFilter stagingFilter = new InDimFilter("environment", Collections.singletonList("staging"), null);
-    evaluator = new KafkaHeaderBasedFilterEvaluator(new KafkaHeaderBasedFilteringConfig(stagingFilter, null, null));
+    evaluator = new KafkaHeaderBasedFilterEvaluator(new KafkaHeaderBasedInclusionConfig(stagingFilter, null, null));
     Assert.assertFalse("Should not match first header value 'staging'", evaluator.shouldIncludeRecord(multiHeaderRecord));
   }
 
@@ -286,7 +286,7 @@ public class KafkaHeaderBasedFilteringConfigEvaluatorTest
   public void testStringDecodingCacheSize()
   {
     InDimFilter filter = new InDimFilter("environment", Collections.singletonList("production"), null);
-    evaluator = new KafkaHeaderBasedFilterEvaluator(new KafkaHeaderBasedFilteringConfig(filter, null, 50_000));
+    evaluator = new KafkaHeaderBasedFilterEvaluator(new KafkaHeaderBasedInclusionConfig(filter, null, 50_000));
 
     // Test that the evaluator works with custom cache size
     Assert.assertTrue(evaluator.shouldIncludeRecord(record));

--- a/extensions-core/kafka-indexing-service/src/test/java/org/apache/druid/indexing/kafka/KafkaHeaderBasedInclusionConfigIntegrationTest.java
+++ b/extensions-core/kafka-indexing-service/src/test/java/org/apache/druid/indexing/kafka/KafkaHeaderBasedInclusionConfigIntegrationTest.java
@@ -21,7 +21,7 @@ package org.apache.druid.indexing.kafka;
 
 import com.fasterxml.jackson.databind.ObjectMapper;
 import org.apache.druid.common.config.NullHandling;
-import org.apache.druid.indexing.kafka.supervisor.KafkaHeaderBasedFilteringConfig;
+import org.apache.druid.indexing.kafka.supervisor.KafkaHeaderBasedInclusionConfig;
 import org.apache.druid.jackson.DefaultObjectMapper;
 import org.apache.druid.query.filter.InDimFilter;
 import org.apache.kafka.clients.consumer.ConsumerRecord;
@@ -37,7 +37,7 @@ import java.nio.charset.StandardCharsets;
 import java.util.Arrays;
 import java.util.Collections;
 
-public class KafkaHeaderBasedFilteringConfigIntegrationTest
+public class KafkaHeaderBasedInclusionConfigIntegrationTest
 {
   private KafkaHeaderBasedFilterEvaluator evaluator;
   private final ObjectMapper objectMapper = new DefaultObjectMapper();
@@ -91,7 +91,7 @@ public class KafkaHeaderBasedFilteringConfigIntegrationTest
   {
     // Test Case: Only include records from production environment
     InDimFilter filter = new InDimFilter("environment", Collections.singletonList("production"), null);
-    KafkaHeaderBasedFilteringConfig headerFilter = new KafkaHeaderBasedFilteringConfig(filter, null, null);
+    KafkaHeaderBasedInclusionConfig headerFilter = new KafkaHeaderBasedInclusionConfig(filter, null, null);
     evaluator = new KafkaHeaderBasedFilterEvaluator(headerFilter);
 
     // Production record - should be included
@@ -127,7 +127,7 @@ public class KafkaHeaderBasedFilteringConfigIntegrationTest
   {
     // Test Case: Include records from multiple services
     InDimFilter filter = new InDimFilter("service", Arrays.asList("user-service", "payment-service"), null);
-    KafkaHeaderBasedFilteringConfig headerFilter = new KafkaHeaderBasedFilteringConfig(filter, null, null);
+    KafkaHeaderBasedInclusionConfig headerFilter = new KafkaHeaderBasedInclusionConfig(filter, null, null);
     evaluator = new KafkaHeaderBasedFilterEvaluator(headerFilter);
 
     // User service record - should be included
@@ -171,7 +171,7 @@ public class KafkaHeaderBasedFilteringConfigIntegrationTest
         ),
         null
     );
-    KafkaHeaderBasedFilteringConfig headerFilter = new KafkaHeaderBasedFilteringConfig(filter, null, null);
+    KafkaHeaderBasedInclusionConfig headerFilter = new KafkaHeaderBasedInclusionConfig(filter, null, null);
     evaluator = new KafkaHeaderBasedFilterEvaluator(headerFilter);
 
     // Matching metric - should be included
@@ -198,7 +198,7 @@ public class KafkaHeaderBasedFilteringConfigIntegrationTest
   {
     // Test Case: Verify basic filtering behavior
     InDimFilter filter = new InDimFilter("environment", Collections.singletonList("production"), null);
-    KafkaHeaderBasedFilteringConfig headerFilter = new KafkaHeaderBasedFilteringConfig(filter, null, null);
+    KafkaHeaderBasedInclusionConfig headerFilter = new KafkaHeaderBasedInclusionConfig(filter, null, null);
     evaluator = new KafkaHeaderBasedFilterEvaluator(headerFilter);
 
     // Process multiple records to verify filtering logic
@@ -217,13 +217,13 @@ public class KafkaHeaderBasedFilteringConfigIntegrationTest
   {
     // Test that header filter configurations can be serialized/deserialized correctly
     InDimFilter filter = new InDimFilter("environment", Arrays.asList("production", "staging"), null);
-    KafkaHeaderBasedFilteringConfig originalFilter = new KafkaHeaderBasedFilteringConfig(filter, "UTF-16", null);
+    KafkaHeaderBasedInclusionConfig originalFilter = new KafkaHeaderBasedInclusionConfig(filter, "UTF-16", null);
 
     // Serialize to JSON
     String json = objectMapper.writeValueAsString(originalFilter);
 
     // Deserialize back
-    KafkaHeaderBasedFilteringConfig deserializedFilter = objectMapper.readValue(json, KafkaHeaderBasedFilteringConfig.class);
+    KafkaHeaderBasedInclusionConfig deserializedFilter = objectMapper.readValue(json, KafkaHeaderBasedInclusionConfig.class);
 
     // Verify they're equivalent
     Assert.assertEquals(originalFilter.getFilter(), deserializedFilter.getFilter());
@@ -243,7 +243,7 @@ public class KafkaHeaderBasedFilteringConfigIntegrationTest
     String testValue = "café"; // Contains non-ASCII characters
 
     InDimFilter filter = new InDimFilter("text", Collections.singletonList(testValue), null);
-    KafkaHeaderBasedFilteringConfig headerFilter = new KafkaHeaderBasedFilteringConfig(filter, "ISO-8859-1", null);
+    KafkaHeaderBasedInclusionConfig headerFilter = new KafkaHeaderBasedInclusionConfig(filter, "ISO-8859-1", null);
     evaluator = new KafkaHeaderBasedFilterEvaluator(headerFilter);
 
     // Create record with ISO-8859-1 encoded header
@@ -260,7 +260,7 @@ public class KafkaHeaderBasedFilteringConfigIntegrationTest
   {
     // Test with custom cache size
     InDimFilter filter = new InDimFilter("environment", Collections.singletonList("production"), null);
-    KafkaHeaderBasedFilteringConfig headerFilter = new KafkaHeaderBasedFilteringConfig(filter, null, 100_000);
+    KafkaHeaderBasedInclusionConfig headerFilter = new KafkaHeaderBasedInclusionConfig(filter, null, 100_000);
     evaluator = new KafkaHeaderBasedFilterEvaluator(headerFilter);
 
     ConsumerRecord<byte[], byte[]> record = createRecord("events", 0, 100L, headers("environment", "production"));

--- a/extensions-core/kafka-indexing-service/src/test/java/org/apache/druid/indexing/kafka/KafkaRecordSupplierHeaderFilterTest.java
+++ b/extensions-core/kafka-indexing-service/src/test/java/org/apache/druid/indexing/kafka/KafkaRecordSupplierHeaderFilterTest.java
@@ -22,7 +22,7 @@ package org.apache.druid.indexing.kafka;
 import org.apache.druid.common.config.NullHandling;
 import org.apache.druid.data.input.kafka.KafkaRecordEntity;
 import org.apache.druid.data.input.kafka.KafkaTopicPartition;
-import org.apache.druid.indexing.kafka.supervisor.KafkaHeaderBasedFilteringConfig;
+import org.apache.druid.indexing.kafka.supervisor.KafkaHeaderBasedInclusionConfig;
 import org.apache.druid.indexing.seekablestream.common.OrderedPartitionableRecord;
 import org.apache.druid.query.filter.InDimFilter;
 import org.apache.kafka.clients.consumer.ConsumerRecord;
@@ -97,7 +97,7 @@ public class KafkaRecordSupplierHeaderFilterTest
   {
     // Test filtering with in filter (single value)
     InDimFilter filter = new InDimFilter("environment", Collections.singletonList("production"), null);
-    KafkaHeaderBasedFilteringConfig headerFilter = new KafkaHeaderBasedFilteringConfig(filter, null, null);
+    KafkaHeaderBasedInclusionConfig headerFilter = new KafkaHeaderBasedInclusionConfig(filter, null, null);
 
     recordSupplier = new KafkaRecordSupplier(mockConsumer, false, headerFilter);
 
@@ -138,7 +138,7 @@ public class KafkaRecordSupplierHeaderFilterTest
   {
     // Test that filtered records are properly marked with filtered flag
     InDimFilter filter = new InDimFilter("environment", Collections.singletonList("production"), null);
-    KafkaHeaderBasedFilteringConfig headerFilter = new KafkaHeaderBasedFilteringConfig(filter, null, null);
+    KafkaHeaderBasedInclusionConfig headerFilter = new KafkaHeaderBasedInclusionConfig(filter, null, null);
 
     recordSupplier = new KafkaRecordSupplier(mockConsumer, false, headerFilter);
 
@@ -173,7 +173,7 @@ public class KafkaRecordSupplierHeaderFilterTest
   {
     // Test filtering with in filter (multiple values)
     InDimFilter filter = new InDimFilter("service", Arrays.asList("user-service", "payment-service"), null);
-    KafkaHeaderBasedFilteringConfig headerFilter = new KafkaHeaderBasedFilteringConfig(filter, null, null);
+    KafkaHeaderBasedInclusionConfig headerFilter = new KafkaHeaderBasedInclusionConfig(filter, null, null);
 
     recordSupplier = new KafkaRecordSupplier(mockConsumer, false, headerFilter);
 
@@ -214,7 +214,7 @@ public class KafkaRecordSupplierHeaderFilterTest
   {
     // Test InDimFilter with multiple possible values
     InDimFilter serviceFilter = new InDimFilter("service", Arrays.asList("user-service", "payment-service"), null);
-    KafkaHeaderBasedFilteringConfig headerFilter = new KafkaHeaderBasedFilteringConfig(serviceFilter, null, null);
+    KafkaHeaderBasedInclusionConfig headerFilter = new KafkaHeaderBasedInclusionConfig(serviceFilter, null, null);
 
     recordSupplier = new KafkaRecordSupplier(mockConsumer, false, headerFilter);
 
@@ -255,7 +255,7 @@ public class KafkaRecordSupplierHeaderFilterTest
   {
     // Test that statistics accumulate across multiple polls
     InDimFilter filter = new InDimFilter("environment", Collections.singletonList("production"), null);
-    KafkaHeaderBasedFilteringConfig headerFilter = new KafkaHeaderBasedFilteringConfig(filter, null, null);
+    KafkaHeaderBasedInclusionConfig headerFilter = new KafkaHeaderBasedInclusionConfig(filter, null, null);
 
     recordSupplier = new KafkaRecordSupplier(mockConsumer, false, headerFilter);
 
@@ -300,7 +300,7 @@ public class KafkaRecordSupplierHeaderFilterTest
   {
     // Test that empty polls don't affect statistics
     InDimFilter filter = new InDimFilter("environment", Collections.singletonList("production"), null);
-    KafkaHeaderBasedFilteringConfig headerFilter = new KafkaHeaderBasedFilteringConfig(filter, null, null);
+    KafkaHeaderBasedInclusionConfig headerFilter = new KafkaHeaderBasedInclusionConfig(filter, null, null);
 
     recordSupplier = new KafkaRecordSupplier(mockConsumer, false, headerFilter);
 
@@ -321,7 +321,7 @@ public class KafkaRecordSupplierHeaderFilterTest
     // CRITICAL TEST: Verify that when ALL records are filtered out, we still return
     // filtered record markers to prevent infinite loop
     InDimFilter filter = new InDimFilter("environment", Collections.singletonList("production"), null);
-    KafkaHeaderBasedFilteringConfig headerFilter = new KafkaHeaderBasedFilteringConfig(filter, null, null);
+    KafkaHeaderBasedInclusionConfig headerFilter = new KafkaHeaderBasedInclusionConfig(filter, null, null);
 
     recordSupplier = new KafkaRecordSupplier(mockConsumer, false, headerFilter);
 
@@ -362,7 +362,7 @@ public class KafkaRecordSupplierHeaderFilterTest
   {
     // Test that mix of filtered and accepted records works correctly
     InDimFilter filter = new InDimFilter("environment", Collections.singletonList("production"), null);
-    KafkaHeaderBasedFilteringConfig headerFilter = new KafkaHeaderBasedFilteringConfig(filter, null, null);
+    KafkaHeaderBasedInclusionConfig headerFilter = new KafkaHeaderBasedInclusionConfig(filter, null, null);
 
     recordSupplier = new KafkaRecordSupplier(mockConsumer, false, headerFilter);
 
@@ -402,7 +402,7 @@ public class KafkaRecordSupplierHeaderFilterTest
   {
     // Test header filtering with multi-topic configuration
     InDimFilter filter = new InDimFilter("environment", Collections.singletonList("production"), null);
-    KafkaHeaderBasedFilteringConfig headerFilter = new KafkaHeaderBasedFilteringConfig(filter, null, null);
+    KafkaHeaderBasedInclusionConfig headerFilter = new KafkaHeaderBasedInclusionConfig(filter, null, null);
 
     recordSupplier = new KafkaRecordSupplier(mockConsumer, true, headerFilter); // multiTopic = true
 

--- a/extensions-core/kafka-indexing-service/src/test/java/org/apache/druid/indexing/kafka/supervisor/KafkaHeaderBasedInclusionConfigTest.java
+++ b/extensions-core/kafka-indexing-service/src/test/java/org/apache/druid/indexing/kafka/supervisor/KafkaHeaderBasedInclusionConfigTest.java
@@ -34,7 +34,7 @@ import org.junit.Test;
 import java.util.Arrays;
 import java.util.Collections;
 
-public class KafkaHeaderBasedFilteringConfigTest
+public class KafkaHeaderBasedInclusionConfigTest
 {
   private final ObjectMapper objectMapper = new DefaultObjectMapper();
 
@@ -48,7 +48,7 @@ public class KafkaHeaderBasedFilteringConfigTest
   public void testInFilterSingleValue()
   {
     InDimFilter dimFilter = new InDimFilter("environment", Collections.singletonList("production"), null);
-    KafkaHeaderBasedFilteringConfig filter = new KafkaHeaderBasedFilteringConfig(dimFilter, null, null);
+    KafkaHeaderBasedInclusionConfig filter = new KafkaHeaderBasedInclusionConfig(dimFilter, null, null);
 
     Assert.assertEquals(dimFilter, filter.getFilter());
     Assert.assertEquals("UTF-8", filter.getEncoding());
@@ -59,7 +59,7 @@ public class KafkaHeaderBasedFilteringConfigTest
   public void testInFilterMultipleValues()
   {
     InDimFilter dimFilter = new InDimFilter("service", Arrays.asList("user-service", "payment-service"), null);
-    KafkaHeaderBasedFilteringConfig filter = new KafkaHeaderBasedFilteringConfig(dimFilter, "ISO-8859-1", null);
+    KafkaHeaderBasedInclusionConfig filter = new KafkaHeaderBasedInclusionConfig(dimFilter, "ISO-8859-1", null);
 
     Assert.assertEquals(dimFilter, filter.getFilter());
     Assert.assertEquals("ISO-8859-1", filter.getEncoding());
@@ -70,7 +70,7 @@ public class KafkaHeaderBasedFilteringConfigTest
   public void testInFilterWithCustomCacheSize()
   {
     InDimFilter dimFilter = new InDimFilter("environment", Collections.singletonList("production"), null);
-    KafkaHeaderBasedFilteringConfig filter = new KafkaHeaderBasedFilteringConfig(dimFilter, null, 50_000);
+    KafkaHeaderBasedInclusionConfig filter = new KafkaHeaderBasedInclusionConfig(dimFilter, null, 50_000);
 
     Assert.assertEquals(dimFilter, filter.getFilter());
     Assert.assertEquals("UTF-8", filter.getEncoding());
@@ -82,7 +82,7 @@ public class KafkaHeaderBasedFilteringConfigTest
   {
     SelectorDimFilter dimFilter = new SelectorDimFilter("environment", "production", null);
     try {
-      new KafkaHeaderBasedFilteringConfig(dimFilter, null, null);
+      new KafkaHeaderBasedInclusionConfig(dimFilter, null, null);
       Assert.fail("Expected DruidException for SelectorDimFilter");
     }
     catch (DruidException e) {
@@ -98,7 +98,7 @@ public class KafkaHeaderBasedFilteringConfigTest
     SelectorDimFilter serviceFilter = new SelectorDimFilter("service", "user-service", null);
     AndDimFilter andFilter = new AndDimFilter(Arrays.asList(envFilter, serviceFilter));
     try {
-      new KafkaHeaderBasedFilteringConfig(andFilter, null, null);
+      new KafkaHeaderBasedInclusionConfig(andFilter, null, null);
       Assert.fail("Expected DruidException for AndDimFilter");
     }
     catch (DruidException e) {
@@ -113,7 +113,7 @@ public class KafkaHeaderBasedFilteringConfigTest
     SelectorDimFilter debugFilter = new SelectorDimFilter("debug-mode", "true", null);
     NotDimFilter notFilter = new NotDimFilter(debugFilter);
     try {
-      new KafkaHeaderBasedFilteringConfig(notFilter, null, null);
+      new KafkaHeaderBasedInclusionConfig(notFilter, null, null);
       Assert.fail("Expected DruidException for NotDimFilter");
     }
     catch (DruidException e) {
@@ -125,27 +125,27 @@ public class KafkaHeaderBasedFilteringConfigTest
   @Test(expected = NullPointerException.class)
   public void testNullFilter()
   {
-    new KafkaHeaderBasedFilteringConfig(null, null, null);
+    new KafkaHeaderBasedInclusionConfig(null, null, null);
   }
 
   @Test(expected = IllegalArgumentException.class)
   public void testInvalidEncoding()
   {
     InDimFilter dimFilter = new InDimFilter("environment", Collections.singletonList("production"), null);
-    new KafkaHeaderBasedFilteringConfig(dimFilter, "INVALID-ENCODING", null);
+    new KafkaHeaderBasedInclusionConfig(dimFilter, "INVALID-ENCODING", null);
   }
 
   @Test
   public void testSerialization() throws Exception
   {
     InDimFilter dimFilter = new InDimFilter("environment", Collections.singletonList("production"), null);
-    KafkaHeaderBasedFilteringConfig originalFilter = new KafkaHeaderBasedFilteringConfig(dimFilter, "UTF-16", null);
+    KafkaHeaderBasedInclusionConfig originalFilter = new KafkaHeaderBasedInclusionConfig(dimFilter, "UTF-16", null);
 
     // Serialize to JSON
     String json = objectMapper.writeValueAsString(originalFilter);
 
     // Deserialize back
-    KafkaHeaderBasedFilteringConfig deserializedFilter = objectMapper.readValue(json, KafkaHeaderBasedFilteringConfig.class);
+    KafkaHeaderBasedInclusionConfig deserializedFilter = objectMapper.readValue(json, KafkaHeaderBasedInclusionConfig.class);
 
     Assert.assertEquals(originalFilter.getFilter(), deserializedFilter.getFilter());
     Assert.assertEquals(originalFilter.getEncoding(), deserializedFilter.getEncoding());
@@ -159,11 +159,11 @@ public class KafkaHeaderBasedFilteringConfigTest
     InDimFilter dimFilter2 = new InDimFilter("environment", Collections.singletonList("production"), null);
     InDimFilter dimFilter3 = new InDimFilter("environment", Collections.singletonList("staging"), null);
 
-    KafkaHeaderBasedFilteringConfig filter1 = new KafkaHeaderBasedFilteringConfig(dimFilter1, "UTF-8", null);
-    KafkaHeaderBasedFilteringConfig filter2 = new KafkaHeaderBasedFilteringConfig(dimFilter2, "UTF-8", null);
-    KafkaHeaderBasedFilteringConfig filter3 = new KafkaHeaderBasedFilteringConfig(dimFilter3, "UTF-8", null);
-    KafkaHeaderBasedFilteringConfig filter4 = new KafkaHeaderBasedFilteringConfig(dimFilter1, "UTF-16", null);
-    KafkaHeaderBasedFilteringConfig filter5 = new KafkaHeaderBasedFilteringConfig(dimFilter1, "UTF-8", 5000);
+    KafkaHeaderBasedInclusionConfig filter1 = new KafkaHeaderBasedInclusionConfig(dimFilter1, "UTF-8", null);
+    KafkaHeaderBasedInclusionConfig filter2 = new KafkaHeaderBasedInclusionConfig(dimFilter2, "UTF-8", null);
+    KafkaHeaderBasedInclusionConfig filter3 = new KafkaHeaderBasedInclusionConfig(dimFilter3, "UTF-8", null);
+    KafkaHeaderBasedInclusionConfig filter4 = new KafkaHeaderBasedInclusionConfig(dimFilter1, "UTF-16", null);
+    KafkaHeaderBasedInclusionConfig filter5 = new KafkaHeaderBasedInclusionConfig(dimFilter1, "UTF-8", 5000);
 
     Assert.assertEquals(filter1, filter2);
     Assert.assertNotEquals(filter1, filter3);
@@ -177,10 +177,10 @@ public class KafkaHeaderBasedFilteringConfigTest
   public void testToString()
   {
     InDimFilter dimFilter = new InDimFilter("environment", Collections.singletonList("production"), null);
-    KafkaHeaderBasedFilteringConfig filter = new KafkaHeaderBasedFilteringConfig(dimFilter, "UTF-8", null);
+    KafkaHeaderBasedInclusionConfig filter = new KafkaHeaderBasedInclusionConfig(dimFilter, "UTF-8", null);
 
     String toString = filter.toString();
-    Assert.assertTrue(toString.contains("KafkaHeaderBasedFilteringConfig"));
+    Assert.assertTrue(toString.contains("KafkaheaderBasedInclusionConfig"));
     Assert.assertTrue(toString.contains("filter="));
     Assert.assertTrue(toString.contains("encoding='UTF-8'"));
     Assert.assertTrue(toString.contains("stringDecodingCacheSize=10000"));


### PR DESCRIPTION
Fixes #XXXX.

Previous PR - https://github.com/confluentinc/druid/pull/379


### Description
* Renamed headerBasedFilterConfig config to headerBasedInclusionConfig as it was misleading and confusing



#### Fixed the bug ...
#### Renamed the class ...
#### Added a forbidden-apis entry ...




#### Release note
For tips about how to write a good release note, see [Release notes](https://github.com/apache/druid/blob/master/CONTRIBUTING.md#release-notes).


<hr>

##### Key changed/added classes in this PR
 * `MyFoo`
 * `OurBar`
 * `TheirBaz`

<hr>

<!-- Check the items by putting "x" in the brackets for the done things. Not all of these items apply to every PR. Remove the items which are not done or not relevant to the PR. None of the items from the checklist below are strictly necessary, but it would be very helpful if you at least self-review the PR. -->

This PR has:

- [x] been self-reviewed.
   - [ ] using the [concurrency checklist](https://github.com/apache/druid/blob/master/dev/code-review/concurrency.md) (Remove this item if the PR doesn't have any relation to concurrency.)
- [x] added documentation for new or modified features or behaviors.
- [x] a release note entry in the PR description.
- [x] added Javadocs for most classes and all non-trivial methods. Linked related entities via Javadoc links.
- [x] added or updated version, license, or notice information in [licenses.yaml](https://github.com/apache/druid/blob/master/dev/license.md)
- [x] added comments explaining the "why" and the intent of the code wherever would not be obvious for an unfamiliar reader.
- [x] added unit tests or modified existing tests to cover new code paths, ensuring the threshold for [code coverage](https://github.com/apache/druid/blob/master/dev/code-review/code-coverage.md) is met.
- [x] added integration tests.
- [x] been tested in a test Druid cluster.
