### PR TITLE
[OBSDATA-11562] Sync KafkaHeaderBasedFilter Feature with upstream PR

### DIFF
--- a/docs/ingestion/kafka-ingestion.md
+++ b/docs/ingestion/kafka-ingestion.md
@@ -125,7 +125,7 @@ For configuration properties shared across all streaming ingestion methods, refe
 |`consumerProperties`|String, Object|A map of properties to pass to the Kafka consumer. See [Consumer properties](#consumer-properties) for details.|Yes. At the minimum, you must set the `bootstrap.servers` property to establish the initial connection to the Kafka cluster.||
 |`pollTimeout`|Long|The length of time to wait for the Kafka consumer to poll records, in milliseconds.|No|100|
 |`useEarliestOffset`|Boolean|If a supervisor is managing a datasource for the first time, it obtains a set of starting offsets from Kafka. This flag determines whether the supervisor retrieves the earliest or latest offsets in Kafka. Under normal circumstances, subsequent tasks start from where the previous segments ended so this flag is only used on the first run.|No|`false`|
-|`headerBasedInclusionConfig`|Object|Configuration for including Kafka records based on their headers before ingestion. See [Header-based inclusion filtering](#header-based-inclusion-filtering) for more details.|No|null|
+|`headerBasedFilterConfig`|Object|Configuration for including Kafka records based on their headers before ingestion. See [Header-based inclusion filtering](#header-based-inclusion-filtering) for more details.|No|null|
 |`idleConfig`|Object|Defines how and when the Kafka supervisor can become idle. See [Idle configuration](#idle-configuration) for more details.|No|null|
 
 #### Ingest from multiple topics
@@ -269,7 +269,7 @@ The following example shows a supervisor spec with idle configuration enabled:
 
 Header-based inclusion filtering allows you to include only specific Kafka records based on their headers before ingestion, reducing the amount of data processed and improving ingestion performance. This is particularly useful when you want to ingest only a subset of records from a Kafka topic based on header values.
 
-The following table outlines the configuration options for `headerBasedInclusionConfig`:
+The following table outlines the configuration options for `headerBasedFilterConfig`:
 
 |Property|Type|Description|Required|Default|
 |--------|----|-----------|--------|-------|
@@ -326,7 +326,7 @@ The following example shows how to configure header-based inclusion filtering to
       "consumerProperties": {
         "bootstrap.servers": "localhost:9092"
       },
-      "headerBasedInclusionConfig": {
+      "headerBasedFilterConfig": {
         "filter": {
           "type": "in",
           "dimension": "environment",

--- a/extensions-core/kafka-indexing-service/src/main/java/org/apache/druid/indexing/kafka/HeaderFilterHandler.java
+++ b/extensions-core/kafka-indexing-service/src/main/java/org/apache/druid/indexing/kafka/HeaderFilterHandler.java
@@ -1,0 +1,52 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+package org.apache.druid.indexing.kafka;
+
+/**
+ * Interface for handling different filter types in Kafka header evaluation.
+ *
+ * This provides an extensible way to support various Druid filter types for
+ * header-based filtering without modifying the core evaluation logic.
+ */
+public interface HeaderFilterHandler
+{
+  /**
+   * Gets the header name/key to evaluate from the filter.
+   *
+   * @return the header name to look for in Kafka message headers
+   */
+  String getHeaderName();
+
+  /**
+   * Evaluates whether a record should be included based on the header value.
+   *
+   * @param headerValue the decoded header value (guaranteed to be non-null when called)
+   * @return true if the record should be included, false if it should be filtered out
+   */
+  boolean shouldInclude(String headerValue);
+
+  /**
+   * Gets a human-readable description of this filter for logging and debugging.
+   *
+   * @return a descriptive string representation of the filter
+   */
+  String getDescription();
+
+}

--- a/extensions-core/kafka-indexing-service/src/main/java/org/apache/druid/indexing/kafka/HeaderFilterHandlerFactory.java
+++ b/extensions-core/kafka-indexing-service/src/main/java/org/apache/druid/indexing/kafka/HeaderFilterHandlerFactory.java
@@ -1,0 +1,57 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+package org.apache.druid.indexing.kafka;
+
+import org.apache.druid.query.filter.Filter;
+import org.apache.druid.query.filter.InDimFilter;
+
+/**
+ * Factory for creating HeaderFilterHandler instances.
+ *
+ * This factory uses explicit instanceof checks for clarity and performance,
+ * making it easy to add support for new filter types by simply adding
+ * new conditional branches.
+ */
+public final class HeaderFilterHandlerFactory
+{
+  private HeaderFilterHandlerFactory()
+  {
+    // Utility class - prevent instantiation
+  }
+
+  /**
+   * Creates the appropriate handler for the given filter.
+   *
+   * @param filter the Druid filter to create a handler for
+   * @return a HeaderFilterHandler that can evaluate the given filter type
+   * @throws IllegalArgumentException if the filter type is not supported
+   */
+  public static HeaderFilterHandler forFilter(Filter filter)
+  {
+    if (filter instanceof InDimFilter) {
+      return new InDimFilterHandler((InDimFilter) filter);
+    }
+
+    throw new IllegalArgumentException(
+        "Unsupported filter type for header filtering: " + filter.getClass().getSimpleName() +
+        ". Supported types: InDimFilter"
+    );
+  }
+}

--- a/extensions-core/kafka-indexing-service/src/main/java/org/apache/druid/indexing/kafka/InDimFilterHandler.java
+++ b/extensions-core/kafka-indexing-service/src/main/java/org/apache/druid/indexing/kafka/InDimFilterHandler.java
@@ -1,0 +1,78 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+package org.apache.druid.indexing.kafka;
+
+import com.google.common.base.Preconditions;
+import org.apache.druid.java.util.common.StringUtils;
+import org.apache.druid.query.filter.InDimFilter;
+
+import javax.annotation.Nullable;
+import java.util.HashSet;
+import java.util.Set;
+
+/**
+ * Handler for InDimFilter in Kafka header evaluation.
+ *
+ * This handler evaluates whether a header value is contained in the filter's value set.
+ * It uses a HashSet for O(1) average-case lookup performance instead of the filter's
+ * internal TreeSet which has O(log n) lookup time.
+ */
+public class InDimFilterHandler implements HeaderFilterHandler
+{
+  private final InDimFilter filter;
+  private final Set<String> filterValues;
+
+  /**
+   * Creates a new handler for the given InDimFilter.
+   *
+   * @param filter the InDimFilter to handle, must not be null
+   * @throws IllegalArgumentException if filter is null
+   */
+  public InDimFilterHandler(InDimFilter filter)
+  {
+    this.filter = Preconditions.checkNotNull(filter, "filter cannot be null");
+
+    // Convert to HashSet for O(1) lookups instead of O(log n) TreeSet lookups
+    // This optimization is particularly beneficial when the filter has many values
+    this.filterValues = new HashSet<>(filter.getValues());
+  }
+
+  @Override
+  public String getHeaderName()
+  {
+    return filter.getDimension();
+  }
+
+  @Override
+  public boolean shouldInclude(@Nullable String headerValue)
+  {
+    return filterValues.contains(headerValue);
+  }
+
+  @Override
+  public String getDescription()
+  {
+    return StringUtils.format(
+        "InDimFilter[header=%s, values=%d]",
+        filter.getDimension(),
+        filterValues.size()
+    );
+  }
+}

--- a/extensions-core/kafka-indexing-service/src/main/java/org/apache/druid/indexing/kafka/KafkaHeaderBasedFilterEvaluator.java
+++ b/extensions-core/kafka-indexing-service/src/main/java/org/apache/druid/indexing/kafka/KafkaHeaderBasedFilterEvaluator.java
@@ -24,7 +24,6 @@ import com.github.benmanes.caffeine.cache.Caffeine;
 import org.apache.druid.indexing.kafka.supervisor.KafkaHeaderBasedFilterConfig;
 import org.apache.druid.java.util.common.logger.Logger;
 import org.apache.druid.query.filter.Filter;
-import org.apache.druid.query.filter.InDimFilter;
 import org.apache.kafka.clients.consumer.ConsumerRecord;
 import org.apache.kafka.common.header.Header;
 import org.apache.kafka.common.header.Headers;
@@ -33,8 +32,6 @@ import javax.annotation.Nullable;
 
 import java.nio.ByteBuffer;
 import java.nio.charset.Charset;
-import java.util.HashSet;
-import java.util.Set;
 
 /**
  * Evaluates Kafka header filters for pre-ingestion filtering.
@@ -43,11 +40,17 @@ public class KafkaHeaderBasedFilterEvaluator
 {
   private static final Logger log = new Logger(KafkaHeaderBasedFilterEvaluator.class);
 
-  private final Filter filter;
+  private final HeaderFilterHandler filterHandler;
+  private final String headerName;
   private final Charset encoding;
   private final Cache<ByteBuffer, String> stringDecodingCache;
-  private final Set<String> filterValues;
 
+  /**
+   * Creates a new KafkaHeaderBasedFilterEvaluator with the given configuration.
+   *
+   * @param headerBasedFilterConfig the configuration containing filter, encoding, and cache settings
+   * @throws IllegalArgumentException if the filter type is not supported
+   */
   public KafkaHeaderBasedFilterEvaluator(KafkaHeaderBasedFilterConfig headerBasedFilterConfig)
   {
     this.encoding = Charset.forName(headerBasedFilterConfig.getEncoding());
@@ -55,21 +58,14 @@ public class KafkaHeaderBasedFilterEvaluator
         .maximumSize(headerBasedFilterConfig.getStringDecodingCacheSize())
         .build();
 
-    this.filter = headerBasedFilterConfig.getFilter().toFilter();
-    if (!(filter instanceof InDimFilter)) {
-      // Only InDimFilter supported
-      throw new IllegalStateException("Unsupported filter type: " + filter.getClass().getSimpleName());
-    }
+    Filter filter = headerBasedFilterConfig.getFilter().toFilter();
+    this.filterHandler = HeaderFilterHandlerFactory.forFilter(filter);
+    this.headerName = filterHandler.getHeaderName();
 
-    // Convert SortedSet to HashSet for O(1) lookups instead of O(log n) TreeSet lookups
-    InDimFilter inFilter = (InDimFilter) filter;
-    this.filterValues = new HashSet<>(inFilter.getValues());
-
-    log.info("Initialized Kafka header filter with encoding [%s] - direct evaluation for [%s] with Caffeine string cache (max %d entries) and HashSet lookup (%d filter values)",
-             headerBasedFilterConfig.getEncoding(),
-             this.filter.getClass().getSimpleName(),
-             headerBasedFilterConfig.getStringDecodingCacheSize(),
-             this.filterValues.size());
+    log.info("Initialized Kafka header filter: %s with encoding [%s] and cache size [%d]",
+            filterHandler.getDescription(),
+            headerBasedFilterConfig.getEncoding(),
+            headerBasedFilterConfig.getStringDecodingCacheSize());
   }
 
 
@@ -96,16 +92,25 @@ public class KafkaHeaderBasedFilterEvaluator
     }
   }
 
+  /**
+   * Evaluates whether a record should be included based on its headers.
+   * 
+   * Uses permissive behavior: records with missing, null, or undecodable headers
+   * are included by default. Only records with successfully decoded header values
+   * that don't match the filter criteria are excluded.
+   * 
+   * @param headers the Kafka message headers to evaluate
+   * @return true if the record should be included, false if it should be filtered out
+   */
   private boolean evaluateInclusion(Headers headers)
   {
-    InDimFilter inFilter = (InDimFilter) filter;
-
     // Permissive behavior: missing headers result in inclusion
     if (headers == null) {
       return true;
     }
 
-    Header header = headers.lastHeader(inFilter.getDimension());
+    Header header = headers.lastHeader(headerName);
+    
     // Permissive behavior: header is null or empty
     if (header == null || header.value() == null) {
       return true;
@@ -117,7 +122,7 @@ public class KafkaHeaderBasedFilterEvaluator
       return true;
     }
 
-    return filterValues.contains(headerValue);
+    return filterHandler.shouldInclude(headerValue);
   }
 
 

--- a/extensions-core/kafka-indexing-service/src/main/java/org/apache/druid/indexing/kafka/KafkaHeaderBasedFilterEvaluator.java
+++ b/extensions-core/kafka-indexing-service/src/main/java/org/apache/druid/indexing/kafka/KafkaHeaderBasedFilterEvaluator.java
@@ -21,7 +21,7 @@ package org.apache.druid.indexing.kafka;
 
 import com.github.benmanes.caffeine.cache.Cache;
 import com.github.benmanes.caffeine.cache.Caffeine;
-import org.apache.druid.indexing.kafka.supervisor.KafkaHeaderBasedInclusionConfig;
+import org.apache.druid.indexing.kafka.supervisor.KafkaHeaderBasedFilterConfig;
 import org.apache.druid.java.util.common.logger.Logger;
 import org.apache.druid.query.filter.Filter;
 import org.apache.druid.query.filter.InDimFilter;
@@ -48,14 +48,14 @@ public class KafkaHeaderBasedFilterEvaluator
   private final Cache<ByteBuffer, String> stringDecodingCache;
   private final Set<String> filterValues;
 
-  public KafkaHeaderBasedFilterEvaluator(KafkaHeaderBasedInclusionConfig headerBasedInclusionConfig)
+  public KafkaHeaderBasedFilterEvaluator(KafkaHeaderBasedFilterConfig headerBasedFilterConfig)
   {
-    this.encoding = Charset.forName(headerBasedInclusionConfig.getEncoding());
+    this.encoding = Charset.forName(headerBasedFilterConfig.getEncoding());
     this.stringDecodingCache = Caffeine.newBuilder()
-        .maximumSize(headerBasedInclusionConfig.getStringDecodingCacheSize())
+        .maximumSize(headerBasedFilterConfig.getStringDecodingCacheSize())
         .build();
 
-    this.filter = headerBasedInclusionConfig.getFilter().toFilter();
+    this.filter = headerBasedFilterConfig.getFilter().toFilter();
     if (!(filter instanceof InDimFilter)) {
       // Only InDimFilter supported
       throw new IllegalStateException("Unsupported filter type: " + filter.getClass().getSimpleName());
@@ -66,9 +66,9 @@ public class KafkaHeaderBasedFilterEvaluator
     this.filterValues = new HashSet<>(inFilter.getValues());
 
     log.info("Initialized Kafka header filter with encoding [%s] - direct evaluation for [%s] with Caffeine string cache (max %d entries) and HashSet lookup (%d filter values)",
-             headerBasedInclusionConfig.getEncoding(),
+             headerBasedFilterConfig.getEncoding(),
              this.filter.getClass().getSimpleName(),
-             headerBasedInclusionConfig.getStringDecodingCacheSize(),
+             headerBasedFilterConfig.getStringDecodingCacheSize(),
              this.filterValues.size());
   }
 

--- a/extensions-core/kafka-indexing-service/src/main/java/org/apache/druid/indexing/kafka/KafkaIndexTask.java
+++ b/extensions-core/kafka-indexing-service/src/main/java/org/apache/druid/indexing/kafka/KafkaIndexTask.java
@@ -123,7 +123,7 @@ public class KafkaIndexTask extends SeekableStreamIndexTask<KafkaTopicPartition,
               configMapper,
               kafkaIndexTaskIOConfig.getConfigOverrides(),
               kafkaIndexTaskIOConfig.isMultiTopic(),
-              kafkaIndexTaskIOConfig.getheaderBasedInclusionConfig()
+              kafkaIndexTaskIOConfig.getheaderBasedFilterConfig()
           );
 
       if (toolbox.getMonitorScheduler() != null) {

--- a/extensions-core/kafka-indexing-service/src/main/java/org/apache/druid/indexing/kafka/KafkaIndexTaskIOConfig.java
+++ b/extensions-core/kafka-indexing-service/src/main/java/org/apache/druid/indexing/kafka/KafkaIndexTaskIOConfig.java
@@ -24,7 +24,7 @@ import com.fasterxml.jackson.annotation.JsonProperty;
 import com.google.common.base.Preconditions;
 import org.apache.druid.data.input.InputFormat;
 import org.apache.druid.data.input.kafka.KafkaTopicPartition;
-import org.apache.druid.indexing.kafka.supervisor.KafkaHeaderBasedInclusionConfig;
+import org.apache.druid.indexing.kafka.supervisor.KafkaHeaderBasedFilterConfig;
 import org.apache.druid.indexing.kafka.supervisor.KafkaSupervisorIOConfig;
 import org.apache.druid.indexing.seekablestream.SeekableStreamEndSequenceNumbers;
 import org.apache.druid.indexing.seekablestream.SeekableStreamIndexTaskIOConfig;
@@ -40,7 +40,7 @@ public class KafkaIndexTaskIOConfig extends SeekableStreamIndexTaskIOConfig<Kafk
   private final Map<String, Object> consumerProperties;
   private final long pollTimeout;
   private final KafkaConfigOverrides configOverrides;
-  private final KafkaHeaderBasedInclusionConfig headerBasedInclusionConfig;
+  private final KafkaHeaderBasedFilterConfig headerBasedFilterConfig;
 
   private final boolean multiTopic;
 
@@ -67,7 +67,7 @@ public class KafkaIndexTaskIOConfig extends SeekableStreamIndexTaskIOConfig<Kafk
       @JsonProperty("configOverrides") @Nullable KafkaConfigOverrides configOverrides,
       @JsonProperty("multiTopic") @Nullable Boolean multiTopic,
       @JsonProperty("refreshRejectionPeriodsInMinutes") Long refreshRejectionPeriodsInMinutes,
-      @JsonProperty("headerBasedInclusionConfig") @Nullable KafkaHeaderBasedInclusionConfig headerBasedInclusionConfig
+      @JsonProperty("headerBasedFilterConfig") @Nullable KafkaHeaderBasedFilterConfig headerBasedFilterConfig
   )
   {
     super(
@@ -87,7 +87,7 @@ public class KafkaIndexTaskIOConfig extends SeekableStreamIndexTaskIOConfig<Kafk
     this.consumerProperties = Preconditions.checkNotNull(consumerProperties, "consumerProperties");
     this.pollTimeout = pollTimeout != null ? pollTimeout : KafkaSupervisorIOConfig.DEFAULT_POLL_TIMEOUT_MILLIS;
     this.configOverrides = configOverrides;
-    this.headerBasedInclusionConfig = headerBasedInclusionConfig;
+    this.headerBasedFilterConfig = headerBasedFilterConfig;
     this.multiTopic = multiTopic != null ? multiTopic : KafkaSupervisorIOConfig.DEFAULT_IS_MULTI_TOPIC;
 
     final SeekableStreamEndSequenceNumbers<KafkaTopicPartition, Long> myEndSequenceNumbers = getEndSequenceNumbers();
@@ -115,7 +115,7 @@ public class KafkaIndexTaskIOConfig extends SeekableStreamIndexTaskIOConfig<Kafk
       InputFormat inputFormat,
       KafkaConfigOverrides configOverrides,
       Long refreshRejectionPeriodsInMinutes,
-      KafkaHeaderBasedInclusionConfig headerBasedInclusionConfig
+      KafkaHeaderBasedFilterConfig headerBasedFilterConfig
   )
   {
     this(
@@ -134,7 +134,7 @@ public class KafkaIndexTaskIOConfig extends SeekableStreamIndexTaskIOConfig<Kafk
         configOverrides,
         KafkaSupervisorIOConfig.DEFAULT_IS_MULTI_TOPIC,
         refreshRejectionPeriodsInMinutes,
-        headerBasedInclusionConfig
+        headerBasedFilterConfig
     );
   }
 
@@ -193,9 +193,9 @@ public class KafkaIndexTaskIOConfig extends SeekableStreamIndexTaskIOConfig<Kafk
 
   @JsonProperty
   @Nullable
-  public KafkaHeaderBasedInclusionConfig getheaderBasedInclusionConfig()
+  public KafkaHeaderBasedFilterConfig getheaderBasedFilterConfig()
   {
-    return headerBasedInclusionConfig;
+    return headerBasedFilterConfig;
   }
 
   @Override
@@ -212,7 +212,7 @@ public class KafkaIndexTaskIOConfig extends SeekableStreamIndexTaskIOConfig<Kafk
            ", minimumMessageTime=" + getMinimumMessageTime() +
            ", maximumMessageTime=" + getMaximumMessageTime() +
            ", configOverrides=" + getConfigOverrides() +
-           ", headerBasedInclusionConfig=" + getheaderBasedInclusionConfig() +
+           ", headerBasedFilterConfig=" + getheaderBasedFilterConfig() +
            ", multiTopic=" + multiTopic +
            '}';
   }

--- a/extensions-core/kafka-indexing-service/src/main/java/org/apache/druid/indexing/kafka/KafkaIndexTaskModule.java
+++ b/extensions-core/kafka-indexing-service/src/main/java/org/apache/druid/indexing/kafka/KafkaIndexTaskModule.java
@@ -26,7 +26,7 @@ import com.google.common.collect.ImmutableList;
 import com.google.inject.Binder;
 import org.apache.druid.data.input.kafka.KafkaTopicPartition;
 import org.apache.druid.data.input.kafkainput.KafkaInputFormat;
-import org.apache.druid.indexing.kafka.supervisor.KafkaHeaderBasedInclusionConfig;
+import org.apache.druid.indexing.kafka.supervisor.KafkaHeaderBasedFilterConfig;
 import org.apache.druid.indexing.kafka.supervisor.KafkaSupervisorSpec;
 import org.apache.druid.indexing.kafka.supervisor.KafkaSupervisorTuningConfig;
 import org.apache.druid.initialization.DruidModule;
@@ -53,7 +53,7 @@ public class KafkaIndexTaskModule implements DruidModule
                 new NamedType(KafkaSupervisorSpec.class, SCHEME),
                 new NamedType(KafkaSamplerSpec.class, SCHEME),
                 new NamedType(KafkaInputFormat.class, SCHEME),
-                new NamedType(KafkaHeaderBasedInclusionConfig.class, SCHEME)
+                new NamedType(KafkaHeaderBasedFilterConfig.class, SCHEME)
             )
             .addKeySerializer(KafkaTopicPartition.class, new KafkaTopicPartition.KafkaTopicPartitionKeySerializer())
     );

--- a/extensions-core/kafka-indexing-service/src/main/java/org/apache/druid/indexing/kafka/KafkaRecordSupplier.java
+++ b/extensions-core/kafka-indexing-service/src/main/java/org/apache/druid/indexing/kafka/KafkaRecordSupplier.java
@@ -27,7 +27,7 @@ import org.apache.druid.data.input.kafka.KafkaRecordEntity;
 import org.apache.druid.data.input.kafka.KafkaTopicPartition;
 import org.apache.druid.error.DruidException;
 import org.apache.druid.error.InvalidInput;
-import org.apache.druid.indexing.kafka.supervisor.KafkaHeaderBasedInclusionConfig;
+import org.apache.druid.indexing.kafka.supervisor.KafkaHeaderBasedFilterConfig;
 import org.apache.druid.indexing.kafka.supervisor.KafkaSupervisorIOConfig;
 import org.apache.druid.indexing.seekablestream.common.OrderedPartitionableRecord;
 import org.apache.druid.indexing.seekablestream.common.OrderedSequenceNumber;
@@ -99,7 +99,7 @@ public class KafkaRecordSupplier implements RecordSupplier<KafkaTopicPartition, 
       boolean multiTopic
   )
   {
-    this(getKafkaConsumer(sortingMapper, consumerProperties, configOverrides), multiTopic, (KafkaHeaderBasedInclusionConfig) null);
+    this(getKafkaConsumer(sortingMapper, consumerProperties, configOverrides), multiTopic, (KafkaHeaderBasedFilterConfig) null);
   }
 
   public KafkaRecordSupplier(
@@ -107,30 +107,30 @@ public class KafkaRecordSupplier implements RecordSupplier<KafkaTopicPartition, 
       ObjectMapper sortingMapper,
       KafkaConfigOverrides configOverrides,
       boolean multiTopic,
-      @Nullable KafkaHeaderBasedInclusionConfig headerBasedInclusionConfig
+      @Nullable KafkaHeaderBasedFilterConfig headerBasedFilterConfig
   )
   {
-    this(getKafkaConsumer(sortingMapper, consumerProperties, configOverrides), multiTopic, headerBasedInclusionConfig);
+    this(getKafkaConsumer(sortingMapper, consumerProperties, configOverrides), multiTopic, headerBasedFilterConfig);
   }
 
   @VisibleForTesting
   public KafkaRecordSupplier(KafkaConsumer<byte[], byte[]> consumer, boolean multiTopic)
   {
-    this(consumer, multiTopic, (KafkaHeaderBasedInclusionConfig) null);
+    this(consumer, multiTopic, (KafkaHeaderBasedFilterConfig) null);
   }
 
   @VisibleForTesting
   public KafkaRecordSupplier(
       KafkaConsumer<byte[], byte[]> consumer,
       boolean multiTopic,
-      @Nullable KafkaHeaderBasedInclusionConfig headerBasedInclusionConfig
+      @Nullable KafkaHeaderBasedFilterConfig headerBasedFilterConfig
   )
   {
     this.consumer = consumer;
     this.multiTopic = multiTopic;
     this.monitor = new KafkaConsumerMonitor(consumer);
-    this.headerFilterEvaluator = headerBasedInclusionConfig != null ?
-        new KafkaHeaderBasedFilterEvaluator(headerBasedInclusionConfig) : null;
+    this.headerFilterEvaluator = headerBasedFilterConfig != null ?
+        new KafkaHeaderBasedFilterEvaluator(headerBasedFilterConfig) : null;
   }
 
   @Override
@@ -213,18 +213,17 @@ public class KafkaRecordSupplier implements RecordSupplier<KafkaTopicPartition, 
             record.timestamp(),
             true // Mark as filtered
         ));
