### PR TITLE
Fix ungraceful overlord termination

### DIFF
--- a/extensions-core/postgresql-metadata-storage/src/main/java/org/apache/druid/metadata/storage/postgresql/PostgreSQLConnector.java
+++ b/extensions-core/postgresql-metadata-storage/src/main/java/org/apache/druid/metadata/storage/postgresql/PostgreSQLConnector.java
@@ -42,6 +42,7 @@ import java.sql.DatabaseMetaData;
 import java.sql.SQLException;
 import java.util.List;
 import java.util.Locale;
+import java.util.Set;
 
 public class PostgreSQLConnector extends SQLMetadataConnector
 {
@@ -286,5 +287,25 @@ public class PostgreSQLConnector extends SQLMetadataConnector
       return sqlState != null && (sqlState.startsWith("08") || sqlState.startsWith("53"));
     }
     return false;
+  }
+
+  /**
+   * This method has been overridden to pass lowercase tableName.
+   * This is done because PostgreSQL creates tables with lowercased names unless explicitly enclosed in double quotes.
+   */
+  @Override
+  protected boolean tableHasColumn(String tableName, String columnName)
+  {
+    return super.tableHasColumn(StringUtils.toLowerCase(tableName), columnName);
+  }
+
+  /**
+   * This method has been overridden to pass lowercase tableName.
+   * This is done because PostgreSQL creates tables with lowercased names unless explicitly enclosed in double quotes.
+   */
+  @Override
+  public Set<String> getIndexOnTable(String tableName)
+  {
+    return super.getIndexOnTable(StringUtils.toLowerCase(tableName));
   }
 }


### PR DESCRIPTION
### Fix PostgreSQL metadata storage warning logs because of table-name casing issues


Cherry-picks https://github.com/apache/druid/pull/17351 to fix ungraceful overlord termination in Druid-30. Pls refer original PR's description on why it can cause ingestion-lag

This PR has:

- [x] been self-reviewed.
   - [ ] using the [concurrency checklist](https://github.com/apache/druid/blob/master/dev/code-review/concurrency.md) (Remove this item if the PR doesn't have any relation to concurrency.)
- [ ] added documentation for new or modified features or behaviors.
- [ ] a release note entry in the PR description.
- [ ] added Javadocs for most classes and all non-trivial methods. Linked related entities via Javadoc links.
- [ ] added or updated version, license, or notice information in [licenses.yaml](https://github.com/apache/druid/blob/master/dev/license.md)
- [ ] added comments explaining the "why" and the intent of the code wherever would not be obvious for an unfamiliar reader.
- [ ] added unit tests or modified existing tests to cover new code paths, ensuring the threshold for [code coverage](https://github.com/apache/druid/blob/master/dev/code-review/code-coverage.md) is met.
- [ ] added integration tests.
- [ ] been tested in a test Druid cluster.
