### PR TITLE
Rename headerBasedFilterConfig config to headerBasedInclusionConfig

### DIFF
--- a/extensions-core/kafka-indexing-service/src/main/java/org/apache/druid/indexing/kafka/KafkaHeaderBasedFilterEvaluator.java
+++ b/extensions-core/kafka-indexing-service/src/main/java/org/apache/druid/indexing/kafka/KafkaHeaderBasedFilterEvaluator.java
@@ -45,23 +45,23 @@ public class KafkaHeaderBasedFilterEvaluator
   private final Charset encoding;
   private final Cache<ByteBuffer, String> stringDecodingCache;
 
-  public KafkaHeaderBasedFilterEvaluator(KafkaHeaderBasedInclusionConfig headerBasedFilteringConfig)
+  public KafkaHeaderBasedFilterEvaluator(KafkaHeaderBasedInclusionConfig headerBasedInclusionConfig)
   {
-    this.encoding = Charset.forName(headerBasedFilteringConfig.getEncoding());
+    this.encoding = Charset.forName(headerBasedInclusionConfig.getEncoding());
     this.stringDecodingCache = Caffeine.newBuilder()
-        .maximumSize(headerBasedFilteringConfig.getStringDecodingCacheSize())
+        .maximumSize(headerBasedInclusionConfig.getStringDecodingCacheSize())
         .build();
 
-    this.filter = headerBasedFilteringConfig.getFilter().toFilter();
+    this.filter = headerBasedInclusionConfig.getFilter().toFilter();
     if (!(filter instanceof InDimFilter)) {
       // Only InDimFilter supported
       throw new IllegalStateException("Unsupported filter type: " + filter.getClass().getSimpleName());
     }
 
     log.info("Initialized Kafka header filter with encoding [%s] - direct evaluation for [%s] with Caffeine string cache (max %d entries)",
-             headerBasedFilteringConfig.getEncoding(),
+             headerBasedInclusionConfig.getEncoding(),
              this.filter.getClass().getSimpleName(),
-             headerBasedFilteringConfig.getStringDecodingCacheSize());
+             headerBasedInclusionConfig.getStringDecodingCacheSize());
   }
 
 

--- a/extensions-core/kafka-indexing-service/src/main/java/org/apache/druid/indexing/kafka/KafkaIndexTask.java
+++ b/extensions-core/kafka-indexing-service/src/main/java/org/apache/druid/indexing/kafka/KafkaIndexTask.java
@@ -123,7 +123,7 @@ public class KafkaIndexTask extends SeekableStreamIndexTask<KafkaTopicPartition,
               configMapper,
               kafkaIndexTaskIOConfig.getConfigOverrides(),
               kafkaIndexTaskIOConfig.isMultiTopic(),