-        continue;
+      } else {
+        // Create record for accepted records
+        polledRecords.add(new OrderedPartitionableRecord<>(
+                record.topic(),
+                kafkaPartition,
+                record.offset(),
+                record.value() == null ? null : ImmutableList.of(new KafkaRecordEntity(record)),
+                record.timestamp(),
+                false
+        ));
       }
-
-      // Create record for accepted records
-      polledRecords.add(new OrderedPartitionableRecord<>(
-          record.topic(),
-          kafkaPartition,
-          record.offset(),
-          record.value() == null ? null : ImmutableList.of(new KafkaRecordEntity(record)),
-          record.timestamp(),
-          false
-      ));
     }
 
     return polledRecords;

--- a/extensions-core/kafka-indexing-service/src/main/java/org/apache/druid/indexing/kafka/supervisor/KafkaHeaderBasedFilterConfig.java
+++ b/extensions-core/kafka-indexing-service/src/main/java/org/apache/druid/indexing/kafka/supervisor/KafkaHeaderBasedFilterConfig.java
@@ -36,7 +36,7 @@ import java.nio.charset.StandardCharsets;
  * Kafka-specific implementation of header-based filtering.
  * Allows filtering Kafka records based on message headers before deserialization.
  */
-public class KafkaHeaderBasedInclusionConfig
+public class KafkaHeaderBasedFilterConfig
 {
   private static final ImmutableSet<Class<? extends DimFilter>> SUPPORTED_FILTER_TYPES = ImmutableSet.of(
       InDimFilter.class
@@ -47,7 +47,7 @@ public class KafkaHeaderBasedInclusionConfig
   private final int stringDecodingCacheSize;
 
   @JsonCreator
-  public KafkaHeaderBasedInclusionConfig(
+  public KafkaHeaderBasedFilterConfig(
       @JsonProperty("filter") DimFilter filter,
       @JsonProperty("encoding") @Nullable String encoding,
       @JsonProperty("stringDecodingCacheSize") @Nullable Integer stringDecodingCacheSize
@@ -110,7 +110,7 @@ public class KafkaHeaderBasedInclusionConfig
     if (o == null || getClass() != o.getClass()) {
       return false;
     }
-    KafkaHeaderBasedInclusionConfig that = (KafkaHeaderBasedInclusionConfig) o;
+    KafkaHeaderBasedFilterConfig that = (KafkaHeaderBasedFilterConfig) o;
     return stringDecodingCacheSize == that.stringDecodingCacheSize &&
            filter.equals(that.filter) &&
            encoding.equals(that.encoding);
@@ -128,7 +128,7 @@ public class KafkaHeaderBasedInclusionConfig
   @Override
   public String toString()
   {
-    return "KafkaheaderBasedInclusionConfig{" +
+    return "KafkaheaderBasedFilterConfig{" +
            "filter=" + filter +
            ", encoding='" + encoding + '\'' +
            ", stringDecodingCacheSize=" + stringDecodingCacheSize +

--- a/extensions-core/kafka-indexing-service/src/main/java/org/apache/druid/indexing/kafka/supervisor/KafkaSupervisor.java
+++ b/extensions-core/kafka-indexing-service/src/main/java/org/apache/druid/indexing/kafka/supervisor/KafkaSupervisor.java
@@ -132,7 +132,7 @@ public class KafkaSupervisor extends SeekableStreamSupervisor<KafkaTopicPartitio
         sortingMapper,
         spec.getIoConfig().getConfigOverrides(),
         spec.getIoConfig().isMultiTopic(),
-        spec.getIoConfig().getheaderBasedInclusionConfig()
+        spec.getIoConfig().getheaderBasedFilterConfig()
     );
   }
 
@@ -222,7 +222,7 @@ public class KafkaSupervisor extends SeekableStreamSupervisor<KafkaTopicPartitio
         kafkaIoConfig.getConfigOverrides(),
         kafkaIoConfig.isMultiTopic(),
         ioConfig.getTaskDuration().getStandardMinutes(),
-        kafkaIoConfig.getheaderBasedInclusionConfig()
+        kafkaIoConfig.getheaderBasedFilterConfig()
     );
   }
 

--- a/extensions-core/kafka-indexing-service/src/main/java/org/apache/druid/indexing/kafka/supervisor/KafkaSupervisorIOConfig.java
+++ b/extensions-core/kafka-indexing-service/src/main/java/org/apache/druid/indexing/kafka/supervisor/KafkaSupervisorIOConfig.java
@@ -54,7 +54,7 @@ public class KafkaSupervisorIOConfig extends SeekableStreamSupervisorIOConfig
   private final String topic;
   private final String topicPattern;
   private final boolean emitTimeLagMetrics;
-  private final KafkaHeaderBasedInclusionConfig headerBasedInclusionConfig;
+  private final KafkaHeaderBasedFilterConfig headerBasedFilterConfig;
 
   @JsonCreator
   public KafkaSupervisorIOConfig(
@@ -76,7 +76,7 @@ public class KafkaSupervisorIOConfig extends SeekableStreamSupervisorIOConfig
       @JsonProperty("earlyMessageRejectionPeriod") Period earlyMessageRejectionPeriod,
       @JsonProperty("lateMessageRejectionStartDateTime") DateTime lateMessageRejectionStartDateTime,
       @JsonProperty("configOverrides") KafkaConfigOverrides configOverrides,
-      @JsonProperty("headerBasedInclusionConfig") KafkaHeaderBasedInclusionConfig headerBasedInclusionConfig,
+      @JsonProperty("headerBasedFilterConfig") KafkaHeaderBasedFilterConfig headerBasedFilterConfig,
       @JsonProperty("idleConfig") IdleConfig idleConfig,
       @JsonProperty("stopTaskCount") Integer stopTaskCount,
       @Nullable @JsonProperty("emitTimeLagMetrics") Boolean emitTimeLagMetrics
@@ -101,7 +101,7 @@ public class KafkaSupervisorIOConfig extends SeekableStreamSupervisorIOConfig
         stopTaskCount
     );
 
-    this.headerBasedInclusionConfig = headerBasedInclusionConfig;
+    this.headerBasedFilterConfig = headerBasedFilterConfig;
     this.consumerProperties = Preconditions.checkNotNull(consumerProperties, "consumerProperties");
     Preconditions.checkNotNull(
         consumerProperties.get(BOOTSTRAP_SERVERS_KEY),
@@ -172,9 +172,9 @@ public class KafkaSupervisorIOConfig extends SeekableStreamSupervisorIOConfig
 
   @JsonProperty
   @Nullable
-  public KafkaHeaderBasedInclusionConfig getheaderBasedInclusionConfig()
+  public KafkaHeaderBasedFilterConfig getheaderBasedFilterConfig()
   {
-    return headerBasedInclusionConfig;
+    return headerBasedFilterConfig;
   }
 
 
@@ -198,7 +198,7 @@ public class KafkaSupervisorIOConfig extends SeekableStreamSupervisorIOConfig
            ", lateMessageRejectionPeriod=" + getLateMessageRejectionPeriod() +
            ", lateMessageRejectionStartDateTime=" + getLateMessageRejectionStartDateTime() +
            ", configOverrides=" + getConfigOverrides() +
-           ", headerBasedInclusionConfig=" + headerBasedInclusionConfig +
+           ", headerBasedFilterConfig=" + headerBasedFilterConfig +
            ", idleConfig=" + getIdleConfig() +
            ", stopTaskCount=" + getStopTaskCount() +
            '}';

--- a/extensions-core/kafka-indexing-service/src/test/java/org/apache/druid/indexing/kafka/HeaderFilterHandlerTest.java
+++ b/extensions-core/kafka-indexing-service/src/test/java/org/apache/druid/indexing/kafka/HeaderFilterHandlerTest.java
@@ -1,0 +1,79 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+package org.apache.druid.indexing.kafka;
+
+import com.google.common.collect.ImmutableSet;
+import org.apache.druid.query.filter.Filter;
+import org.apache.druid.query.filter.InDimFilter;
+import org.apache.druid.query.filter.TrueDimFilter;
+import org.junit.Assert;
+import org.junit.Test;
+
+public class HeaderFilterHandlerTest
+{
+  @Test
+  public void testInDimFilterHandler()
+  {
+    // Create an InDimFilter for testing
+    InDimFilter filter = new InDimFilter("environment", ImmutableSet.of("production", "staging"));
+
+    // Create handler using our extensible factory
+    HeaderFilterHandler handler = HeaderFilterHandlerFactory.forFilter(filter);
+
+    // Verify it's the correct type
+    Assert.assertTrue("Handler should be InDimFilterHandler", handler instanceof InDimFilterHandler);
+
+    // Test header name extraction
+    Assert.assertEquals("environment", handler.getHeaderName());
+
+    // Test matching values
+    Assert.assertTrue("Production should be included", handler.shouldInclude("production"));
+    Assert.assertTrue("Staging should be included", handler.shouldInclude("staging"));
+
+    // Test non-matching values
+    Assert.assertFalse("Development should be excluded", handler.shouldInclude("development"));
+    Assert.assertFalse("Test should be excluded", handler.shouldInclude("test"));
+
+    // Test description
+    String description = handler.getDescription();
+    Assert.assertTrue("Description should contain filter type", description.contains("InDimFilter"));
+    Assert.assertTrue("Description should contain header name", description.contains("environment"));
+    Assert.assertTrue("Description should contain value count", description.contains("2"));
+  }
+
+  @Test
+  public void testUnsupportedFilterType()
+  {
+    // Create a mock filter that's not supported
+    Filter unsupportedFilter = TrueDimFilter.instance().toFilter();
+
+    // Should throw IllegalArgumentException
+    try {
+      HeaderFilterHandlerFactory.forFilter(unsupportedFilter);
+      Assert.fail("Should have thrown IllegalArgumentException for unsupported filter type");
+    }
+    catch (IllegalArgumentException e) {
+      Assert.assertTrue("Error message should mention unsupported type",
+                       e.getMessage().contains("Unsupported filter type"));
+      Assert.assertTrue("Error message should mention True",
+                       e.getMessage().contains("True"));
+    }
+  }
+}

--- a/extensions-core/kafka-indexing-service/src/test/java/org/apache/druid/indexing/kafka/KafkaHeaderBasedFilterConfigEvaluatorTest.java
+++ b/extensions-core/kafka-indexing-service/src/test/java/org/apache/druid/indexing/kafka/KafkaHeaderBasedFilterConfigEvaluatorTest.java
@@ -19,7 +19,7 @@
 
 package org.apache.druid.indexing.kafka;
 
-import org.apache.druid.indexing.kafka.supervisor.KafkaHeaderBasedInclusionConfig;
+import org.apache.druid.indexing.kafka.supervisor.KafkaHeaderBasedFilterConfig;
 import org.apache.druid.math.expr.ExpressionProcessing;
 import org.apache.druid.query.filter.InDimFilter;
 import org.apache.kafka.clients.consumer.ConsumerRecord;
@@ -35,7 +35,7 @@ import java.nio.charset.StandardCharsets;
 import java.util.Arrays;
 import java.util.Collections;
 
-public class KafkaHeaderBasedInclusionConfigEvaluatorTest
+public class KafkaHeaderBasedFilterConfigEvaluatorTest
 {
   private KafkaHeaderBasedFilterEvaluator evaluator;
   private ConsumerRecord<byte[], byte[]> record;
@@ -78,7 +78,7 @@ public class KafkaHeaderBasedInclusionConfigEvaluatorTest
   public void testInFilterSingleValueMatch()
   {
     InDimFilter filter = new InDimFilter("environment", Collections.singletonList("production"), null);
-    evaluator = new KafkaHeaderBasedFilterEvaluator(new KafkaHeaderBasedInclusionConfig(filter, null, null));
+    evaluator = new KafkaHeaderBasedFilterEvaluator(new KafkaHeaderBasedFilterConfig(filter, null, null));
 
     Assert.assertTrue(evaluator.shouldIncludeRecord(record));
   }
@@ -87,7 +87,7 @@ public class KafkaHeaderBasedInclusionConfigEvaluatorTest
   public void testInFilterSingleValueNoMatch()
   {
     InDimFilter filter = new InDimFilter("environment", Collections.singletonList("staging"), null);
-    evaluator = new KafkaHeaderBasedFilterEvaluator(new KafkaHeaderBasedInclusionConfig(filter, null, null));
+    evaluator = new KafkaHeaderBasedFilterEvaluator(new KafkaHeaderBasedFilterConfig(filter, null, null));
 
     Assert.assertFalse(evaluator.shouldIncludeRecord(record));
   }
@@ -96,7 +96,7 @@ public class KafkaHeaderBasedInclusionConfigEvaluatorTest
   public void testInFilterMultipleValuesMatch()
   {
     InDimFilter filter = new InDimFilter("environment", Arrays.asList("staging", "production", "development"), null);
-    evaluator = new KafkaHeaderBasedFilterEvaluator(new KafkaHeaderBasedInclusionConfig(filter, null, null));
+    evaluator = new KafkaHeaderBasedFilterEvaluator(new KafkaHeaderBasedFilterConfig(filter, null, null));
 
     Assert.assertTrue(evaluator.shouldIncludeRecord(record));
   }
@@ -105,7 +105,7 @@ public class KafkaHeaderBasedInclusionConfigEvaluatorTest
   public void testInFilterMultipleValuesNoMatch()
   {
     InDimFilter filter = new InDimFilter("environment", Arrays.asList("staging", "development"), null);
-    evaluator = new KafkaHeaderBasedFilterEvaluator(new KafkaHeaderBasedInclusionConfig(filter, null, null));
+    evaluator = new KafkaHeaderBasedFilterEvaluator(new KafkaHeaderBasedFilterConfig(filter, null, null));
 
     Assert.assertFalse(evaluator.shouldIncludeRecord(record));
   }
@@ -114,7 +114,7 @@ public class KafkaHeaderBasedInclusionConfigEvaluatorTest
   public void testInFilterMissingHeader()
   {
     InDimFilter filter = new InDimFilter("missing-header", Collections.singletonList("value"), null);
-    evaluator = new KafkaHeaderBasedFilterEvaluator(new KafkaHeaderBasedInclusionConfig(filter, null, null));
+    evaluator = new KafkaHeaderBasedFilterEvaluator(new KafkaHeaderBasedFilterConfig(filter, null, null));
 
     // With permissive filtering, missing headers should result in inclusion
     Assert.assertTrue("InDimFilter with missing header should include record (permissive)", evaluator.shouldIncludeRecord(record));
@@ -145,7 +145,7 @@ public class KafkaHeaderBasedInclusionConfigEvaluatorTest
     }
 
     InDimFilter filter = new InDimFilter("null-header", Collections.singletonList("value"), null);
-    evaluator = new KafkaHeaderBasedFilterEvaluator(new KafkaHeaderBasedInclusionConfig(filter, null, null));
+    evaluator = new KafkaHeaderBasedFilterEvaluator(new KafkaHeaderBasedFilterConfig(filter, null, null));
 
     Assert.assertTrue(evaluator.shouldIncludeRecord(nullRecord));
   }
@@ -154,7 +154,7 @@ public class KafkaHeaderBasedInclusionConfigEvaluatorTest
   public void testInFilterWithDifferentServices()
   {
     InDimFilter filter = new InDimFilter("service", Arrays.asList("user-service", "payment-service"), null);
-    evaluator = new KafkaHeaderBasedFilterEvaluator(new KafkaHeaderBasedInclusionConfig(filter, null, null));
+    evaluator = new KafkaHeaderBasedFilterEvaluator(new KafkaHeaderBasedFilterConfig(filter, null, null));
 
     Assert.assertTrue(evaluator.shouldIncludeRecord(record)); // matches "user-service"
   }
@@ -163,7 +163,7 @@ public class KafkaHeaderBasedInclusionConfigEvaluatorTest
   public void testInFilterWithDifferentServicesNoMatch()
   {
     InDimFilter filter = new InDimFilter("service", Arrays.asList("payment-service", "notification-service"), null);
-    evaluator = new KafkaHeaderBasedFilterEvaluator(new KafkaHeaderBasedInclusionConfig(filter, null, null));
+    evaluator = new KafkaHeaderBasedFilterEvaluator(new KafkaHeaderBasedFilterConfig(filter, null, null));
 
     Assert.assertFalse(evaluator.shouldIncludeRecord(record)); // doesn't match "user-service"
   }
@@ -172,7 +172,7 @@ public class KafkaHeaderBasedInclusionConfigEvaluatorTest
   public void testRepeatedEvaluations()
   {
     InDimFilter filter = new InDimFilter("environment", Collections.singletonList("production"), null);
-    evaluator = new KafkaHeaderBasedFilterEvaluator(new KafkaHeaderBasedInclusionConfig(filter, null, null));
+    evaluator = new KafkaHeaderBasedFilterEvaluator(new KafkaHeaderBasedFilterConfig(filter, null, null));
 
     // Test multiple evaluations to verify consistent behavior
     boolean result1 = evaluator.shouldIncludeRecord(record); // should match
@@ -210,7 +210,7 @@ public class KafkaHeaderBasedInclusionConfigEvaluatorTest
     }
 
     InDimFilter filter = new InDimFilter("text", Collections.singletonList(testValue), null);
-    evaluator = new KafkaHeaderBasedFilterEvaluator(new KafkaHeaderBasedInclusionConfig(filter, "ISO-8859-1", null));
+    evaluator = new KafkaHeaderBasedFilterEvaluator(new KafkaHeaderBasedFilterConfig(filter, "ISO-8859-1", null));
 
     Assert.assertTrue(evaluator.shouldIncludeRecord(encodedRecord));
   }
@@ -240,7 +240,7 @@ public class KafkaHeaderBasedInclusionConfigEvaluatorTest
     }
 
     InDimFilter filter = new InDimFilter("environment", Collections.singletonList("production"), null);
