### PR TITLE
Backport #18623

### DIFF
--- a/docs/configuration/index.md
+++ b/docs/configuration/index.md
@@ -1497,6 +1497,7 @@ Druid uses Jetty to serve HTTP requests.
 |`druid.server.http.allowedHttpMethods`|List of HTTP methods that should be allowed in addition to the ones required by Druid APIs. Druid APIs require GET, PUT, POST, and DELETE, which are always allowed. This option is not useful unless you have installed an extension that needs these additional HTTP methods or that adds functionality related to CORS. None of Druid's bundled extensions require these methods.|`[]`|
 |`druid.server.http.contentSecurityPolicy`|Content-Security-Policy header value to set on each non-POST response. Setting this property to an empty string, or omitting it, both result in the default `frame-ancestors: none` being set.|`frame-ancestors 'none'`|
 |`druid.server.http.uriCompliance`|Jetty `UriCompliance` mode for Druid's embedded Jetty servers. To modify, override this config with the string representation of any `UriCompliance` mode that [Jetty supports](https://javadoc.jetty.org/jetty-12/org/eclipse/jetty/http/UriCompliance.html).|LEGACY|
+|`druid.server.http.enforceStrictSNIHostChecking`| If enabled, the Jetty server will enforce strict SNI host checking. This means that if a client connects to the server using TLS but does not provide an SNI hostname, or provides an SNI hostname that does not match the server's configured hostname, a request will get a 400 response. Setting this to false is not recommended in production.|true|
 
 #### Indexer processing resources
 

--- a/server/src/main/java/org/apache/druid/server/initialization/ServerConfig.java
+++ b/server/src/main/java/org/apache/druid/server/initialization/ServerConfig.java
@@ -84,7 +84,8 @@ public class ServerConfig
       @NotNull ErrorResponseTransformStrategy errorResponseTransformStrategy,
       @Nullable String contentSecurityPolicy,
       boolean enableHSTS,
-      @Nullable UriCompliance uriCompliance
+      @Nullable UriCompliance uriCompliance,
+      boolean enforceStrictSNIHostChecking
   )
   {
     this.numThreads = numThreads;
@@ -109,6 +110,7 @@ public class ServerConfig
     this.contentSecurityPolicy = contentSecurityPolicy;
     this.enableHSTS = enableHSTS;
     this.uriCompliance = uriCompliance != null ? uriCompliance : UriCompliance.LEGACY;
+    this.enforceStrictSNIHostChecking = enforceStrictSNIHostChecking;
   }
 
   public ServerConfig()
@@ -211,6 +213,9 @@ public class ServerConfig
 
   @JsonProperty
   private boolean showDetailedJettyErrors = true;
+
+  @JsonProperty
+  private boolean enforceStrictSNIHostChecking = true;
 
   public int getNumThreads()
   {
@@ -328,6 +333,11 @@ public class ServerConfig
     return uriCompliance;
   }
 
+  public boolean isEnforceStrictSNIHostChecking()
+  {
+    return enforceStrictSNIHostChecking;
+  }
+
   @Override
   public boolean equals(Object o)
   {
@@ -360,7 +370,8 @@ public class ServerConfig
            Objects.equals(contentSecurityPolicy, that.getContentSecurityPolicy()) &&
            enableHSTS == that.enableHSTS &&
            enableQueryRequestsQueuing == that.enableQueryRequestsQueuing &&
-           Objects.equals(uriCompliance, that.uriCompliance);
+           Objects.equals(uriCompliance, that.uriCompliance) &&
+           enforceStrictSNIHostChecking == that.enforceStrictSNIHostChecking;
   }
 
   @Override
@@ -389,7 +400,8 @@ public class ServerConfig
         contentSecurityPolicy,
         enableHSTS,
         enableQueryRequestsQueuing,
-        uriCompliance
+        uriCompliance,
+        enforceStrictSNIHostChecking
     );
   }
 
@@ -420,6 +432,7 @@ public class ServerConfig
            ", enableHSTS=" + enableHSTS +
            ", enableQueryRequestsQueuing=" + enableQueryRequestsQueuing +
            ", uriCompliance=" + uriCompliance +
+           ", enforceStrictSNIHostChecking=" + enforceStrictSNIHostChecking +
            '}';
   }
 

--- a/server/src/main/java/org/apache/druid/server/initialization/jetty/CliIndexerServerModule.java
+++ b/server/src/main/java/org/apache/druid/server/initialization/jetty/CliIndexerServerModule.java
@@ -167,7 +167,8 @@ public class CliIndexerServerModule implements Module
         oldConfig.getErrorResponseTransformStrategy(),
         oldConfig.getContentSecurityPolicy(),
         oldConfig.isEnableHSTS(),
-        oldConfig.getUriCompliance()
+        oldConfig.getUriCompliance(),
+        oldConfig.isEnforceStrictSNIHostChecking()
     );
   }
 }

--- a/server/src/main/java/org/apache/druid/server/initialization/jetty/JettyServerModule.java
+++ b/server/src/main/java/org/apache/druid/server/initialization/jetty/JettyServerModule.java
@@ -314,7 +314,13 @@ public class JettyServerModule extends JerseyServletModule
       }
       httpsConfiguration.setSecureScheme("https");
       httpsConfiguration.setSecurePort(node.getTlsPort());
