### PR TITLE
shrink Semaphore agent types

### DIFF
--- a/.semaphore/semaphore.yml
+++ b/.semaphore/semaphore.yml
@@ -7,6 +7,7 @@ execution_time_limit:
   hours: 5
 blocks:
   - name: "Install"
+    dependencies: []
     task:
       agent:
         machine:
@@ -63,6 +64,7 @@ blocks:
             - artifact push workflow cache-post-install.tgz
 
   - name: "Tests"
+    dependencies: ["Install"]
     task:
       env_vars: *env_vars
       prologue:
@@ -153,6 +155,24 @@ blocks:
               value: extensions-core/kafka-indexing-service
           commands: *run_tests
 
+  - name: "Other Tests"
+    dependencies: ["Install"]
+    task:
+      agent:
+        machine:
+          type: s1-prod-ubuntu24-04-arm64-3
+      env_vars: *env_vars
+      prologue:
+        commands:
+          - echo $SEMAPHORE_WORKFLOW_ID
+          - sem-version java 17
+          - checkout
+          - artifact pull workflow cache-post-install.tgz
+          - tar zxf cache-post-install.tgz
+          # This is a change meant to validate semaphore public builds
+          # so thus removing configurations for Confluent's internal CodeArtifact
+          - rm ~/.m2/settings.xml
+      jobs:
         - name: "Other Tests"
           env_vars:
             - name: MAVEN_PROJECTS

--- a/.semaphore/semaphore.yml
+++ b/.semaphore/semaphore.yml
@@ -8,9 +8,6 @@ execution_time_limit:
 blocks:
   - name: "Install"
     task:
-      agent:
-        machine:
-          type: s1-prod-ubuntu24-04-arm64-1
       env_vars: &env_vars
         - name: MVN
           value: "mvn -B"

--- a/.semaphore/semaphore.yml
+++ b/.semaphore/semaphore.yml
@@ -11,7 +11,7 @@ blocks:
     task:
       agent:
         machine:
-          type: s1-prod-ubuntu24-04-arm64-1
+          type: s1-prod-ubuntu24-04-arm64-2
       env_vars: &env_vars
         - name: MVN
           value: "mvn -B"

--- a/.semaphore/semaphore.yml
+++ b/.semaphore/semaphore.yml
@@ -2,7 +2,7 @@ version: v1.0
 name: Apache Druid
 agent:
   machine:
-    type: s1-prod-ubuntu24-04-amd64-3
+    type: s1-prod-ubuntu24-04-arm64-1
 execution_time_limit:
   hours: 5
 blocks:

--- a/.semaphore/semaphore.yml
+++ b/.semaphore/semaphore.yml
@@ -8,6 +8,9 @@ execution_time_limit:
 blocks:
   - name: "Install"
     task:
+      agent:
+        machine:
+          type: s1-prod-ubuntu24-04-arm64-1
       env_vars: &env_vars
         - name: MVN
           value: "mvn -B"


### PR DESCRIPTION
This changes the Semaphore pipeline to use smaller agents. This will save on costs. The pipeline duration is similar.