-              kafkaIndexTaskIOConfig.getHeaderBasedFilteringConfig()
+              kafkaIndexTaskIOConfig.getheaderBasedInclusionConfig()
           );
 
       if (toolbox.getMonitorScheduler() != null) {

--- a/extensions-core/kafka-indexing-service/src/main/java/org/apache/druid/indexing/kafka/KafkaIndexTaskIOConfig.java
+++ b/extensions-core/kafka-indexing-service/src/main/java/org/apache/druid/indexing/kafka/KafkaIndexTaskIOConfig.java
@@ -40,7 +40,7 @@ public class KafkaIndexTaskIOConfig extends SeekableStreamIndexTaskIOConfig<Kafk
   private final Map<String, Object> consumerProperties;
   private final long pollTimeout;
   private final KafkaConfigOverrides configOverrides;
-  private final KafkaHeaderBasedInclusionConfig headerBasedFilteringConfig;
+  private final KafkaHeaderBasedInclusionConfig headerBasedInclusionConfig;
 
   private final boolean multiTopic;
 
@@ -67,7 +67,7 @@ public class KafkaIndexTaskIOConfig extends SeekableStreamIndexTaskIOConfig<Kafk
       @JsonProperty("configOverrides") @Nullable KafkaConfigOverrides configOverrides,
       @JsonProperty("multiTopic") @Nullable Boolean multiTopic,
       @JsonProperty("refreshRejectionPeriodsInMinutes") Long refreshRejectionPeriodsInMinutes,
-      @JsonProperty("headerBasedFilteringConfig") @Nullable KafkaHeaderBasedInclusionConfig headerBasedFilteringConfig
+      @JsonProperty("headerBasedInclusionConfig") @Nullable KafkaHeaderBasedInclusionConfig headerBasedInclusionConfig
   )
   {
     super(
@@ -87,7 +87,7 @@ public class KafkaIndexTaskIOConfig extends SeekableStreamIndexTaskIOConfig<Kafk
     this.consumerProperties = Preconditions.checkNotNull(consumerProperties, "consumerProperties");
     this.pollTimeout = pollTimeout != null ? pollTimeout : KafkaSupervisorIOConfig.DEFAULT_POLL_TIMEOUT_MILLIS;
     this.configOverrides = configOverrides;
-    this.headerBasedFilteringConfig = headerBasedFilteringConfig;
+    this.headerBasedInclusionConfig = headerBasedInclusionConfig;
     this.multiTopic = multiTopic != null ? multiTopic : KafkaSupervisorIOConfig.DEFAULT_IS_MULTI_TOPIC;
 
     final SeekableStreamEndSequenceNumbers<KafkaTopicPartition, Long> myEndSequenceNumbers = getEndSequenceNumbers();
@@ -115,7 +115,7 @@ public class KafkaIndexTaskIOConfig extends SeekableStreamIndexTaskIOConfig<Kafk
       InputFormat inputFormat,
       KafkaConfigOverrides configOverrides,
       Long refreshRejectionPeriodsInMinutes,
-      KafkaHeaderBasedInclusionConfig headerBasedFilteringConfig
+      KafkaHeaderBasedInclusionConfig headerBasedInclusionConfig
   )
   {
     this(
@@ -134,7 +134,7 @@ public class KafkaIndexTaskIOConfig extends SeekableStreamIndexTaskIOConfig<Kafk
         configOverrides,
         KafkaSupervisorIOConfig.DEFAULT_IS_MULTI_TOPIC,
         refreshRejectionPeriodsInMinutes,
-        headerBasedFilteringConfig
+        headerBasedInclusionConfig
     );
   }
 
@@ -193,9 +193,9 @@ public class KafkaIndexTaskIOConfig extends SeekableStreamIndexTaskIOConfig<Kafk
 
   @JsonProperty
   @Nullable
-  public KafkaHeaderBasedInclusionConfig getHeaderBasedFilteringConfig()
+  public KafkaHeaderBasedInclusionConfig getheaderBasedInclusionConfig()
   {
-    return headerBasedFilteringConfig;
+    return headerBasedInclusionConfig;
   }
 
   @Override
@@ -212,7 +212,7 @@ public class KafkaIndexTaskIOConfig extends SeekableStreamIndexTaskIOConfig<Kafk
            ", minimumMessageTime=" + getMinimumMessageTime() +
            ", maximumMessageTime=" + getMaximumMessageTime() +
            ", configOverrides=" + getConfigOverrides() +
-           ", headerBasedFilteringConfig=" + getHeaderBasedFilteringConfig() +
+           ", headerBasedInclusionConfig=" + getheaderBasedInclusionConfig() +
            ", multiTopic=" + multiTopic +
            '}';
   }

--- a/extensions-core/kafka-indexing-service/src/main/java/org/apache/druid/indexing/kafka/KafkaRecordSupplier.java
+++ b/extensions-core/kafka-indexing-service/src/main/java/org/apache/druid/indexing/kafka/KafkaRecordSupplier.java
@@ -107,10 +107,10 @@ public class KafkaRecordSupplier implements RecordSupplier<KafkaTopicPartition, 
       ObjectMapper sortingMapper,
       KafkaConfigOverrides configOverrides,
       boolean multiTopic,
-      @Nullable KafkaHeaderBasedInclusionConfig headerBasedFilteringConfig
+      @Nullable KafkaHeaderBasedInclusionConfig headerBasedInclusionConfig
   )
   {
-    this(getKafkaConsumer(sortingMapper, consumerProperties, configOverrides), multiTopic, headerBasedFilteringConfig);
+    this(getKafkaConsumer(sortingMapper, consumerProperties, configOverrides), multiTopic, headerBasedInclusionConfig);
   }
 
   @VisibleForTesting
