### PR TITLE
[OBSDATA-11562] Use hashset to optimize large number of values in "IN" filter.

### DIFF
--- a/extensions-core/kafka-indexing-service/src/main/java/org/apache/druid/indexing/kafka/KafkaHeaderBasedFilterEvaluator.java
+++ b/extensions-core/kafka-indexing-service/src/main/java/org/apache/druid/indexing/kafka/KafkaHeaderBasedFilterEvaluator.java
@@ -33,6 +33,8 @@ import javax.annotation.Nullable;
 
 import java.nio.ByteBuffer;
 import java.nio.charset.Charset;
+import java.util.HashSet;
+import java.util.Set;
 
 /**
  * Evaluates Kafka header filters for pre-ingestion filtering.
@@ -44,6 +46,7 @@ public class KafkaHeaderBasedFilterEvaluator
   private final Filter filter;
   private final Charset encoding;
   private final Cache<ByteBuffer, String> stringDecodingCache;
+  private final Set<String> filterValues;
 
   public KafkaHeaderBasedFilterEvaluator(KafkaHeaderBasedInclusionConfig headerBasedInclusionConfig)
   {
@@ -58,10 +61,15 @@ public class KafkaHeaderBasedFilterEvaluator
       throw new IllegalStateException("Unsupported filter type: " + filter.getClass().getSimpleName());
     }
 
-    log.info("Initialized Kafka header filter with encoding [%s] - direct evaluation for [%s] with Caffeine string cache (max %d entries)",
-             headerBasedInclusionConfig.getEncoding(),
-             this.filter.getClass().getSimpleName(),
-             headerBasedInclusionConfig.getStringDecodingCacheSize());
+    // Convert SortedSet to HashSet for O(1) lookups instead of O(log n) TreeSet lookups
+    InDimFilter inFilter = (InDimFilter) filter;
+    this.filterValues = new HashSet<>(inFilter.getValues());
+
+    log.info("Initialized Kafka header filter with encoding [%s] - direct evaluation for [%s] with Caffeine string cache (max %d entries) and HashSet lookup (%d filter values)",
+            headerBasedInclusionConfig.getEncoding(),
+            this.filter.getClass().getSimpleName(),
+            headerBasedInclusionConfig.getStringDecodingCacheSize(),
+            this.filterValues.size());
   }
 
 
@@ -109,7 +117,7 @@ public class KafkaHeaderBasedFilterEvaluator
       return true;
     }
 
-    return inFilter.getValues().contains(headerValue);
+    return filterValues.contains(headerValue);
   }
 
 


### PR DESCRIPTION
Fixes #XXXX.


### Description

* Related PR in Druid-34 branch - https://github.com/confluentinc/druid/pull/385

#### Fixed the bug ...
#### Renamed the class ...
#### Added a forbidden-apis entry ...





#### Release note

For tips about how to write a good release note, see [Release notes](https://github.com/apache/druid/blob/master/CONTRIBUTING.md#release-notes).


<hr>

##### Key changed/added classes in this PR
 * `MyFoo`
 * `OurBar`
 * `TheirBaz`

<hr>

<!-- Check the items by putting "x" in the brackets for the done things. Not all of these items apply to every PR. Remove the items which are not done or not relevant to the PR. None of the items from the checklist below are strictly necessary, but it would be very helpful if you at least self-review the PR. -->

This PR has:

- [ ] been self-reviewed.
   - [ ] using the [concurrency checklist](https://github.com/apache/druid/blob/master/dev/code-review/concurrency.md) (Remove this item if the PR doesn't have any relation to concurrency.)
- [ ] added documentation for new or modified features or behaviors.
- [ ] a release note entry in the PR description.
- [ ] added Javadocs for most classes and all non-trivial methods. Linked related entities via Javadoc links.
- [ ] added or updated version, license, or notice information in [licenses.yaml](https://github.com/apache/druid/blob/master/dev/license.md)
- [ ] added comments explaining the "why" and the intent of the code wherever would not be obvious for an unfamiliar reader.
- [ ] added unit tests or modified existing tests to cover new code paths, ensuring the threshold for [code coverage](https://github.com/apache/druid/blob/master/dev/code-review/code-coverage.md) is met.
- [ ] added integration tests.
- [ ] been tested in a test Druid cluster.
