### PR TITLE
[OBSDATA-11654]: Increase number of retries in case of retryable failure while publishing segment.

### DIFF
--- a/server/src/main/java/org/apache/druid/segment/realtime/appenderator/TransactionalSegmentPublisher.java
+++ b/server/src/main/java/org/apache/druid/segment/realtime/appenderator/TransactionalSegmentPublisher.java
@@ -34,7 +34,7 @@ import java.util.function.Function;
 public abstract class TransactionalSegmentPublisher
 {
   private static final int QUIET_RETRIES = 3;
-  private static final int MAX_RETRIES = 5;
+  private static final int MAX_RETRIES = 12;
 
   /**
    * Publish segments, along with some commit metadata, in a single transaction.

--- a/server/src/test/java/org/apache/druid/segment/realtime/appenderator/TransactionalSegmentPublisherTest.java
+++ b/server/src/test/java/org/apache/druid/segment/realtime/appenderator/TransactionalSegmentPublisherTest.java
@@ -50,17 +50,18 @@ public class TransactionalSegmentPublisherTest
               Mockito.anyBoolean()
       )).thenAnswer(invocation -> null);
 
-    final AtomicInteger attemptCount = new AtomicInteger(0);
-    final TransactionalSegmentPublisher publisher = createPublisher(
-        SegmentPublishResult.retryableFailure("this error is retryable"),
-        attemptCount
-    );
+      final AtomicInteger attemptCount = new AtomicInteger(0);
+      final TransactionalSegmentPublisher publisher = createPublisher(
+              SegmentPublishResult.retryableFailure("this error is retryable"),
+              attemptCount
+      );
 
-    Assert.assertEquals(
-        SegmentPublishResult.retryableFailure("this error is retryable"),
-        publisher.publishSegments(null, Set.of(), Function.identity(), null, null)
-    );
-    Assert.assertEquals(12, attemptCount.get());
+      Assert.assertEquals(
+              SegmentPublishResult.retryableFailure("this error is retryable"),
+              publisher.publishSegments(null, Set.of(), Function.identity(), null, null)
+      );
+      Assert.assertEquals(13, attemptCount.get());
+    }
   }
 
   @Test

--- a/server/src/test/java/org/apache/druid/segment/realtime/appenderator/TransactionalSegmentPublisherTest.java
+++ b/server/src/test/java/org/apache/druid/segment/realtime/appenderator/TransactionalSegmentPublisherTest.java
@@ -20,10 +20,13 @@
 package org.apache.druid.segment.realtime.appenderator;
 
 import org.apache.druid.indexing.overlord.SegmentPublishResult;
+import org.apache.druid.java.util.common.RetryUtils;
 import org.apache.druid.segment.SegmentSchemaMapping;
 import org.apache.druid.timeline.DataSegment;
 import org.junit.Assert;
 import org.junit.Test;
+import org.mockito.MockedStatic;
+import org.mockito.Mockito;
 
 import javax.annotation.Nullable;
 import java.io.IOException;
@@ -34,8 +37,19 @@ import java.util.function.Function;
 public class TransactionalSegmentPublisherTest
 {
   @Test(timeout = 60_000L)
-  public void testPublishSegments_retriesUpto5Times_ifFailureIsRetryable() throws IOException
+  public void testPublishSegments_retriesUpto12Times_ifFailureIsRetryable() throws IOException
   {
+    // Mock RetryUtils.awaitNextRetry to skip sleep delays for faster test execution
+    try (MockedStatic<RetryUtils> retryUtilsMock = Mockito.mockStatic(RetryUtils.class)) {
+      // Make awaitNextRetry() do nothing (skip the sleep)
+      retryUtilsMock.when(() -> RetryUtils.awaitNextRetry(
+              Mockito.any(),
+              Mockito.anyString(),
+              Mockito.anyInt(),
+              Mockito.anyInt(),
+              Mockito.anyBoolean()
+      )).thenAnswer(invocation -> null);
+
     final AtomicInteger attemptCount = new AtomicInteger(0);
     final TransactionalSegmentPublisher publisher = createPublisher(
         SegmentPublishResult.retryableFailure("this error is retryable"),
@@ -46,7 +60,7 @@ public class TransactionalSegmentPublisherTest
         SegmentPublishResult.retryableFailure("this error is retryable"),
         publisher.publishSegments(null, Set.of(), Function.identity(), null, null)
     );
-    Assert.assertEquals(6, attemptCount.get());
+    Assert.assertEquals(12, attemptCount.get());
   }
 
   @Test


### PR DESCRIPTION
<!-- Thanks for trying to help us make Apache Druid be the best it can be! Please fill out as much of the following information as is possible (where relevant, and remove it when irrelevant) to help make the intention and scope of this PR clear in order to ease review. -->

<!-- Please read the doc for contribution (https://github.com/apache/druid/blob/master/CONTRIBUTING.md) before making this PR. Also, once you open a PR, please _avoid using force pushes and rebasing_ since these make it difficult for reviewers to see what you've changed in response to their reviews. See [the 'If your pull request shows conflicts with master' section](https://github.com/apache/druid/blob/master/CONTRIBUTING.md#if-your-pull-request-shows-conflicts-with-master) for more details. -->


### Description
- I tested it on Druid stag 358af, and I am able to verify it does retry in case of retryable failure. But even after retries, the segment publish failed because the retries were very quick. So, increasing the number of retries. 
- With 12 retries, we will have around ~7 to 14 minutes (at max) for the retries to finish.

#### Fixed the bug ...
#### Renamed the class ...
#### Added a forbidden-apis entry ...

<!--
In each section, please describe design decisions made, including:
 - Choice of algorithms
 - Behavioral aspects. What configuration values are acceptable? How are corner cases and error conditions handled, such as when there are insufficient resources?
 - Class organization and design (how the logic is split between classes, inheritance, composition, design patterns)
 - Method organization and design (how the logic is split between methods, parameters and return types)
 - Naming (class, method, API, configuration, HTTP endpoint, names of emitted metrics)
-->


<!-- It's good to describe an alternative design (or mention an alternative name) for every design (or naming) decision point and compare the alternatives with the designs that you've implemented (or the names you've chosen) to highlight the advantages of the chosen designs and names. -->

<!-- If there was a discussion of the design of the feature implemented in this PR elsewhere (e. g. a "Proposal" issue, any other issue, or a thread in the development mailing list), link to that discussion from this PR description and explain what have changed in your final design compared to your original proposal or the consensus version in the end of the discussion. If something hasn't changed since the original discussion, you can omit a detailed discussion of those aspects of the design here, perhaps apart from brief mentioning for the sake of readability of this PR description. -->

<!-- Some of the aspects mentioned above may be omitted for simple and small changes. -->

#### Release note
<!-- Give your best effort to summarize your changes in a couple of sentences aimed toward Druid users. 

If your change doesn't have end user impact, you can skip this section.

-->
For tips about how to write a good release note, see [Release notes](https://github.com/apache/druid/blob/master/CONTRIBUTING.md#release-notes).


<hr>

##### Key changed/added classes in this PR
 * `MyFoo`
 * `OurBar`
 * `TheirBaz`

<hr>

<!-- Check the items by putting "x" in the brackets for the done things. Not all of these items apply to every PR. Remove the items which are not done or not relevant to the PR. None of the items from the checklist below are strictly necessary, but it would be very helpful if you at least self-review the PR. -->

This PR has:

- [ ] been self-reviewed.
   - [ ] using the [concurrency checklist](https://github.com/apache/druid/blob/master/dev/code-review/concurrency.md) (Remove this item if the PR doesn't have any relation to concurrency.)
- [ ] added documentation for new or modified features or behaviors.
- [ ] a release note entry in the PR description.
- [ ] added Javadocs for most classes and all non-trivial methods. Linked related entities via Javadoc links.
- [ ] added or updated version, license, or notice information in [licenses.yaml](https://github.com/apache/druid/blob/master/dev/license.md)
- [ ] added comments explaining the "why" and the intent of the code wherever would not be obvious for an unfamiliar reader.
- [ ] added unit tests or modified existing tests to cover new code paths, ensuring the threshold for [code coverage](https://github.com/apache/druid/blob/master/dev/code-review/code-coverage.md) is met.
- [ ] added integration tests.
- [ ] been tested in a test Druid cluster.