-    evaluator = new KafkaHeaderBasedFilterEvaluator(new KafkaHeaderBasedInclusionConfig(filter, null, null));
+    evaluator = new KafkaHeaderBasedFilterEvaluator(new KafkaHeaderBasedFilterConfig(filter, null, null));
 
     // Missing header should result in inclusion (permissive behavior)
     Assert.assertTrue(evaluator.shouldIncludeRecord(noHeaderRecord));
@@ -273,12 +273,12 @@ public class KafkaHeaderBasedInclusionConfigEvaluatorTest
 
     // Filter should match "production" (the last value), not "staging" (the first value)
     InDimFilter prodFilter = new InDimFilter("environment", Collections.singletonList("production"), null);
-    evaluator = new KafkaHeaderBasedFilterEvaluator(new KafkaHeaderBasedInclusionConfig(prodFilter, null, null));
+    evaluator = new KafkaHeaderBasedFilterEvaluator(new KafkaHeaderBasedFilterConfig(prodFilter, null, null));
     Assert.assertTrue("Should match last header value 'production'", evaluator.shouldIncludeRecord(multiHeaderRecord));
 
     // Filter should NOT match "staging" (the first value)
     InDimFilter stagingFilter = new InDimFilter("environment", Collections.singletonList("staging"), null);