@@ -123,14 +123,14 @@ public class KafkaRecordSupplier implements RecordSupplier<KafkaTopicPartition, 
   public KafkaRecordSupplier(
       KafkaConsumer<byte[], byte[]> consumer,
       boolean multiTopic,
-      @Nullable KafkaHeaderBasedInclusionConfig headerBasedFilteringConfig
+      @Nullable KafkaHeaderBasedInclusionConfig headerBasedInclusionConfig
   )
   {
     this.consumer = consumer;
     this.multiTopic = multiTopic;
     this.monitor = new KafkaConsumerMonitor(consumer);
-    this.headerFilterEvaluator = headerBasedFilteringConfig != null ?
-        new KafkaHeaderBasedFilterEvaluator(headerBasedFilteringConfig) : null;
+    this.headerFilterEvaluator = headerBasedInclusionConfig != null ?
+        new KafkaHeaderBasedFilterEvaluator(headerBasedInclusionConfig) : null;
   }
 
   @Override

--- a/extensions-core/kafka-indexing-service/src/main/java/org/apache/druid/indexing/kafka/supervisor/KafkaHeaderBasedInclusionConfig.java
+++ b/extensions-core/kafka-indexing-service/src/main/java/org/apache/druid/indexing/kafka/supervisor/KafkaHeaderBasedInclusionConfig.java
@@ -128,7 +128,7 @@ public class KafkaHeaderBasedInclusionConfig
   @Override
   public String toString()
   {
-    return "KafkaHeaderBasedFilteringConfig{" +
+    return "KafkaheaderBasedInclusionConfig{" +
            "filter=" + filter +
            ", encoding='" + encoding + '\'' +
            ", stringDecodingCacheSize=" + stringDecodingCacheSize +

--- a/extensions-core/kafka-indexing-service/src/main/java/org/apache/druid/indexing/kafka/supervisor/KafkaSupervisor.java
+++ b/extensions-core/kafka-indexing-service/src/main/java/org/apache/druid/indexing/kafka/supervisor/KafkaSupervisor.java
@@ -132,7 +132,7 @@ public class KafkaSupervisor extends SeekableStreamSupervisor<KafkaTopicPartitio
         sortingMapper,
         spec.getIoConfig().getConfigOverrides(),
         spec.getIoConfig().isMultiTopic(),
-        spec.getIoConfig().getHeaderBasedFilteringConfig()
+        spec.getIoConfig().getheaderBasedInclusionConfig()
     );
   }
 
@@ -222,7 +222,7 @@ public class KafkaSupervisor extends SeekableStreamSupervisor<KafkaTopicPartitio
         kafkaIoConfig.getConfigOverrides(),
         kafkaIoConfig.isMultiTopic(),
         ioConfig.getTaskDuration().getStandardMinutes(),
-        kafkaIoConfig.getHeaderBasedFilteringConfig()
+        kafkaIoConfig.getheaderBasedInclusionConfig()
     );
   }
 

--- a/extensions-core/kafka-indexing-service/src/main/java/org/apache/druid/indexing/kafka/supervisor/KafkaSupervisorIOConfig.java
+++ b/extensions-core/kafka-indexing-service/src/main/java/org/apache/druid/indexing/kafka/supervisor/KafkaSupervisorIOConfig.java
@@ -54,7 +54,7 @@ public class KafkaSupervisorIOConfig extends SeekableStreamSupervisorIOConfig
   private final String topic;
   private final String topicPattern;
   private final boolean emitTimeLagMetrics;
-  private final KafkaHeaderBasedInclusionConfig headerBasedFilteringConfig;
+  private final KafkaHeaderBasedInclusionConfig headerBasedInclusionConfig;
 
   @JsonCreator
   public KafkaSupervisorIOConfig(
@@ -76,7 +76,7 @@ public class KafkaSupervisorIOConfig extends SeekableStreamSupervisorIOConfig
       @JsonProperty("earlyMessageRejectionPeriod") Period earlyMessageRejectionPeriod,
       @JsonProperty("lateMessageRejectionStartDateTime") DateTime lateMessageRejectionStartDateTime,
       @JsonProperty("configOverrides") KafkaConfigOverrides configOverrides,
-      @JsonProperty("headerBasedFilteringConfig") KafkaHeaderBasedInclusionConfig headerBasedFilteringConfig,
+      @JsonProperty("headerBasedInclusionConfig") KafkaHeaderBasedInclusionConfig headerBasedInclusionConfig,
       @JsonProperty("idleConfig") IdleConfig idleConfig,
       @JsonProperty("stopTaskCount") Integer stopTaskCount,
       @Nullable @JsonProperty("emitTimeLagMetrics") Boolean emitTimeLagMetrics
@@ -101,7 +101,7 @@ public class KafkaSupervisorIOConfig extends SeekableStreamSupervisorIOConfig
         stopTaskCount
     );
 