-      httpsConfiguration.addCustomizer(new SecureRequestCustomizer());
+
+      // see https://github.com/jetty/jetty.project/pull/5398
+      // This new strict enforcement can break some clients. Allow turning it off via config if necessary
+      final SecureRequestCustomizer secureRequestCustomizer = new SecureRequestCustomizer();
+      secureRequestCustomizer.setSniHostCheck(config.isEnforceStrictSNIHostChecking());
+
+      httpsConfiguration.addCustomizer(secureRequestCustomizer);
       httpsConfiguration.setRequestHeaderSize(config.getMaxRequestHeaderSize());
       httpsConfiguration.setSendServerVersion(false);
       final ServerConnector connector = new ServerConnector(

--- a/server/src/test/java/org/apache/druid/initialization/ServerConfigTest.java
+++ b/server/src/test/java/org/apache/druid/initialization/ServerConfigTest.java
@@ -45,6 +45,7 @@ public class ServerConfigTest
     Assert.assertFalse(defaultConfig2.isEnableForwardedRequestCustomizer());
     Assert.assertFalse(defaultConfig2.isEnableHSTS());
     Assert.assertEquals(UriCompliance.LEGACY, defaultConfig.getUriCompliance());
+    Assert.assertEquals(true, defaultConfig.isEnforceStrictSNIHostChecking());
 
     ServerConfig modifiedConfig = new ServerConfig(
         999,
@@ -68,7 +69,8 @@ public class ServerConfigTest
         new AllowedRegexErrorResponseTransformStrategy(ImmutableList.of(".*")),
         "my-cool-policy",
         true,
-        UriCompliance.RFC3986
+        UriCompliance.RFC3986,
+        false
     );
     String modifiedConfigJson = OBJECT_MAPPER.writeValueAsString(modifiedConfig);
     ServerConfig modifiedConfig2 = OBJECT_MAPPER.readValue(modifiedConfigJson, ServerConfig.class);
@@ -83,6 +85,7 @@ public class ServerConfigTest
     Assert.assertEquals("my-cool-policy", modifiedConfig2.getContentSecurityPolicy());
     Assert.assertTrue(modifiedConfig2.isEnableHSTS());
     Assert.assertEquals(UriCompliance.RFC3986, modifiedConfig2.getUriCompliance());
+    Assert.assertFalse(modifiedConfig2.isEnforceStrictSNIHostChecking());
   }
 
   @Test

--- a/website/.spelling
+++ b/website/.spelling
@@ -227,6 +227,7 @@ S3
 SAS
 SDK
 SIGAR
+SNI
 SPNEGO
 Splunk
 SqlInputSource


### PR DESCRIPTION
<!-- Thanks for trying to help us make Apache Druid be the best it can be! Please fill out as much of the following information as is possible (where relevant, and remove it when irrelevant) to help make the intention and scope of this PR clear in order to ease review. -->

<!-- Please read the doc for contribution (https://github.com/apache/druid/blob/master/CONTRIBUTING.md) before making this PR. Also, once you open a PR, please _avoid using force pushes and rebasing_ since these make it difficult for reviewers to see what you've changed in response to their reviews. See [the 'If your pull request shows conflicts with master' section](https://github.com/apache/druid/blob/master/CONTRIBUTING.md#if-your-pull-request-shows-conflicts-with-master) for more details. -->

Backport #18623

<!-- Replace XXXX with the id of the issue fixed in this PR. Remove this section if there is no corresponding issue. Don't reference the issue in the title of this pull-request. -->

<!-- If you are a committer, follow the PR action item checklist for committers:
https://github.com/apache/druid/blob/master/dev/committer-instructions.md#pr-and-issue-action-item-checklist-for-committers. -->


<!--
In each section, please describe design decisions made, including:
 - Choice of algorithms
 - Behavioral aspects. What configuration values are acceptable? How are corner cases and error conditions handled, such as when there are insufficient resources?
 - Class organization and design (how the logic is split between classes, inheritance, composition, design patterns)
 - Method organization and design (how the logic is split between methods, parameters and return types)
 - Naming (class, method, API, configuration, HTTP endpoint, names of emitted metrics)
-->


<!-- It's good to describe an alternative design (or mention an alternative name) for every design (or naming) decision point and compare the alternatives with the designs that you've implemented (or the names you've chosen) to highlight the advantages of the chosen designs and names. -->

<!-- If there was a discussion of the design of the feature implemented in this PR elsewhere (e. g. a "Proposal" issue, any other issue, or a thread in the development mailing list), link to that discussion from this PR description and explain what have changed in your final design compared to your original proposal or the consensus version in the end of the discussion. If something hasn't changed since the original discussion, you can omit a detailed discussion of those aspects of the design here, perhaps apart from brief mentioning for the sake of readability of this PR description. -->

<!-- Some of the aspects mentioned above may be omitted for simple and small changes. -->


<hr>

<!-- Check the items by putting "x" in the brackets for the done things. Not all of these items apply to every PR. Remove the items which are not done or not relevant to the PR. None of the items from the checklist below are strictly necessary, but it would be very helpful if you at least self-review the PR. -->

This PR has:

- [x] been self-reviewed.
   - [ ] using the [concurrency checklist](https://github.com/apache/druid/blob/master/dev/code-review/concurrency.md) (Remove this item if the PR doesn't have any relation to concurrency.)
- [ ] added documentation for new or modified features or behaviors.
- [ ] a release note entry in the PR description.
- [ ] added Javadocs for most classes and all non-trivial methods. Linked related entities via Javadoc links.
- [ ] added or updated version, license, or notice information in [licenses.yaml](https://github.com/apache/druid/blob/master/dev/license.md)
- [ ] added comments explaining the "why" and the intent of the code wherever would not be obvious for an unfamiliar reader.
- [ ] added unit tests or modified existing tests to cover new code paths, ensuring the threshold for [code coverage](https://github.com/apache/druid/blob/master/dev/code-review/code-coverage.md) is met.
- [ ] added integration tests.
- [ ] been tested in a test Druid cluster.