-    evaluator = new KafkaHeaderBasedFilterEvaluator(new KafkaHeaderBasedInclusionConfig(stagingFilter, null, null));
+    evaluator = new KafkaHeaderBasedFilterEvaluator(new KafkaHeaderBasedFilterConfig(stagingFilter, null, null));
     Assert.assertFalse("Should not match first header value 'staging'", evaluator.shouldIncludeRecord(multiHeaderRecord));
   }
 
@@ -286,7 +286,7 @@ public class KafkaHeaderBasedInclusionConfigEvaluatorTest
   public void testStringDecodingCacheSize()
   {
     InDimFilter filter = new InDimFilter("environment", Collections.singletonList("production"), null);
-    evaluator = new KafkaHeaderBasedFilterEvaluator(new KafkaHeaderBasedInclusionConfig(filter, null, 50_000));
+    evaluator = new KafkaHeaderBasedFilterEvaluator(new KafkaHeaderBasedFilterConfig(filter, null, 50_000));
 
     // Test that the evaluator works with custom cache size
     Assert.assertTrue(evaluator.shouldIncludeRecord(record));

--- a/extensions-core/kafka-indexing-service/src/test/java/org/apache/druid/indexing/kafka/KafkaHeaderBasedFilterConfigIntegrationTest.java
+++ b/extensions-core/kafka-indexing-service/src/test/java/org/apache/druid/indexing/kafka/KafkaHeaderBasedFilterConfigIntegrationTest.java
@@ -20,7 +20,7 @@
 package org.apache.druid.indexing.kafka;
 
 import com.fasterxml.jackson.databind.ObjectMapper;
-import org.apache.druid.indexing.kafka.supervisor.KafkaHeaderBasedInclusionConfig;
+import org.apache.druid.indexing.kafka.supervisor.KafkaHeaderBasedFilterConfig;
 import org.apache.druid.jackson.DefaultObjectMapper;
 import org.apache.druid.math.expr.ExpressionProcessing;
 import org.apache.druid.query.filter.InDimFilter;
@@ -37,7 +37,7 @@ import java.nio.charset.StandardCharsets;
 import java.util.Arrays;
 import java.util.Collections;
 
-public class KafkaHeaderBasedInclusionConfigIntegrationTest
+public class KafkaHeaderBasedFilterConfigIntegrationTest
 {
   private KafkaHeaderBasedFilterEvaluator evaluator;
   private final ObjectMapper objectMapper = new DefaultObjectMapper();
@@ -91,7 +91,7 @@ public class KafkaHeaderBasedInclusionConfigIntegrationTest
   {
     // Test Case: Only include records from production environment
     InDimFilter filter = new InDimFilter("environment", Collections.singletonList("production"), null);
-    KafkaHeaderBasedInclusionConfig headerFilter = new KafkaHeaderBasedInclusionConfig(filter, null, null);
+    KafkaHeaderBasedFilterConfig headerFilter = new KafkaHeaderBasedFilterConfig(filter, null, null);
     evaluator = new KafkaHeaderBasedFilterEvaluator(headerFilter);
 
     // Production record - should be included
@@ -127,7 +127,7 @@ public class KafkaHeaderBasedInclusionConfigIntegrationTest
   {
     // Test Case: Include records from multiple services
     InDimFilter filter = new InDimFilter("service", Arrays.asList("user-service", "payment-service"), null);
-    KafkaHeaderBasedInclusionConfig headerFilter = new KafkaHeaderBasedInclusionConfig(filter, null, null);
+    KafkaHeaderBasedFilterConfig headerFilter = new KafkaHeaderBasedFilterConfig(filter, null, null);
     evaluator = new KafkaHeaderBasedFilterEvaluator(headerFilter);
 
     // User service record - should be included
@@ -171,7 +171,7 @@ public class KafkaHeaderBasedInclusionConfigIntegrationTest
         ),
         null
     );
-    KafkaHeaderBasedInclusionConfig headerFilter = new KafkaHeaderBasedInclusionConfig(filter, null, null);
+    KafkaHeaderBasedFilterConfig headerFilter = new KafkaHeaderBasedFilterConfig(filter, null, null);
     evaluator = new KafkaHeaderBasedFilterEvaluator(headerFilter);
 
     // Matching metric - should be included
@@ -198,7 +198,7 @@ public class KafkaHeaderBasedInclusionConfigIntegrationTest
   {
     // Test Case: Verify basic filtering behavior
     InDimFilter filter = new InDimFilter("environment", Collections.singletonList("production"), null);
-    KafkaHeaderBasedInclusionConfig headerFilter = new KafkaHeaderBasedInclusionConfig(filter, null, null);
+    KafkaHeaderBasedFilterConfig headerFilter = new KafkaHeaderBasedFilterConfig(filter, null, null);
     evaluator = new KafkaHeaderBasedFilterEvaluator(headerFilter);
 
     // Process multiple records to verify filtering logic
@@ -217,13 +217,13 @@ public class KafkaHeaderBasedInclusionConfigIntegrationTest
   {
     // Test that header filter configurations can be serialized/deserialized correctly
     InDimFilter filter = new InDimFilter("environment", Arrays.asList("production", "staging"), null);
-    KafkaHeaderBasedInclusionConfig originalFilter = new KafkaHeaderBasedInclusionConfig(filter, "UTF-16", null);
+    KafkaHeaderBasedFilterConfig originalFilter = new KafkaHeaderBasedFilterConfig(filter, "UTF-16", null);
 
     // Serialize to JSON
     String json = objectMapper.writeValueAsString(originalFilter);
 
     // Deserialize back
-    KafkaHeaderBasedInclusionConfig deserializedFilter = objectMapper.readValue(json, KafkaHeaderBasedInclusionConfig.class);
+    KafkaHeaderBasedFilterConfig deserializedFilter = objectMapper.readValue(json, KafkaHeaderBasedFilterConfig.class);
 
     // Verify they're equivalent
     Assert.assertEquals(originalFilter.getFilter(), deserializedFilter.getFilter());
@@ -243,7 +243,7 @@ public class KafkaHeaderBasedInclusionConfigIntegrationTest
     String testValue = "café"; // Contains non-ASCII characters
 
     InDimFilter filter = new InDimFilter("text", Collections.singletonList(testValue), null);
-    KafkaHeaderBasedInclusionConfig headerFilter = new KafkaHeaderBasedInclusionConfig(filter, "ISO-8859-1", null);
+    KafkaHeaderBasedFilterConfig headerFilter = new KafkaHeaderBasedFilterConfig(filter, "ISO-8859-1", null);
     evaluator = new KafkaHeaderBasedFilterEvaluator(headerFilter);
 
     // Create record with ISO-8859-1 encoded header
@@ -260,7 +260,7 @@ public class KafkaHeaderBasedInclusionConfigIntegrationTest
   {
     // Test with custom cache size
     InDimFilter filter = new InDimFilter("environment", Collections.singletonList("production"), null);
-    KafkaHeaderBasedInclusionConfig headerFilter = new KafkaHeaderBasedInclusionConfig(filter, null, 100_000);
+    KafkaHeaderBasedFilterConfig headerFilter = new KafkaHeaderBasedFilterConfig(filter, null, 100_000);
     evaluator = new KafkaHeaderBasedFilterEvaluator(headerFilter);
 
     ConsumerRecord<byte[], byte[]> record = createRecord("events", 0, 100L, headers("environment", "production"));

--- a/extensions-core/kafka-indexing-service/src/test/java/org/apache/druid/indexing/kafka/KafkaRecordSupplierHeaderFilterTest.java
+++ b/extensions-core/kafka-indexing-service/src/test/java/org/apache/druid/indexing/kafka/KafkaRecordSupplierHeaderFilterTest.java
@@ -21,7 +21,7 @@ package org.apache.druid.indexing.kafka;
 
 import org.apache.druid.data.input.kafka.KafkaRecordEntity;
 import org.apache.druid.data.input.kafka.KafkaTopicPartition;
-import org.apache.druid.indexing.kafka.supervisor.KafkaHeaderBasedInclusionConfig;
+import org.apache.druid.indexing.kafka.supervisor.KafkaHeaderBasedFilterConfig;
 import org.apache.druid.indexing.seekablestream.common.OrderedPartitionableRecord;
 import org.apache.druid.math.expr.ExpressionProcessing;
 import org.apache.druid.query.filter.InDimFilter;
@@ -97,7 +97,7 @@ public class KafkaRecordSupplierHeaderFilterTest
   {
     // Test filtering with in filter (single value)
     InDimFilter filter = new InDimFilter("environment", Collections.singletonList("production"), null);
-    KafkaHeaderBasedInclusionConfig headerFilter = new KafkaHeaderBasedInclusionConfig(filter, null, null);
+    KafkaHeaderBasedFilterConfig headerFilter = new KafkaHeaderBasedFilterConfig(filter, null, null);
 
     recordSupplier = new KafkaRecordSupplier(mockConsumer, false, headerFilter);
 
@@ -138,7 +138,7 @@ public class KafkaRecordSupplierHeaderFilterTest
   {
     // Test that filtered records are properly marked with filtered flag
     InDimFilter filter = new InDimFilter("environment", Collections.singletonList("production"), null);
-    KafkaHeaderBasedInclusionConfig headerFilter = new KafkaHeaderBasedInclusionConfig(filter, null, null);
+    KafkaHeaderBasedFilterConfig headerFilter = new KafkaHeaderBasedFilterConfig(filter, null, null);
 
     recordSupplier = new KafkaRecordSupplier(mockConsumer, false, headerFilter);
 
@@ -173,7 +173,7 @@ public class KafkaRecordSupplierHeaderFilterTest
   {
     // Test filtering with in filter (multiple values)
     InDimFilter filter = new InDimFilter("service", Arrays.asList("user-service", "payment-service"), null);
-    KafkaHeaderBasedInclusionConfig headerFilter = new KafkaHeaderBasedInclusionConfig(filter, null, null);
+    KafkaHeaderBasedFilterConfig headerFilter = new KafkaHeaderBasedFilterConfig(filter, null, null);
 
     recordSupplier = new KafkaRecordSupplier(mockConsumer, false, headerFilter);
 
@@ -214,7 +214,7 @@ public class KafkaRecordSupplierHeaderFilterTest
   {
     // Test InDimFilter with multiple possible values
     InDimFilter serviceFilter = new InDimFilter("service", Arrays.asList("user-service", "payment-service"), null);
-    KafkaHeaderBasedInclusionConfig headerFilter = new KafkaHeaderBasedInclusionConfig(serviceFilter, null, null);
+    KafkaHeaderBasedFilterConfig headerFilter = new KafkaHeaderBasedFilterConfig(serviceFilter, null, null);
 
     recordSupplier = new KafkaRecordSupplier(mockConsumer, false, headerFilter);
 
@@ -255,7 +255,7 @@ public class KafkaRecordSupplierHeaderFilterTest
   {
     // Test that statistics accumulate across multiple polls
     InDimFilter filter = new InDimFilter("environment", Collections.singletonList("production"), null);
-    KafkaHeaderBasedInclusionConfig headerFilter = new KafkaHeaderBasedInclusionConfig(filter, null, null);
+    KafkaHeaderBasedFilterConfig headerFilter = new KafkaHeaderBasedFilterConfig(filter, null, null);
 
     recordSupplier = new KafkaRecordSupplier(mockConsumer, false, headerFilter);
 
@@ -300,7 +300,7 @@ public class KafkaRecordSupplierHeaderFilterTest
   {
     // Test that empty polls don't affect statistics
     InDimFilter filter = new InDimFilter("environment", Collections.singletonList("production"), null);
-    KafkaHeaderBasedInclusionConfig headerFilter = new KafkaHeaderBasedInclusionConfig(filter, null, null);
+    KafkaHeaderBasedFilterConfig headerFilter = new KafkaHeaderBasedFilterConfig(filter, null, null);
 
     recordSupplier = new KafkaRecordSupplier(mockConsumer, false, headerFilter);
 
@@ -321,7 +321,7 @@ public class KafkaRecordSupplierHeaderFilterTest
     // CRITICAL TEST: Verify that when ALL records are filtered out, we still return
     // filtered record markers to prevent infinite loop
     InDimFilter filter = new InDimFilter("environment", Collections.singletonList("production"), null);
-    KafkaHeaderBasedInclusionConfig headerFilter = new KafkaHeaderBasedInclusionConfig(filter, null, null);
+    KafkaHeaderBasedFilterConfig headerFilter = new KafkaHeaderBasedFilterConfig(filter, null, null);
 
     recordSupplier = new KafkaRecordSupplier(mockConsumer, false, headerFilter);
 
@@ -362,7 +362,7 @@ public class KafkaRecordSupplierHeaderFilterTest
   {
     // Test that mix of filtered and accepted records works correctly
     InDimFilter filter = new InDimFilter("environment", Collections.singletonList("production"), null);
-    KafkaHeaderBasedInclusionConfig headerFilter = new KafkaHeaderBasedInclusionConfig(filter, null, null);
+    KafkaHeaderBasedFilterConfig headerFilter = new KafkaHeaderBasedFilterConfig(filter, null, null);
 
     recordSupplier = new KafkaRecordSupplier(mockConsumer, false, headerFilter);
 
@@ -402,7 +402,7 @@ public class KafkaRecordSupplierHeaderFilterTest
   {
     // Test header filtering with multi-topic configuration
     InDimFilter filter = new InDimFilter("environment", Collections.singletonList("production"), null);
-    KafkaHeaderBasedInclusionConfig headerFilter = new KafkaHeaderBasedInclusionConfig(filter, null, null);
+    KafkaHeaderBasedFilterConfig headerFilter = new KafkaHeaderBasedFilterConfig(filter, null, null);
 
     recordSupplier = new KafkaRecordSupplier(mockConsumer, true, headerFilter); // multiTopic = true
 

--- a/extensions-core/kafka-indexing-service/src/test/java/org/apache/druid/indexing/kafka/supervisor/KafkaHeaderBasedFilterConfigTest.java
+++ b/extensions-core/kafka-indexing-service/src/test/java/org/apache/druid/indexing/kafka/supervisor/KafkaHeaderBasedFilterConfigTest.java
@@ -34,7 +34,7 @@ import org.junit.Test;
 import java.util.Arrays;
 import java.util.Collections;
 
-public class KafkaHeaderBasedInclusionConfigTest
+public class KafkaHeaderBasedFilterConfigTest
 {
   private final ObjectMapper objectMapper = new DefaultObjectMapper();
 
@@ -48,7 +48,7 @@ public class KafkaHeaderBasedInclusionConfigTest
   public void testInFilterSingleValue()
   {
     InDimFilter dimFilter = new InDimFilter("environment", Collections.singletonList("production"), null);
-    KafkaHeaderBasedInclusionConfig filter = new KafkaHeaderBasedInclusionConfig(dimFilter, null, null);
+    KafkaHeaderBasedFilterConfig filter = new KafkaHeaderBasedFilterConfig(dimFilter, null, null);
 
     Assert.assertEquals(dimFilter, filter.getFilter());
     Assert.assertEquals("UTF-8", filter.getEncoding());
@@ -59,7 +59,7 @@ public class KafkaHeaderBasedInclusionConfigTest
   public void testInFilterMultipleValues()
   {
     InDimFilter dimFilter = new InDimFilter("service", Arrays.asList("user-service", "payment-service"), null);
-    KafkaHeaderBasedInclusionConfig filter = new KafkaHeaderBasedInclusionConfig(dimFilter, "ISO-8859-1", null);
+    KafkaHeaderBasedFilterConfig filter = new KafkaHeaderBasedFilterConfig(dimFilter, "ISO-8859-1", null);
 
     Assert.assertEquals(dimFilter, filter.getFilter());
     Assert.assertEquals("ISO-8859-1", filter.getEncoding());
@@ -70,7 +70,7 @@ public class KafkaHeaderBasedInclusionConfigTest
   public void testInFilterWithCustomCacheSize()
   {
     InDimFilter dimFilter = new InDimFilter("environment", Collections.singletonList("production"), null);
-    KafkaHeaderBasedInclusionConfig filter = new KafkaHeaderBasedInclusionConfig(dimFilter, null, 50_000);
+    KafkaHeaderBasedFilterConfig filter = new KafkaHeaderBasedFilterConfig(dimFilter, null, 50_000);
 
     Assert.assertEquals(dimFilter, filter.getFilter());
     Assert.assertEquals("UTF-8", filter.getEncoding());
@@ -82,7 +82,7 @@ public class KafkaHeaderBasedInclusionConfigTest
   {
     SelectorDimFilter dimFilter = new SelectorDimFilter("environment", "production", null);
     try {
-      new KafkaHeaderBasedInclusionConfig(dimFilter, null, null);
+      new KafkaHeaderBasedFilterConfig(dimFilter, null, null);
       Assert.fail("Expected DruidException for SelectorDimFilter");
     }
     catch (DruidException e) {
@@ -98,7 +98,7 @@ public class KafkaHeaderBasedInclusionConfigTest
     SelectorDimFilter serviceFilter = new SelectorDimFilter("service", "user-service", null);
     AndDimFilter andFilter = new AndDimFilter(Arrays.asList(envFilter, serviceFilter));
     try {
-      new KafkaHeaderBasedInclusionConfig(andFilter, null, null);
+      new KafkaHeaderBasedFilterConfig(andFilter, null, null);
       Assert.fail("Expected DruidException for AndDimFilter");
     }
     catch (DruidException e) {
@@ -113,7 +113,7 @@ public class KafkaHeaderBasedInclusionConfigTest
     SelectorDimFilter debugFilter = new SelectorDimFilter("debug-mode", "true", null);
     NotDimFilter notFilter = new NotDimFilter(debugFilter);
     try {
-      new KafkaHeaderBasedInclusionConfig(notFilter, null, null);
+      new KafkaHeaderBasedFilterConfig(notFilter, null, null);
       Assert.fail("Expected DruidException for NotDimFilter");
     }
     catch (DruidException e) {
@@ -125,27 +125,27 @@ public class KafkaHeaderBasedInclusionConfigTest
   @Test(expected = NullPointerException.class)
   public void testNullFilter()
   {
-    new KafkaHeaderBasedInclusionConfig(null, null, null);
+    new KafkaHeaderBasedFilterConfig(null, null, null);
   }
 
   @Test(expected = IllegalArgumentException.class)
   public void testInvalidEncoding()
   {
     InDimFilter dimFilter = new InDimFilter("environment", Collections.singletonList("production"), null);
-    new KafkaHeaderBasedInclusionConfig(dimFilter, "INVALID-ENCODING", null);
+    new KafkaHeaderBasedFilterConfig(dimFilter, "INVALID-ENCODING", null);
   }
 
   @Test
   public void testSerialization() throws Exception
   {
     InDimFilter dimFilter = new InDimFilter("environment", Collections.singletonList("production"), null);
-    KafkaHeaderBasedInclusionConfig originalFilter = new KafkaHeaderBasedInclusionConfig(dimFilter, "UTF-16", null);
+    KafkaHeaderBasedFilterConfig originalFilter = new KafkaHeaderBasedFilterConfig(dimFilter, "UTF-16", null);
 
     // Serialize to JSON
     String json = objectMapper.writeValueAsString(originalFilter);
 
     // Deserialize back
-    KafkaHeaderBasedInclusionConfig deserializedFilter = objectMapper.readValue(json, KafkaHeaderBasedInclusionConfig.class);
+    KafkaHeaderBasedFilterConfig deserializedFilter = objectMapper.readValue(json, KafkaHeaderBasedFilterConfig.class);
 
     Assert.assertEquals(originalFilter.getFilter(), deserializedFilter.getFilter());
     Assert.assertEquals(originalFilter.getEncoding(), deserializedFilter.getEncoding());
@@ -159,11 +159,11 @@ public class KafkaHeaderBasedInclusionConfigTest
     InDimFilter dimFilter2 = new InDimFilter("environment", Collections.singletonList("production"), null);
     InDimFilter dimFilter3 = new InDimFilter("environment", Collections.singletonList("staging"), null);
 
-    KafkaHeaderBasedInclusionConfig filter1 = new KafkaHeaderBasedInclusionConfig(dimFilter1, "UTF-8", null);
-    KafkaHeaderBasedInclusionConfig filter2 = new KafkaHeaderBasedInclusionConfig(dimFilter2, "UTF-8", null);
-    KafkaHeaderBasedInclusionConfig filter3 = new KafkaHeaderBasedInclusionConfig(dimFilter3, "UTF-8", null);
-    KafkaHeaderBasedInclusionConfig filter4 = new KafkaHeaderBasedInclusionConfig(dimFilter1, "UTF-16", null);
-    KafkaHeaderBasedInclusionConfig filter5 = new KafkaHeaderBasedInclusionConfig(dimFilter1, "UTF-8", 5000);
+    KafkaHeaderBasedFilterConfig filter1 = new KafkaHeaderBasedFilterConfig(dimFilter1, "UTF-8", null);
+    KafkaHeaderBasedFilterConfig filter2 = new KafkaHeaderBasedFilterConfig(dimFilter2, "UTF-8", null);
+    KafkaHeaderBasedFilterConfig filter3 = new KafkaHeaderBasedFilterConfig(dimFilter3, "UTF-8", null);
+    KafkaHeaderBasedFilterConfig filter4 = new KafkaHeaderBasedFilterConfig(dimFilter1, "UTF-16", null);
+    KafkaHeaderBasedFilterConfig filter5 = new KafkaHeaderBasedFilterConfig(dimFilter1, "UTF-8", 5000);
 
     Assert.assertEquals(filter1, filter2);
     Assert.assertNotEquals(filter1, filter3);
@@ -177,10 +177,10 @@ public class KafkaHeaderBasedInclusionConfigTest
   public void testToString()
   {
     InDimFilter dimFilter = new InDimFilter("environment", Collections.singletonList("production"), null);
-    KafkaHeaderBasedInclusionConfig filter = new KafkaHeaderBasedInclusionConfig(dimFilter, "UTF-8", null);
+    KafkaHeaderBasedFilterConfig filter = new KafkaHeaderBasedFilterConfig(dimFilter, "UTF-8", null);
 
     String toString = filter.toString();
-    Assert.assertTrue(toString.contains("KafkaheaderBasedInclusionConfig"));
+    Assert.assertTrue(toString.contains("KafkaheaderBasedFilterConfig"));
     Assert.assertTrue(toString.contains("filter="));
     Assert.assertTrue(toString.contains("encoding='UTF-8'"));
     Assert.assertTrue(toString.contains("stringDecodingCacheSize=10000"));


### PR DESCRIPTION
Fixes #XXXX.


### Description
* Syncing with upstream PR - https://github.com/apache/druid/pull/18525

#### Fixed the bug ...
#### Renamed the class ...
#### Added a forbidden-apis entry ...






#### Release note

For tips about how to write a good release note, see [Release notes](https://github.com/apache/druid/blob/master/CONTRIBUTING.md#release-notes).


<hr>

##### Key changed/added classes in this PR
 * `MyFoo`
 * `OurBar`
 * `TheirBaz`

<hr>

<!-- Check the items by putting "x" in the brackets for the done things. Not all of these items apply to every PR. Remove the items which are not done or not relevant to the PR. None of the items from the checklist below are strictly necessary, but it would be very helpful if you at least self-review the PR. -->

This PR has:

- [ ] been self-reviewed.
   - [ ] using the [concurrency checklist](https://github.com/apache/druid/blob/master/dev/code-review/concurrency.md) (Remove this item if the PR doesn't have any relation to concurrency.)
- [ ] added documentation for new or modified features or behaviors.
- [ ] a release note entry in the PR description.
- [ ] added Javadocs for most classes and all non-trivial methods. Linked related entities via Javadoc links.
- [ ] added or updated version, license, or notice information in [licenses.yaml](https://github.com/apache/druid/blob/master/dev/license.md)
- [ ] added comments explaining the "why" and the intent of the code wherever would not be obvious for an unfamiliar reader.
- [ ] added unit tests or modified existing tests to cover new code paths, ensuring the threshold for [code coverage](https://github.com/apache/druid/blob/master/dev/code-review/code-coverage.md) is met.
- [ ] added integration tests.
- [ ] been tested in a test Druid cluster.