-    this.headerBasedFilteringConfig = headerBasedFilteringConfig;
+    this.headerBasedInclusionConfig = headerBasedInclusionConfig;
     this.consumerProperties = Preconditions.checkNotNull(consumerProperties, "consumerProperties");
     Preconditions.checkNotNull(
         consumerProperties.get(BOOTSTRAP_SERVERS_KEY),
@@ -172,9 +172,9 @@ public class KafkaSupervisorIOConfig extends SeekableStreamSupervisorIOConfig
 
   @JsonProperty
   @Nullable
-  public KafkaHeaderBasedInclusionConfig getHeaderBasedFilteringConfig()
+  public KafkaHeaderBasedInclusionConfig getheaderBasedInclusionConfig()
   {
-    return headerBasedFilteringConfig;
+    return headerBasedInclusionConfig;
   }
 
 
@@ -198,7 +198,7 @@ public class KafkaSupervisorIOConfig extends SeekableStreamSupervisorIOConfig
            ", lateMessageRejectionPeriod=" + getLateMessageRejectionPeriod() +
            ", lateMessageRejectionStartDateTime=" + getLateMessageRejectionStartDateTime() +
            ", configOverrides=" + getConfigOverrides() +
-           ", headerBasedFilteringConfig=" + headerBasedFilteringConfig +
+           ", headerBasedInclusionConfig=" + headerBasedInclusionConfig +
            ", idleConfig=" + getIdleConfig() +
            ", stopTaskCount=" + getStopTaskCount() +
            '}';

--- a/extensions-core/kafka-indexing-service/src/test/java/org/apache/druid/indexing/kafka/supervisor/KafkaHeaderBasedInclusionConfigTest.java
+++ b/extensions-core/kafka-indexing-service/src/test/java/org/apache/druid/indexing/kafka/supervisor/KafkaHeaderBasedInclusionConfigTest.java
@@ -180,7 +180,7 @@ public class KafkaHeaderBasedInclusionConfigTest
     KafkaHeaderBasedInclusionConfig filter = new KafkaHeaderBasedInclusionConfig(dimFilter, "UTF-8", null);
 
     String toString = filter.toString();
-    Assert.assertTrue(toString.contains("KafkaHeaderBasedFilteringConfig"));
+    Assert.assertTrue(toString.contains("KafkaheaderBasedInclusionConfig"));
     Assert.assertTrue(toString.contains("filter="));
     Assert.assertTrue(toString.contains("encoding='UTF-8'"));
     Assert.assertTrue(toString.contains("stringDecodingCacheSize=10000"));


### PR DESCRIPTION
Fixes #XXXX.

Previous PR - https://github.com/confluentinc/druid/pull/380


### Description
* Renamed headerBasedFilterConfig config to headerBasedInclusionConfig as it was misleading and confusing



#### Fixed the bug ...
#### Renamed the class ...
#### Added a forbidden-apis entry ...




#### Release note
For tips about how to write a good release note, see [Release notes](https://github.com/apache/druid/blob/master/CONTRIBUTING.md#release-notes).


<hr>

##### Key changed/added classes in this PR
 * `MyFoo`
 * `OurBar`
 * `TheirBaz`

<hr>

<!-- Check the items by putting "x" in the brackets for the done things. Not all of these items apply to every PR. Remove the items which are not done or not relevant to the PR. None of the items from the checklist below are strictly necessary, but it would be very helpful if you at least self-review the PR. -->

This PR has:

- [x] been self-reviewed.
   - [ ] using the [concurrency checklist](https://github.com/apache/druid/blob/master/dev/code-review/concurrency.md) (Remove this item if the PR doesn't have any relation to concurrency.)
- [x] added documentation for new or modified features or behaviors.
- [x] a release note entry in the PR description.
- [x] added Javadocs for most classes and all non-trivial methods. Linked related entities via Javadoc links.
- [x] added or updated version, license, or notice information in [licenses.yaml](https://github.com/apache/druid/blob/master/dev/license.md)
- [x] added comments explaining the "why" and the intent of the code wherever would not be obvious for an unfamiliar reader.
- [x] added unit tests or modified existing tests to cover new code paths, ensuring the threshold for [code coverage](https://github.com/apache/druid/blob/master/dev/code-review/code-coverage.md) is met.
- [x] added integration tests.
- [x] been tested in a test Druid cluster.
