### PR TITLE
Build kafka-based lookup related extensions for Druid-30

### DIFF
--- a/distribution/pom.xml
+++ b/distribution/pom.xml
@@ -782,6 +782,10 @@
                                         <argument>io.confluent.druid.extensions:confluent-extensions</argument>
                                         <argument>-c</argument>
                                         <argument>org.apache.druid.extensions.contrib:opentelemetry-emitter</argument>
+                                        <argument>-c</argument>
+                                        <argument>org.apache.druid.extensions:druid-kafka-extraction-namespace</argument>
+                                        <argument>-c</argument>
+                                        <argument>org.apache.druid.extensions:druid-lookups-cached-global</argument>
                                     </arguments>
                                 </configuration>
                             </execution>


### PR DESCRIPTION
Bundles kafka-based-lookup related community-extensions into tarball.

Deployed and tested in `druid-stag-unstable`. Pods are up and indexer is able to populate the lookup from the cdc stream