### PR TITLE
Backport #18699: Fix extra router statusCode metric edge cases

### DIFF
--- a/docs/operations/metrics.md
+++ b/docs/operations/metrics.md
@@ -45,7 +45,7 @@ Most metric values reset each emission period, as specified in `druid.monitoring
 
 |Metric|Description|Dimensions|Normal value|
 |------|-----------|----------|------------|
-|`query/time`|Milliseconds taken to complete a query.|Native Query: `dataSource`, `type`, `interval`, `hasFilters`, `duration`, `context`, `remoteAddress`, `id`.|< 1s|
+|`query/time`|Milliseconds taken to complete a query.|Native Query: `dataSource`, `type`, `interval`, `hasFilters`, `duration`, `context`, `remoteAddress`, `id`, `code`.|< 1s|
 
 ### Broker
 
@@ -68,11 +68,7 @@ Most metric values reset each emission period, as specified in `druid.monitoring
 |`query/timeout/count`|Number of timed out queries.|This metric is only available if the `QueryCountStatsMonitor` module is included.| |
 |`query/segments/count`|This metric is not enabled by default. See the `QueryMetrics` Interface for reference regarding enabling this metric. Number of segments that will be touched by the query. In the broker, it makes a plan to distribute the query to realtime tasks and historicals based on a snapshot of segment distribution state. If there are some segments moved after this snapshot is created, certain historicals and realtime tasks can report those segments as missing to the broker. The broker will resend the query to the new servers that serve those segments after move. In this case, those segments can be counted more than once in this metric.||Varies|
 |`query/priority`|Assigned lane and priority, only if Laning strategy is enabled. Refer to [Laning strategies](../configuration/index.md#laning-strategies)|`lane`, `dataSource`, `type`|0|
-|`sqlQuery/time`|Milliseconds taken to complete a SQL query.|`id`, `nativeQueryIds`, `dataSource`, `remoteAddress`, `success`|< 1s|
-|`sqlQuery/planningTimeMs`|Milliseconds taken to plan a SQL to native query.|`id`, `nativeQueryIds`, `dataSource`, `remoteAddress`, `success`| |
-|`sqlQuery/bytes`|Number of bytes returned in the SQL query response.|`id`, `nativeQueryIds`, `dataSource`, `remoteAddress`, `success`| |
-|`httpClient/channelAcquire/timeNs`|Time in nanoseconds spent by the httpclient to acquire the channel.| |
-|`sqlQuery/time`|Milliseconds taken to complete a SQL query.|`id`, `nativeQueryIds`, `dataSource`, `remoteAddress`, `success`, `engine`|< 1s|
+|`sqlQuery/time`|Milliseconds taken to complete a SQL query.|`id`, `nativeQueryIds`, `dataSource`, `remoteAddress`, `success`, `engine`, `code`|< 1s|
 |`sqlQuery/planningTimeMs`|Milliseconds taken to plan a SQL to native query.|`id`, `nativeQueryIds`, `dataSource`, `remoteAddress`, `success`, `engine`| |
 |`sqlQuery/bytes`|Number of bytes returned in the SQL query response.|`id`, `nativeQueryIds`, `dataSource`, `remoteAddress`, `success`, `engine`| |
 |`serverview/init/time`|Time taken to initialize the broker server view. Useful to detect if brokers are taking too long to start.||Depends on the number of segments.|

--- a/processing/src/main/java/org/apache/druid/query/DefaultQueryMetrics.java
+++ b/processing/src/main/java/org/apache/druid/query/DefaultQueryMetrics.java
@@ -27,6 +27,7 @@ import org.apache.druid.java.util.emitter.service.ServiceEmitter;
 import org.apache.druid.java.util.emitter.service.ServiceMetricEvent;
 import org.joda.time.Interval;
 
+import javax.annotation.Nullable;
 import java.util.Collection;
 import java.util.HashMap;
 import java.util.Map;
@@ -191,6 +192,12 @@ public class DefaultQueryMetrics<QueryType extends Query<?>> implements QueryMet
   public void success(boolean success)
   {
     setDimension("success", String.valueOf(success));
+  }
+
+  @Override
+  public void code(@Nullable Throwable error)
+  {
+    setDimension(DruidMetrics.CODE, DruidMetrics.computeStatusCode(error));
   }
 
   @Override

--- a/processing/src/main/java/org/apache/druid/query/DefaultQueryMetrics.java
+++ b/processing/src/main/java/org/apache/druid/query/DefaultQueryMetrics.java
@@ -27,7 +27,6 @@ import org.apache.druid.java.util.emitter.service.ServiceEmitter;
 import org.apache.druid.java.util.emitter.service.ServiceMetricEvent;
 import org.joda.time.Interval;
 
-import javax.annotation.Nullable;
 import java.util.Collection;
 import java.util.HashMap;
 import java.util.Map;
@@ -195,9 +194,9 @@ public class DefaultQueryMetrics<QueryType extends Query<?>> implements QueryMet
   }
 
   @Override
-  public void code(@Nullable Throwable error)
+  public void statusCode(int code)
   {
-    setDimension(DruidMetrics.CODE, DruidMetrics.computeStatusCode(error));
+    setDimension(DruidMetrics.STATUS_CODE, code);
   }
 
   @Override

--- a/processing/src/main/java/org/apache/druid/query/DruidMetrics.java
+++ b/processing/src/main/java/org/apache/druid/query/DruidMetrics.java
@@ -92,7 +92,7 @@ public class DruidMetrics
   }
 
   /**
-   * Computes the HTTP status code for a query/operation based on the error (if any).
+   * Computes the HTTP status code based on the query error (if any) for tagged metric emission.
    * <ul>
    *   <li>If error is null: returns 200 (success)</li>
    *   <li>If error is a DruidException: returns the category's expected HTTP status</li>
@@ -110,7 +110,7 @@ public class DruidMetrics
     if (error instanceof DruidException) {
       return ((DruidException) error).getCategory().getExpectedStatus();
     }
-    // Unclassified errors default to 500 (DEFENSIVE category)
+    // Unclassified errors default to 500 (defensive)
     return DruidException.Category.DEFENSIVE.getExpectedStatus();
   }
 }

--- a/processing/src/main/java/org/apache/druid/query/DruidMetrics.java
+++ b/processing/src/main/java/org/apache/druid/query/DruidMetrics.java
@@ -19,9 +19,11 @@
 
 package org.apache.druid.query;
 
+import org.apache.druid.error.DruidException;
 import org.apache.druid.query.aggregation.AggregatorFactory;
 import org.apache.druid.segment.column.ValueType;
 
+import javax.annotation.Nullable;
 import java.util.List;
 
 /**
@@ -35,6 +37,7 @@ public class DruidMetrics
   public static final String INTERVAL = "interval";
   public static final String ID = "id";
   public static final String SUBQUERY_ID = "subQueryId";
+  public static final String CODE = "code";
   public static final String STATUS = "status";
   public static final String ENGINE = "engine";
   public static final String DURATION = "duration";
@@ -86,5 +89,28 @@ public class DruidMetrics
     }
     queryMetrics.remoteAddress(remoteAddr);
     return queryMetrics;
+  }
+
+  /**
+   * Computes the HTTP status code for a query/operation based on the error (if any).
+   * <ul>
+   *   <li>If error is null: returns 200 (success)</li>
+   *   <li>If error is a DruidException: returns the category's expected HTTP status</li>
+   *   <li>Otherwise (unclassified error): returns 500 (internal server error)</li>
+   * </ul>
+   *
+   * @param error The throwable error, or null if successful
+   * @return HTTP status code appropriate for the error
+   */
+  public static int computeStatusCode(@Nullable Throwable error)
+  {
+    if (error == null) {
+      return 200;
+    }
+    if (error instanceof DruidException) {
+      return ((DruidException) error).getCategory().getExpectedStatus();
+    }
+    // Unclassified errors default to 500 (DEFENSIVE category)
+    return DruidException.Category.DEFENSIVE.getExpectedStatus();
   }
 }

--- a/processing/src/main/java/org/apache/druid/query/DruidMetrics.java
+++ b/processing/src/main/java/org/apache/druid/query/DruidMetrics.java
@@ -37,7 +37,7 @@ public class DruidMetrics
   public static final String INTERVAL = "interval";
   public static final String ID = "id";
   public static final String SUBQUERY_ID = "subQueryId";
-  public static final String CODE = "code";
+  public static final String STATUS_CODE = "statusCode";
   public static final String STATUS = "status";
   public static final String ENGINE = "engine";
   public static final String DURATION = "duration";

--- a/processing/src/main/java/org/apache/druid/query/QueryMetrics.java
+++ b/processing/src/main/java/org/apache/druid/query/QueryMetrics.java
@@ -27,7 +27,6 @@ import org.apache.druid.query.filter.Filter;
 import org.apache.druid.query.filter.FilterBundle;
 import org.apache.druid.query.search.SearchQueryMetricsFactory;
 
-import javax.annotation.Nullable;
 import java.util.List;
 
 /**
@@ -243,10 +242,10 @@ public interface QueryMetrics<QueryType extends Query<?>>
   void success(boolean success);
 
   /**
-   * Translates the given query exception into the appropriate failure status code.
+   * Sets the query status code
    * See {@link DruidMetrics#computeStatusCode}.
    */
-  void code(@Nullable Throwable error);
+  void statusCode(int code);
 
   void segment(String segmentIdentifier);
 

--- a/processing/src/main/java/org/apache/druid/query/QueryMetrics.java
+++ b/processing/src/main/java/org/apache/druid/query/QueryMetrics.java
@@ -27,6 +27,7 @@ import org.apache.druid.query.filter.Filter;
 import org.apache.druid.query.filter.FilterBundle;
 import org.apache.druid.query.search.SearchQueryMetricsFactory;
 
+import javax.annotation.Nullable;
 import java.util.List;
 
 /**
@@ -240,6 +241,12 @@ public interface QueryMetrics<QueryType extends Query<?>>
   void status(String status);
 
   void success(boolean success);
+
+  /**
+   * Translates the given query exception into the appropriate failure status code.
+   * If {@param error} is null, 200 (success) is emitted.
+   */
+  void code(@Nullable Throwable error);
 
   void segment(String segmentIdentifier);
 

--- a/processing/src/main/java/org/apache/druid/query/QueryMetrics.java
+++ b/processing/src/main/java/org/apache/druid/query/QueryMetrics.java
@@ -244,7 +244,7 @@ public interface QueryMetrics<QueryType extends Query<?>>
 
   /**
    * Translates the given query exception into the appropriate failure status code.
-   * If {@param error} is null, 200 (success) is emitted.
+   * See {@link DruidMetrics#computeStatusCode}.
    */
   void code(@Nullable Throwable error);
 

--- a/processing/src/main/java/org/apache/druid/query/search/DefaultSearchQueryMetrics.java
+++ b/processing/src/main/java/org/apache/druid/query/search/DefaultSearchQueryMetrics.java
@@ -27,6 +27,8 @@ import org.apache.druid.query.Query;
 import org.apache.druid.query.QueryMetrics;
 import org.apache.druid.query.filter.FilterBundle;
 
+import javax.annotation.Nullable;
+
 /**
  * This class is implemented with delegation to another QueryMetrics for compatibility, see "Making subinterfaces of
  * QueryMetrics for emitting custom dimensions and/or metrics for specific query types" section in {@link QueryMetrics}
@@ -143,6 +145,12 @@ public class DefaultSearchQueryMetrics implements SearchQueryMetrics
   public void success(boolean success)
   {
     delegateQueryMetrics.success(success);
+  }
+
+  @Override
+  public void code(@Nullable Throwable error)
+  {
+    delegateQueryMetrics.code(error);
   }
 
   @Override

--- a/processing/src/main/java/org/apache/druid/query/search/DefaultSearchQueryMetrics.java
+++ b/processing/src/main/java/org/apache/druid/query/search/DefaultSearchQueryMetrics.java
@@ -27,8 +27,6 @@ import org.apache.druid.query.Query;
 import org.apache.druid.query.QueryMetrics;
 import org.apache.druid.query.filter.FilterBundle;
 
-import javax.annotation.Nullable;
-
 /**
  * This class is implemented with delegation to another QueryMetrics for compatibility, see "Making subinterfaces of
  * QueryMetrics for emitting custom dimensions and/or metrics for specific query types" section in {@link QueryMetrics}
@@ -148,9 +146,9 @@ public class DefaultSearchQueryMetrics implements SearchQueryMetrics
   }
 
   @Override
-  public void code(@Nullable Throwable error)
+  public void statusCode(int code)
   {
-    delegateQueryMetrics.code(error);
+    delegateQueryMetrics.statusCode(code);
   }
 
   @Override

--- a/processing/src/test/java/org/apache/druid/query/DruidMetricsTest.java
+++ b/processing/src/test/java/org/apache/druid/query/DruidMetricsTest.java
@@ -1,0 +1,48 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+package org.apache.druid.query;
+
+import org.apache.druid.error.DruidException;
+import org.junit.Assert;
+import org.junit.Test;
+
+public class DruidMetricsTest
+{
+  @Test
+  public void testComputeStatusCode_nullError()
+  {
+    Assert.assertEquals(200, DruidMetrics.computeStatusCode(null));
+  }
+
+  @Test
+  public void testComputeStatusCode_allDruidExceptionCategories()
+  {
+    for (DruidException.Category cat : DruidException.Category.values()) {
+      Assert.assertEquals(
+          cat.getExpectedStatus(), DruidMetrics.computeStatusCode(
+              DruidException.forPersona(DruidException.Persona.USER)
+                            .ofCategory(cat)
+                            .build("test")
+          )
+      );
+    }
+  }
+}
+

--- a/server/src/main/java/org/apache/druid/server/QueryLifecycle.java
+++ b/server/src/main/java/org/apache/druid/server/QueryLifecycle.java
@@ -439,6 +439,7 @@ public class QueryLifecycle
       statsMap.put("query/rowsScanned", rowsScanned);
       statsMap.put("query/cpu/time", cpuConsumedMillis);
       statsMap.put("success", success);
+      statsMap.put(DruidMetrics.CODE, DruidMetrics.computeStatusCode(e));
 
       if (authenticationResult != null) {
         statsMap.put("identity", authenticationResult.getIdentity());

--- a/server/src/main/java/org/apache/druid/server/QueryLifecycle.java
+++ b/server/src/main/java/org/apache/druid/server/QueryLifecycle.java
@@ -417,7 +417,9 @@ public class QueryLifecycle
           StringUtils.nullToEmptyNonDruidDataString(remoteAddress)
       );
       queryMetrics.success(success);
-      queryMetrics.code(e);
+
+      final int statusCode = DruidMetrics.computeStatusCode(e);
+      queryMetrics.statusCode(statusCode);
       queryMetrics.reportQueryTime(queryTimeNs);
 
       if (bytesWritten >= 0) {
@@ -439,7 +441,7 @@ public class QueryLifecycle
       statsMap.put("query/rowsScanned", rowsScanned);
       statsMap.put("query/cpu/time", cpuConsumedMillis);
       statsMap.put("success", success);
-      statsMap.put(DruidMetrics.CODE, DruidMetrics.computeStatusCode(e));
+      statsMap.put(DruidMetrics.STATUS_CODE, statusCode);
 
       if (authenticationResult != null) {
         statsMap.put("identity", authenticationResult.getIdentity());

--- a/server/src/main/java/org/apache/druid/server/QueryLifecycle.java
+++ b/server/src/main/java/org/apache/druid/server/QueryLifecycle.java
@@ -417,6 +417,7 @@ public class QueryLifecycle
           StringUtils.nullToEmptyNonDruidDataString(remoteAddress)
       );
       queryMetrics.success(success);
+      queryMetrics.code(e);
       queryMetrics.reportQueryTime(queryTimeNs);
 
       if (bytesWritten >= 0) {

--- a/server/src/test/java/org/apache/druid/server/QueryResourceTest.java
+++ b/server/src/test/java/org/apache/druid/server/QueryResourceTest.java
@@ -50,10 +50,13 @@ import org.apache.druid.java.util.common.guava.Yielders;
 import org.apache.druid.java.util.common.guava.YieldingAccumulator;
 import org.apache.druid.java.util.emitter.EmittingLogger;
 import org.apache.druid.java.util.emitter.service.ServiceEmitter;
+import org.apache.druid.java.util.emitter.service.ServiceMetricEvent;
+import org.apache.druid.java.util.metrics.StubServiceEmitter;
 import org.apache.druid.query.BadJsonQueryException;
 import org.apache.druid.query.DefaultGenericQueryMetricsFactory;
 import org.apache.druid.query.DefaultQueryConfig;
 import org.apache.druid.query.DefaultQueryRunnerFactoryConglomerate;
+import org.apache.druid.query.DruidMetrics;
 import org.apache.druid.query.Query;
 import org.apache.druid.query.QueryCapacityExceededException;
 import org.apache.druid.query.QueryException;
@@ -123,6 +126,7 @@ import java.util.concurrent.Executors;
 import java.util.concurrent.Future;
 import java.util.concurrent.atomic.AtomicReference;
 import java.util.function.Consumer;
+import java.util.stream.Collectors;
 
 public class QueryResourceTest
 {
@@ -214,6 +218,7 @@ public class QueryResourceTest
   private QueryResource queryResource;
   private QueryScheduler queryScheduler;
   private TestRequestLogger testRequestLogger;
+  private StubServiceEmitter emitter;
 
   @BeforeClass
   public static void staticSetup()
@@ -234,6 +239,7 @@ public class QueryResourceTest
 
     queryScheduler = QueryStackTests.DEFAULT_NOOP_SCHEDULER;
     testRequestLogger = new TestRequestLogger();
+    emitter = new StubServiceEmitter();
     queryResource = createQueryResource(ResponseContextConfig.newConfig(true));
   }
 
@@ -244,7 +250,7 @@ public class QueryResourceTest
             CONGLOMERATE,
             TEST_SEGMENT_WALKER,
             new DefaultGenericQueryMetricsFactory(),
-            new NoopServiceEmitter(),
+            emitter,
             testRequestLogger,
             new AuthConfig(),
             NoopPolicyEnforcer.instance(),
@@ -293,7 +299,7 @@ public class QueryResourceTest
             CONGLOMERATE,
             TEST_SEGMENT_WALKER,
             new DefaultGenericQueryMetricsFactory(),
-            new NoopServiceEmitter(),
+            emitter,
             testRequestLogger,
             new AuthConfig(),
             NoopPolicyEnforcer.instance(),
@@ -373,7 +379,7 @@ public class QueryResourceTest
               }
             },
             new DefaultGenericQueryMetricsFactory(),
-            new NoopServiceEmitter(),
+            emitter,
             testRequestLogger,
             new AuthConfig(),
             NoopPolicyEnforcer.instance(),
@@ -398,6 +404,8 @@ public class QueryResourceTest
 
     final Response response = expectSynchronousRequestFlow(SIMPLE_TIMESERIES_QUERY);
     Assert.assertEquals(Status.INTERNAL_SERVER_ERROR.getStatusCode(), response.getStatus());
+    emitter.verifyEmitted("query/time", 1);
+    Assert.assertEquals(500, emitter.getMetricEvents("query/time").get(0).toMap().get(DruidMetrics.CODE));
 
     final ErrorResponse entity = (ErrorResponse) response.getEntity();
     MatcherAssert.assertThat(
@@ -471,7 +479,7 @@ public class QueryResourceTest
               }
             },
             new DefaultGenericQueryMetricsFactory(),
-            new NoopServiceEmitter(),
+            emitter,
             testRequestLogger,
             new AuthConfig(),
             NoopPolicyEnforcer.instance(),
@@ -505,6 +513,91 @@ public class QueryResourceTest
 
     Assert.assertTrue(fields.containsKey(QueryResource.RESPONSE_COMPLETE_TRAILER_HEADER));
     Assert.assertEquals(fields.get(QueryResource.RESPONSE_COMPLETE_TRAILER_HEADER), "false");
+
+    emitter.verifyEmitted("query/time", 1);
+    Assert.assertEquals(504, emitter.getMetricEvents("query/time").get(0).toMap().get(DruidMetrics.CODE));
+  }
+
+  @Test
+  public void testResponseWithMidFlightExceptions() throws IOException
+  {
+    queryResource = new QueryResource(
+        new QueryLifecycleFactory(
+            CONGLOMERATE,
+            new QuerySegmentWalker()
+            {
+              @Override
+              public <T> QueryRunner<T> getQueryRunnerForIntervals(
+                  Query<T> query,
+                  Iterable<Interval> intervals
+              )
+              {
+                return (queryPlus, responseContext) -> new Sequence<T>()
+                {
+                  @Override
+                  public <OutType> OutType accumulate(OutType initValue, Accumulator<OutType, T> accumulator)
+                  {
+                    accumulator.accumulate(null,
+                                           (T) new TimeBoundaryResultValue(ImmutableMap.<String, Object>of("maxTime", DateTimes.of("2014-08-02")))
+                    );
+                    throw InvalidInput.exception("mid-flight exception");
+                  }
+
+                  @Override
+                  public <OutType> Yielder<OutType> toYielder(
+                      OutType initValue,
+                      YieldingAccumulator<OutType, T> accumulator
+                  )
+                  {
+                    throw new UnsupportedOperationException("not implemented");
+                  }
+                };
+              }
+
+              @Override
+              public <T> QueryRunner<T> getQueryRunnerForSegments(
+                  Query<T> query,
+                  Iterable<SegmentDescriptor> specs
+              )
+              {
+                throw new UnsupportedOperationException();
+              }
+            },
+            new DefaultGenericQueryMetricsFactory(),
+            emitter,
+            testRequestLogger,
+            new AuthConfig(),
+            NoopPolicyEnforcer.instance(),
+            AuthTestUtils.TEST_AUTHORIZER_MAPPER,
+            Suppliers.ofInstance(new DefaultQueryConfig(ImmutableMap.of()))
+        ),
+        jsonMapper,
+        queryScheduler,
+        null,
+        new QueryResourceQueryResultPusherFactory(
+            jsonMapper,
+            ResponseContextConfig.newConfig(true),
+            DRUID_NODE
+        ),
+        new ResourceIOReaderWriterFactory(jsonMapper, smileMapper)
+    );
+
+    expectPermissiveHappyPathAuth();
+
+    MockHttpServletResponse response = expectAsyncRequestFlow(testServletRequest,
+                                                              SIMPLE_TIMESERIES_QUERY_WRITE_EXCEPTION_AS_ROW.getBytes(
+                                                                  StandardCharsets.UTF_8),
+                                                              queryResource
+    );
+    String actualOutput = response.baos.toString(Charset.defaultCharset());
+    Assert.assertEquals(
+        "[{\"maxTime\":\"2014-08-02T00:00:00.000Z\"},{\"error\":\"druidException\","
+        + "\"errorCode\":\"invalidInput\",\"persona\":\"USER\",\"category\":\"INVALID_INPUT\","
+        + "\"errorMessage\":\"mid-flight exception\",\"context\":{}}]",
+        actualOutput
+    );
+    emitter.verifyEmitted("query/time", 1);
+    Assert.assertEquals(400, emitter.getMetricEvents("query/time").get(0).toMap().get(DruidMetrics.CODE));
   }
 
   @Test
@@ -569,7 +662,7 @@ public class QueryResourceTest
               }
             },
             new DefaultGenericQueryMetricsFactory(),
-            new NoopServiceEmitter(),
+            emitter,
             testRequestLogger,
             new AuthConfig(),
             NoopPolicyEnforcer.instance(),
@@ -606,6 +699,9 @@ public class QueryResourceTest
 
     Assert.assertTrue(fields.containsKey(QueryResource.RESPONSE_COMPLETE_TRAILER_HEADER));
     Assert.assertEquals("true", fields.get(QueryResource.RESPONSE_COMPLETE_TRAILER_HEADER));
+
+    emitter.verifyEmitted("query/time", 1);
+    Assert.assertEquals(200, emitter.getMetricEvents("query/time").get(0).toMap().get(DruidMetrics.CODE));
   }
 
 
@@ -649,7 +745,7 @@ public class QueryResourceTest
                 CONGLOMERATE,
                 querySegmentWalker,
                 new DefaultGenericQueryMetricsFactory(),
-                new NoopServiceEmitter(),
+                emitter,
                 testRequestLogger,
                 AuthTestUtils.TEST_AUTHORIZER_MAPPER,
                 overrideConfig,
@@ -662,6 +758,7 @@ public class QueryResourceTest
               @Override
               public void emitLogsAndMetrics(@Nullable Throwable e, @Nullable String remoteAddress, long bytesWritten, long rowsScanned, long cpuConsumedMillis)
               {
+                super.emitLogsAndMetrics(e, remoteAddress, bytesWritten);
                 Assert.assertTrue(Throwables.getStackTraceAsString(e).contains(embeddedExceptionMessage));
               }
             };
@@ -695,6 +792,8 @@ public class QueryResourceTest
         )
             .expectMessageIs("something")
     );
+    emitter.verifyEmitted("query/time", 1);
+    Assert.assertEquals(500, emitter.getMetricEvents("query/time").get(0).toMap().get(DruidMetrics.CODE));
   }
 
   @Test
@@ -708,7 +807,7 @@ public class QueryResourceTest
             CONGLOMERATE,
             TEST_SEGMENT_WALKER,
             new DefaultGenericQueryMetricsFactory(),
-            new NoopServiceEmitter(),
+            emitter,
             testRequestLogger,
             new AuthConfig(),
             NoopPolicyEnforcer.instance(),
@@ -755,6 +854,8 @@ public class QueryResourceTest
         -1,
         testRequestLogger.getNativeQuerylogs().get(0).getQuery().getContext().get(overrideConfigKey)
     );
+    emitter.verifyEmitted("query/time", 1);
+    Assert.assertEquals(200, emitter.getMetricEvents("query/time").get(0).toMap().get(DruidMetrics.CODE));
   }
 
   @Test
@@ -779,6 +880,8 @@ public class QueryResourceTest
         expectedException,
         jsonMapper.readValue(response.baos.toByteArray(), QueryInterruptedException.class).toString()
     );
+    emitter.verifyEmitted("query/time", 1);
+    Assert.assertEquals(500, emitter.getMetricEvents("query/time").get(0).toMap().get(DruidMetrics.CODE));
   }
 
   @Test
@@ -793,6 +896,10 @@ public class QueryResourceTest
         queryResource
     );
     Assert.assertEquals(HttpStatus.SC_OK, response.getStatus());
+
+    emitter.verifyEmitted("query/time", 1);
+    Assert.assertEquals(1, queryResource.getSuccessfulQueryCount());
+    Assert.assertEquals(200, emitter.getMetricEvents("query/time").get(0).toMap().get(DruidMetrics.CODE));
   }
 
   @Test
@@ -805,6 +912,10 @@ public class QueryResourceTest
     Assert.assertEquals(HttpStatus.SC_OK, response.getStatus());
     //since accept header is null, the response content type should be same as the value of 'Content-Type' header
     Assert.assertEquals(MediaType.APPLICATION_JSON, response.getContentType());
+
+    emitter.verifyEmitted("query/time", 1);
+    Assert.assertEquals(1, queryResource.getSuccessfulQueryCount());
+    Assert.assertEquals(200, emitter.getMetricEvents("query/time").get(0).toMap().get(DruidMetrics.CODE));
   }
 
   @Test
@@ -818,6 +929,10 @@ public class QueryResourceTest
     Assert.assertEquals(HttpStatus.SC_OK, response.getStatus());
     //since accept header is empty, the response content type should be same as the value of 'Content-Type' header
     Assert.assertEquals(MediaType.APPLICATION_JSON, response.getContentType());
+
+    emitter.verifyEmitted("query/time", 1);
+    Assert.assertEquals(1, queryResource.getSuccessfulQueryCount());
+    Assert.assertEquals(200, emitter.getMetricEvents("query/time").get(0).toMap().get(DruidMetrics.CODE));
   }
 
   @Test
@@ -833,6 +948,10 @@ public class QueryResourceTest
 
     // Content-Type in response should be Smile
     Assert.assertEquals(SmileMediaTypes.APPLICATION_JACKSON_SMILE, response.getContentType());
+
+    emitter.verifyEmitted("query/time", 1);
+    Assert.assertEquals(1, queryResource.getSuccessfulQueryCount());
+    Assert.assertEquals(200, emitter.getMetricEvents("query/time").get(0).toMap().get(DruidMetrics.CODE));
   }
 
   @Test
@@ -853,6 +972,10 @@ public class QueryResourceTest
 
     // Content-Type in response should be Smile
     Assert.assertEquals(SmileMediaTypes.APPLICATION_JACKSON_SMILE, response.getContentType());
+
+    emitter.verifyEmitted("query/time", 1);
+    Assert.assertEquals(1, queryResource.getSuccessfulQueryCount());
+    Assert.assertEquals(200, emitter.getMetricEvents("query/time").get(0).toMap().get(DruidMetrics.CODE));
   }
 
   @Test
@@ -872,6 +995,10 @@ public class QueryResourceTest
 
     // Content-Type in response should default to Content-Type from request
     Assert.assertEquals(SmileMediaTypes.APPLICATION_JACKSON_SMILE, response.getContentType());
+
+    emitter.verifyEmitted("query/time", 1);
+    Assert.assertEquals(1, queryResource.getSuccessfulQueryCount());
+    Assert.assertEquals(200, emitter.getMetricEvents("query/time").get(0).toMap().get(DruidMetrics.CODE));
   }
 
   @Test
@@ -1032,7 +1159,7 @@ public class QueryResourceTest
             CONGLOMERATE,
             timeoutSegmentWalker,
             new DefaultGenericQueryMetricsFactory(),
-            new NoopServiceEmitter(),
+            emitter,
             testRequestLogger,
             new AuthConfig(),
             NoopPolicyEnforcer.instance(),
@@ -1081,6 +1208,8 @@ public class QueryResourceTest
     Assert.assertEquals(QueryException.QUERY_TIMEOUT_ERROR_CODE, ex.getErrorCode());
     Assert.assertEquals(1, timeoutQueryResource.getTimedOutQueryCount());
 
+    emitter.verifyEmitted("query/time", 1);
+    Assert.assertEquals(504, emitter.getMetricEvents("query/time").get(0).toMap().get(DruidMetrics.CODE));
   }
 
   @Test(timeout = 60_000L)
@@ -1381,6 +1510,16 @@ public class QueryResourceTest
     }
     Assert.assertEquals(2, queryResource.getSuccessfulQueryCount());
     Assert.assertEquals(1, queryResource.getFailedQueryCount());
+
+    emitter.verifyEmitted("query/time", 3);
+    Map<Integer, Long> codeFrequencies = emitter.getMetricEvents("query/time").stream()
+                                                .map(ServiceMetricEvent::toMap)
+                                                .map(map -> (int) map.get(DruidMetrics.CODE))
+                                                .collect(Collectors.groupingBy(
+                                                    code -> code,
+                                                    Collectors.counting()
+                                                ));
+    Assert.assertEquals(Map.of(200, 2L, 429, 1L), codeFrequencies);
   }
 
   @Test(timeout = 10_000L)
@@ -1451,6 +1590,16 @@ public class QueryResourceTest
     for (Future<Boolean> theFuture : back2) {
       Assert.assertTrue(theFuture.get());
     }
+
+    emitter.verifyEmitted("query/time", 3);
+    Map<Integer, Long> codeFrequencies = emitter.getMetricEvents("query/time").stream()
+                                                .map(ServiceMetricEvent::toMap)
+                                                .map(map -> (int) map.get(DruidMetrics.CODE))
+                                                .collect(Collectors.groupingBy(
+                                                    code -> code,
+                                                    Collectors.counting()
+                                                ));
+    Assert.assertEquals(Map.of(200, 2L, 429, 1L), codeFrequencies);
   }
 
   @Test(timeout = 10_000L)
@@ -1519,6 +1668,15 @@ public class QueryResourceTest
     for (Future<Boolean> theFuture : back2) {
       Assert.assertTrue(theFuture.get());
     }
+    emitter.verifyEmitted("query/time", 3);
+    Map<Integer, Long> codeFrequencies = emitter.getMetricEvents("query/time").stream()
+                                                .map(ServiceMetricEvent::toMap)
+                                                .map(map -> (int) map.get(DruidMetrics.CODE))
+                                                .collect(Collectors.groupingBy(
+                                                    code -> code,
+                                                    Collectors.counting()
+                                                ));
+    Assert.assertEquals(Map.of(200, 2L, 429, 1L), codeFrequencies);
   }
 
   @Test
@@ -1607,7 +1765,7 @@ public class QueryResourceTest
             CONGLOMERATE,
             texasRanger,
             new DefaultGenericQueryMetricsFactory(),
-            new NoopServiceEmitter(),
+            emitter,
             testRequestLogger,
             new AuthConfig(),
             NoopPolicyEnforcer.instance(),

--- a/server/src/test/java/org/apache/druid/server/QueryResourceTest.java
+++ b/server/src/test/java/org/apache/druid/server/QueryResourceTest.java
@@ -405,7 +405,7 @@ public class QueryResourceTest
     final Response response = expectSynchronousRequestFlow(SIMPLE_TIMESERIES_QUERY);
     Assert.assertEquals(Status.INTERNAL_SERVER_ERROR.getStatusCode(), response.getStatus());
     emitter.verifyEmitted("query/time", 1);
-    Assert.assertEquals(500, emitter.getMetricEvents("query/time").get(0).toMap().get(DruidMetrics.CODE));
+    Assert.assertEquals(500, emitter.getMetricEvents("query/time").get(0).toMap().get(DruidMetrics.STATUS_CODE));
 
     final ErrorResponse entity = (ErrorResponse) response.getEntity();
     MatcherAssert.assertThat(
@@ -515,7 +515,7 @@ public class QueryResourceTest
     Assert.assertEquals(fields.get(QueryResource.RESPONSE_COMPLETE_TRAILER_HEADER), "false");
 
     emitter.verifyEmitted("query/time", 1);
-    Assert.assertEquals(504, emitter.getMetricEvents("query/time").get(0).toMap().get(DruidMetrics.CODE));
+    Assert.assertEquals(504, emitter.getMetricEvents("query/time").get(0).toMap().get(DruidMetrics.STATUS_CODE));
   }
 
   @Test
@@ -597,7 +597,7 @@ public class QueryResourceTest
         actualOutput
     );
     emitter.verifyEmitted("query/time", 1);
-    Assert.assertEquals(400, emitter.getMetricEvents("query/time").get(0).toMap().get(DruidMetrics.CODE));
+    Assert.assertEquals(400, emitter.getMetricEvents("query/time").get(0).toMap().get(DruidMetrics.STATUS_CODE));
   }
 
   @Test
@@ -701,7 +701,7 @@ public class QueryResourceTest
     Assert.assertEquals("true", fields.get(QueryResource.RESPONSE_COMPLETE_TRAILER_HEADER));
 
     emitter.verifyEmitted("query/time", 1);
-    Assert.assertEquals(200, emitter.getMetricEvents("query/time").get(0).toMap().get(DruidMetrics.CODE));
+    Assert.assertEquals(200, emitter.getMetricEvents("query/time").get(0).toMap().get(DruidMetrics.STATUS_CODE));
   }
 
 
@@ -793,7 +793,7 @@ public class QueryResourceTest
             .expectMessageIs("something")
     );
     emitter.verifyEmitted("query/time", 1);
-    Assert.assertEquals(500, emitter.getMetricEvents("query/time").get(0).toMap().get(DruidMetrics.CODE));
+    Assert.assertEquals(500, emitter.getMetricEvents("query/time").get(0).toMap().get(DruidMetrics.STATUS_CODE));
   }
 
   @Test
@@ -855,7 +855,7 @@ public class QueryResourceTest
         testRequestLogger.getNativeQuerylogs().get(0).getQuery().getContext().get(overrideConfigKey)
     );
     emitter.verifyEmitted("query/time", 1);
-    Assert.assertEquals(200, emitter.getMetricEvents("query/time").get(0).toMap().get(DruidMetrics.CODE));
+    Assert.assertEquals(200, emitter.getMetricEvents("query/time").get(0).toMap().get(DruidMetrics.STATUS_CODE));
   }
 
   @Test
@@ -881,7 +881,7 @@ public class QueryResourceTest
         jsonMapper.readValue(response.baos.toByteArray(), QueryInterruptedException.class).toString()
     );
     emitter.verifyEmitted("query/time", 1);
-    Assert.assertEquals(500, emitter.getMetricEvents("query/time").get(0).toMap().get(DruidMetrics.CODE));
+    Assert.assertEquals(500, emitter.getMetricEvents("query/time").get(0).toMap().get(DruidMetrics.STATUS_CODE));
   }
 
   @Test
@@ -899,7 +899,7 @@ public class QueryResourceTest
 
     emitter.verifyEmitted("query/time", 1);
     Assert.assertEquals(1, queryResource.getSuccessfulQueryCount());
-    Assert.assertEquals(200, emitter.getMetricEvents("query/time").get(0).toMap().get(DruidMetrics.CODE));
+    Assert.assertEquals(200, emitter.getMetricEvents("query/time").get(0).toMap().get(DruidMetrics.STATUS_CODE));
   }
 
   @Test
@@ -915,7 +915,7 @@ public class QueryResourceTest
 
     emitter.verifyEmitted("query/time", 1);
     Assert.assertEquals(1, queryResource.getSuccessfulQueryCount());
-    Assert.assertEquals(200, emitter.getMetricEvents("query/time").get(0).toMap().get(DruidMetrics.CODE));
+    Assert.assertEquals(200, emitter.getMetricEvents("query/time").get(0).toMap().get(DruidMetrics.STATUS_CODE));
   }
 
   @Test
@@ -932,7 +932,7 @@ public class QueryResourceTest
 
     emitter.verifyEmitted("query/time", 1);
     Assert.assertEquals(1, queryResource.getSuccessfulQueryCount());
-    Assert.assertEquals(200, emitter.getMetricEvents("query/time").get(0).toMap().get(DruidMetrics.CODE));
+    Assert.assertEquals(200, emitter.getMetricEvents("query/time").get(0).toMap().get(DruidMetrics.STATUS_CODE));
   }
 
   @Test
@@ -951,7 +951,7 @@ public class QueryResourceTest
 
     emitter.verifyEmitted("query/time", 1);
     Assert.assertEquals(1, queryResource.getSuccessfulQueryCount());
-    Assert.assertEquals(200, emitter.getMetricEvents("query/time").get(0).toMap().get(DruidMetrics.CODE));
+    Assert.assertEquals(200, emitter.getMetricEvents("query/time").get(0).toMap().get(DruidMetrics.STATUS_CODE));
   }
 
   @Test
@@ -975,7 +975,7 @@ public class QueryResourceTest
 
     emitter.verifyEmitted("query/time", 1);
     Assert.assertEquals(1, queryResource.getSuccessfulQueryCount());
-    Assert.assertEquals(200, emitter.getMetricEvents("query/time").get(0).toMap().get(DruidMetrics.CODE));
+    Assert.assertEquals(200, emitter.getMetricEvents("query/time").get(0).toMap().get(DruidMetrics.STATUS_CODE));
   }
 
   @Test
@@ -998,7 +998,7 @@ public class QueryResourceTest
 
     emitter.verifyEmitted("query/time", 1);
     Assert.assertEquals(1, queryResource.getSuccessfulQueryCount());
-    Assert.assertEquals(200, emitter.getMetricEvents("query/time").get(0).toMap().get(DruidMetrics.CODE));
+    Assert.assertEquals(200, emitter.getMetricEvents("query/time").get(0).toMap().get(DruidMetrics.STATUS_CODE));
   }
 
   @Test
@@ -1209,7 +1209,7 @@ public class QueryResourceTest
     Assert.assertEquals(1, timeoutQueryResource.getTimedOutQueryCount());
 
     emitter.verifyEmitted("query/time", 1);
-    Assert.assertEquals(504, emitter.getMetricEvents("query/time").get(0).toMap().get(DruidMetrics.CODE));
+    Assert.assertEquals(504, emitter.getMetricEvents("query/time").get(0).toMap().get(DruidMetrics.STATUS_CODE));
   }
 
   @Test(timeout = 60_000L)
@@ -1514,7 +1514,7 @@ public class QueryResourceTest
     emitter.verifyEmitted("query/time", 3);
     Map<Integer, Long> codeFrequencies = emitter.getMetricEvents("query/time").stream()
                                                 .map(ServiceMetricEvent::toMap)
-                                                .map(map -> (int) map.get(DruidMetrics.CODE))
+                                                .map(map -> (int) map.get(DruidMetrics.STATUS_CODE))
                                                 .collect(Collectors.groupingBy(
                                                     code -> code,
                                                     Collectors.counting()
@@ -1594,7 +1594,7 @@ public class QueryResourceTest
     emitter.verifyEmitted("query/time", 3);
     Map<Integer, Long> codeFrequencies = emitter.getMetricEvents("query/time").stream()
                                                 .map(ServiceMetricEvent::toMap)
-                                                .map(map -> (int) map.get(DruidMetrics.CODE))
+                                                .map(map -> (int) map.get(DruidMetrics.STATUS_CODE))
                                                 .collect(Collectors.groupingBy(
                                                     code -> code,
                                                     Collectors.counting()
@@ -1671,7 +1671,7 @@ public class QueryResourceTest
     emitter.verifyEmitted("query/time", 3);
     Map<Integer, Long> codeFrequencies = emitter.getMetricEvents("query/time").stream()
                                                 .map(ServiceMetricEvent::toMap)
-                                                .map(map -> (int) map.get(DruidMetrics.CODE))
+                                                .map(map -> (int) map.get(DruidMetrics.STATUS_CODE))
                                                 .collect(Collectors.groupingBy(
                                                     code -> code,
                                                     Collectors.counting()

--- a/services/src/main/java/org/apache/druid/server/AsyncQueryForwardingServlet.java
+++ b/services/src/main/java/org/apache/druid/server/AsyncQueryForwardingServlet.java
@@ -817,8 +817,7 @@ public class AsyncQueryForwardingServlet extends AsyncProxyServlet implements Qu
                         "query/time",
                         TimeUnit.NANOSECONDS.toMillis(requestTimeNs),
                         "success",
-                        success
-                        && result.getResponse().getStatus() == Status.OK.getStatusCode(),
+                        success,
                         "identity",
                         authenticationResult.getIdentity()
                     )

--- a/services/src/main/java/org/apache/druid/server/AsyncQueryForwardingServlet.java
+++ b/services/src/main/java/org/apache/druid/server/AsyncQueryForwardingServlet.java
@@ -107,7 +107,8 @@ public class AsyncQueryForwardingServlet extends AsyncProxyServlet implements Qu
   private static final String PROPERTY_SQL_ENABLE_DEFAULT = "false";
 
   private static final long CANCELLATION_TIMEOUT_MILLIS = TimeUnit.SECONDS.toMillis(5);
-  private static final int UNASSIGNED_DEFAULT_STATUS_CODE = 0; // Jetty-specific default (un-assigned) status code
+  // Jetty-specific default (un-assigned) status code
+  private static final int UNASSIGNED_DEFAULT_STATUS_CODE = 0;
 
   private final AtomicLong successfulQueryCount = new AtomicLong();
   private final AtomicLong failedQueryCount = new AtomicLong();
@@ -770,7 +771,8 @@ public class AsyncQueryForwardingServlet extends AsyncProxyServlet implements Qu
       }
 
       // As router is simply a proxy, we don't make an effort to construct the error code from the exception ourselves.
-      // We rely on broker to set this for us if the error occurs downstream. Otherwise, if there's a router/client error, we log this as an ISE.
+      // We rely on broker to set this for us if the error occurs downstream.
+      // Otherwise, if there's a router/client error, we log this as an unknown error.
       emitQueryTime(requestTimeNs, success, sqlQueryId, queryId, statusCode);
 
       AuthenticationResult authenticationResult = AuthorizationUtils.authenticationResultFromRequest(req);
@@ -858,7 +860,8 @@ public class AsyncQueryForwardingServlet extends AsyncProxyServlet implements Qu
       failedQueryCount.incrementAndGet();
 
       // As router is simply a proxy, we don't make an effort to construct the error code from the exception ourselves.
-      // We rely on broker to set this for us if the error occurs downstream. Otherwise, if there's a router/client error, we log this as an ISE.
+      // We rely on broker to set this for us if the error occurs downstream. 
+      // Otherwise, if there's a router/client error, we log this as an unknown error.
       final int statusCode = determineStatusCode(false, response.getStatus());
       emitQueryTime(requestTimeNs, false, sqlQueryId, queryId, statusCode);
       AuthenticationResult authenticationResult = AuthorizationUtils.authenticationResultFromRequest(req);

--- a/services/src/main/java/org/apache/druid/server/AsyncQueryForwardingServlet.java
+++ b/services/src/main/java/org/apache/druid/server/AsyncQueryForwardingServlet.java
@@ -766,7 +766,7 @@ public class AsyncQueryForwardingServlet extends AsyncProxyServlet implements Qu
       } else {
         failedQueryCount.incrementAndGet();
       }
-      emitQueryTime(requestTimeNs, success, sqlQueryId, queryId);
+      emitQueryTime(requestTimeNs, success, sqlQueryId, queryId, result.getFailure());
 
       AuthenticationResult authenticationResult = AuthorizationUtils.authenticationResultFromRequest(req);
 
@@ -853,7 +853,7 @@ public class AsyncQueryForwardingServlet extends AsyncProxyServlet implements Qu
       }
 
       failedQueryCount.incrementAndGet();
-      emitQueryTime(requestTimeNs, false, sqlQueryId, queryId);
+      emitQueryTime(requestTimeNs, false, sqlQueryId, queryId, failure);
       AuthenticationResult authenticationResult = AuthorizationUtils.authenticationResultFromRequest(req);
 
       //noinspection VariableNotUsedInsideIf
@@ -929,7 +929,8 @@ public class AsyncQueryForwardingServlet extends AsyncProxyServlet implements Qu
         long requestTimeNs,
         boolean success,
         @Nullable String sqlQueryId,
-        @Nullable String queryId
+        @Nullable String queryId,
+        Throwable queryException
     )
     {
       QueryMetrics queryMetrics;
@@ -950,6 +951,7 @@ public class AsyncQueryForwardingServlet extends AsyncProxyServlet implements Qu
         );
       }
       queryMetrics.success(success);
+      queryMetrics.code(queryException);
       queryMetrics.reportQueryTime(requestTimeNs).emit(emitter);
     }
   }

--- a/services/src/main/java/org/apache/druid/server/AsyncQueryForwardingServlet.java
+++ b/services/src/main/java/org/apache/druid/server/AsyncQueryForwardingServlet.java
@@ -107,6 +107,7 @@ public class AsyncQueryForwardingServlet extends AsyncProxyServlet implements Qu
   private static final String PROPERTY_SQL_ENABLE_DEFAULT = "false";
 
   private static final long CANCELLATION_TIMEOUT_MILLIS = TimeUnit.SECONDS.toMillis(5);
+  private static final int UNASSIGNED_DEFAULT_STATUS_CODE = 0; // Jetty-specific default (un-assigned) status code
 
   private final AtomicLong successfulQueryCount = new AtomicLong();
   private final AtomicLong failedQueryCount = new AtomicLong();
@@ -760,8 +761,8 @@ public class AsyncQueryForwardingServlet extends AsyncProxyServlet implements Qu
         return;
       }
 
-      final int statusCode = result.getResponse().getStatus();
-      boolean success = result.isSucceeded() && statusCode == Status.OK.getStatusCode();
+      final boolean success = result.isSucceeded() && result.getResponse().getStatus() == Status.OK.getStatusCode();
+      final int statusCode = determineStatusCode(success, result.getResponse().getStatus());
       if (success) {
         successfulQueryCount.incrementAndGet();
       } else {
@@ -769,7 +770,7 @@ public class AsyncQueryForwardingServlet extends AsyncProxyServlet implements Qu
       }
 
       // As router is simply a proxy, we don't make an effort to construct the error code from the exception ourselves.
-      // We rely on broker to set this for us if the error occurs downstream.
+      // We rely on broker to set this for us if the error occurs downstream. Otherwise, if there's a router/client error, we log this as an ISE.
       emitQueryTime(requestTimeNs, success, sqlQueryId, queryId, statusCode);
 
       AuthenticationResult authenticationResult = AuthorizationUtils.authenticationResultFromRequest(req);
@@ -857,8 +858,9 @@ public class AsyncQueryForwardingServlet extends AsyncProxyServlet implements Qu
       failedQueryCount.incrementAndGet();
 
       // As router is simply a proxy, we don't make an effort to construct the error code from the exception ourselves.
-      // We rely on broker to set this for us if the error occurs downstream.
-      emitQueryTime(requestTimeNs, false, sqlQueryId, queryId, response.getStatus());
+      // We rely on broker to set this for us if the error occurs downstream. Otherwise, if there's a router/client error, we log this as an ISE.
+      final int statusCode = determineStatusCode(false, response.getStatus());
+      emitQueryTime(requestTimeNs, false, sqlQueryId, queryId, statusCode);
       AuthenticationResult authenticationResult = AuthorizationUtils.authenticationResultFromRequest(req);
 
       //noinspection VariableNotUsedInsideIf
@@ -959,5 +961,25 @@ public class AsyncQueryForwardingServlet extends AsyncProxyServlet implements Qu
       queryMetrics.statusCode(statusCode);
       queryMetrics.reportQueryTime(requestTimeNs).emit(emitter);
     }
+  }
+
+  /**
+   * Helper method to assign reasonable status codes in ambigious cases like client/broker connection errors.
+   *
+   * @param success Whether the query was successful
+   * @param statusCode Status code reported by the broker (or {@value UNASSIGNED_DEFAULT_STATUS_CODE})
+   */
+  private static int determineStatusCode(boolean success, int statusCode)
+  {
+    if (success) {
+      if (statusCode == UNASSIGNED_DEFAULT_STATUS_CODE) {
+        statusCode = Status.OK.getStatusCode();
+      }
+    } else {
+      if (statusCode == UNASSIGNED_DEFAULT_STATUS_CODE || statusCode == Status.OK.getStatusCode()) {
+        statusCode = Status.INTERNAL_SERVER_ERROR.getStatusCode();
+      }
+    }
+    return statusCode;
   }
 }

--- a/services/src/test/java/org/apache/druid/server/AsyncQueryForwardingServletTest.java
+++ b/services/src/test/java/org/apache/druid/server/AsyncQueryForwardingServletTest.java
@@ -92,6 +92,7 @@ import org.eclipse.jetty.ee8.servlet.ServletHolder;
 import org.eclipse.jetty.http.HttpField;
 import org.eclipse.jetty.http.HttpFields;
 import org.eclipse.jetty.http.HttpVersion;
+import org.eclipse.jetty.io.EofException;
 import org.eclipse.jetty.server.Handler;
 import org.eclipse.jetty.server.Server;
 import org.junit.Assert;
@@ -529,6 +530,132 @@ public class AsyncQueryForwardingServletTest extends BaseJettyTest
     );
     Assert.assertEquals("false", stubServiceEmitter.getMetricEvents("query/time").get(0).toMap().get("success"));
   }
+
+  @Test
+  public void testOnCompleteWithClosedException()
+  {
+    final TimeseriesQuery query = Druids.newTimeseriesQueryBuilder()
+                                        .dataSource("foo")
+                                        .intervals("2000/P1D")
+                                        .granularity(Granularities.ALL)
+                                        .context(ImmutableMap.of("queryId", "closed-test"))
+                                        .build();
+
+    final HttpServletRequest requestMock = Mockito.mock(HttpServletRequest.class);
+    Mockito.when(requestMock.getAttribute("org.apache.druid.proxy.avaticaQuery")).thenReturn(null);
+    Mockito.when(requestMock.getAttribute("org.apache.druid.proxy.query")).thenReturn(query);
+    Mockito.when(requestMock.getAttribute("org.apache.druid.proxy.sqlQuery")).thenReturn(null);
+    Mockito.when(requestMock.getRemoteAddr()).thenReturn("127.0.0.1");
+    Mockito.when(requestMock.getAttribute(AuthConfig.DRUID_AUTHENTICATION_RESULT))
+           .thenReturn(new AuthenticationResult("testUser", "basic", "basic", null));
+
+    final Request proxyRequestMock = Mockito.mock(Request.class);
+    final Response responseMock = Mockito.mock(Response.class);
+    Mockito.when(responseMock.getStatus()).thenReturn(200); // Status OK
+    Mockito.when(responseMock.getHeaders()).thenReturn(HttpFields.build());
+    Mockito.when(responseMock.getRequest()).thenReturn(proxyRequestMock);
+
+    // Result where connection is closed prematurely
+    final Result result = new Result(proxyRequestMock, responseMock)
+    {
+      @Override
+      public boolean isSucceeded()
+      {
+        return false;
+      }
+
+      @Override
+      public Throwable getFailure()
+      {
+        return new EofException("Stream closed");
+      }
+    };
+
+    final StubServiceEmitter stubServiceEmitter = new StubServiceEmitter("", "");
+    final AsyncQueryForwardingServlet servlet = new AsyncQueryForwardingServlet(
+        new MapQueryToolChestWarehouse(ImmutableMap.of()),
+        TestHelper.makeJsonMapper(),
+        TestHelper.makeSmileMapper(),
+        null,
+        null,
+        null,
+        stubServiceEmitter,
+        NoopRequestLogger.instance(),
+        new DefaultGenericQueryMetricsFactory(),
+        new AuthenticatorMapper(ImmutableMap.of()),
+        new Properties(),
+        new ServerConfig()
+    );
+
+    try {
+      servlet.newProxyResponseListener(requestMock, null).onComplete(result);
+    }
+    catch (NullPointerException ignored) {
+    }
+
+    stubServiceEmitter.verifyEmitted("query/time", 1);
+    Assert.assertEquals("closed-test", stubServiceEmitter.getEvents().get(0).toMap().get("id"));
+    Assert.assertEquals(
+        500,
+        stubServiceEmitter.getMetricEvents("query/time").get(0).toMap().get(DruidMetrics.STATUS_CODE)
+    );
+    Assert.assertEquals("false", stubServiceEmitter.getMetricEvents("query/time").get(0).toMap().get("success"));
+  }
+
+  @Test
+  public void testOnFailureWithExceptionAndUnassignedStatusCode()
+  {
+    final TimeseriesQuery query = Druids.newTimeseriesQueryBuilder()
+                                        .dataSource("foo")
+                                        .intervals("2000/P1D")
+                                        .granularity(Granularities.ALL)
+                                        .context(ImmutableMap.of("queryId", "zero-status-test"))
+                                        .build();
+
+    final HttpServletRequest requestMock = Mockito.mock(HttpServletRequest.class);
+    Mockito.when(requestMock.getAttribute("org.apache.druid.proxy.avaticaQuery")).thenReturn(null);
+    Mockito.when(requestMock.getAttribute("org.apache.druid.proxy.query")).thenReturn(query);
+    Mockito.when(requestMock.getAttribute("org.apache.druid.proxy.sqlQuery")).thenReturn(null);
+    Mockito.when(requestMock.getRemoteAddr()).thenReturn("127.0.0.1");
+    Mockito.when(requestMock.getAttribute(AuthConfig.DRUID_AUTHENTICATION_RESULT))
+           .thenReturn(new AuthenticationResult("testUser", "basic", "basic", null));
+
+    final Response responseMock = Mockito.mock(Response.class);
+    Mockito.when(responseMock.getStatus()).thenReturn(0); // Test unassigned http status code case from server
+    Mockito.when(responseMock.getHeaders()).thenReturn(HttpFields.build());
+
+    final StubServiceEmitter stubServiceEmitter = new StubServiceEmitter("", "");
+    final AsyncQueryForwardingServlet servlet = new AsyncQueryForwardingServlet(
+        new MapQueryToolChestWarehouse(ImmutableMap.of()),
+        TestHelper.makeJsonMapper(),
+        TestHelper.makeSmileMapper(),
+        null,
+        null,
+        null,
+        stubServiceEmitter,
+        NoopRequestLogger.instance(),
+        new DefaultGenericQueryMetricsFactory(),
+        new AuthenticatorMapper(ImmutableMap.of()),
+        new Properties(),
+        new ServerConfig()
+    );
+
+    try {
+      servlet.newProxyResponseListener(requestMock, null)
+             .onFailure(responseMock, new IOException("Connection reset by peer"));
+    }
+    catch (NullPointerException ignored) {
+    }
+
+    stubServiceEmitter.verifyEmitted("query/time", 1);
+    Assert.assertEquals("zero-status-test", stubServiceEmitter.getEvents().get(0).toMap().get("id"));
+    Assert.assertEquals(
+        500, // Should default to 500 when status is 0
+        stubServiceEmitter.getMetricEvents("query/time").get(0).toMap().get(DruidMetrics.STATUS_CODE)
+    );
+    Assert.assertEquals("false", stubServiceEmitter.getMetricEvents("query/time").get(0).toMap().get("success"));
+  }
+
 
   @Test
   public void testNoParseExceptionOnGroupByWithFilteredAggregationOnLookups() throws Exception

--- a/services/src/test/java/org/apache/druid/server/AsyncQueryForwardingServletTest.java
+++ b/services/src/test/java/org/apache/druid/server/AsyncQueryForwardingServletTest.java
@@ -467,6 +467,70 @@ public class AsyncQueryForwardingServletTest extends BaseJettyTest
   }
 
   @Test
+  public void testMetricsEmittedWithErrorStatusCodeButNoResultException()
+  {
+    final TimeseriesQuery query = Druids.newTimeseriesQueryBuilder()
+                                        .dataSource("foo")
+                                        .intervals("2000/P1D")
+                                        .granularity(Granularities.ALL)
+                                        .context(ImmutableMap.of("queryId", "test-query-504"))
+                                        .build();
+
+    final HttpServletRequest requestMock = Mockito.mock(HttpServletRequest.class);
+    Mockito.when(requestMock.getAttribute("org.apache.druid.proxy.avaticaQuery")).thenReturn(null);
+    Mockito.when(requestMock.getAttribute("org.apache.druid.proxy.query")).thenReturn(query);
+    Mockito.when(requestMock.getAttribute("org.apache.druid.proxy.sqlQuery")).thenReturn(null);
+    Mockito.when(requestMock.getRemoteAddr()).thenReturn("127.0.0.1");
+    Mockito.when(requestMock.getAttribute(AuthConfig.DRUID_AUTHENTICATION_RESULT))
+           .thenReturn(new AuthenticationResult("testUser", "basic", "basic", null));
+
+    final Request proxyRequestMock = Mockito.mock(Request.class);
+    final Response responseMock = Mockito.mock(Response.class);
+    Mockito.when(responseMock.getStatus()).thenReturn(504); // Gateway Timeout
+    Mockito.when(responseMock.getHeaders()).thenReturn(HttpFields.build());
+    Mockito.when(responseMock.getRequest()).thenReturn(proxyRequestMock);
+
+    final Result result = new Result(proxyRequestMock, responseMock)
+    {
+      @Override
+      public Throwable getFailure()
+      {
+        return null; // No exception thrown
+      }
+    };
+
+    final StubServiceEmitter stubServiceEmitter = new StubServiceEmitter("", "");
+    final AsyncQueryForwardingServlet servlet = new AsyncQueryForwardingServlet(
+        new MapQueryToolChestWarehouse(ImmutableMap.of()),
+        TestHelper.makeJsonMapper(),
+        TestHelper.makeSmileMapper(),
+        null,
+        null,
+        null,
+        stubServiceEmitter,
+        NoopRequestLogger.instance(),
+        new DefaultGenericQueryMetricsFactory(),
+        new AuthenticatorMapper(ImmutableMap.of()),
+        new Properties(),
+        new ServerConfig()
+    );
+
+    try {
+      servlet.newProxyResponseListener(requestMock, null).onComplete(result);
+    }
+    catch (NullPointerException ignored) {
+    }
+
+    stubServiceEmitter.verifyEmitted("query/time", 1);
+    Assert.assertEquals("test-query-504", stubServiceEmitter.getEvents().get(0).toMap().get("id"));
+    Assert.assertEquals(
+        504,
+        stubServiceEmitter.getMetricEvents("query/time").get(0).toMap().get(DruidMetrics.STATUS_CODE)
+    );
+    Assert.assertEquals("false", stubServiceEmitter.getMetricEvents("query/time").get(0).toMap().get("success"));
+  }
+
+  @Test
   public void testNoParseExceptionOnGroupByWithFilteredAggregationOnLookups() throws Exception
   {
     class TestLookupReferenceManager implements LookupExtractorFactoryContainerProvider
@@ -725,9 +789,15 @@ public class AsyncQueryForwardingServletTest extends BaseJettyTest
       Assert.assertEquals("dummy", stubServiceEmitter.getEvents().get(0).toMap().get("id"));
     }
     if (isFailure) {
-      Assert.assertEquals(500, stubServiceEmitter.getMetricEvents("query/time").get(0).toMap().get(DruidMetrics.STATUS_CODE));
+      Assert.assertEquals(
+          500,
+          stubServiceEmitter.getMetricEvents("query/time").get(0).toMap().get(DruidMetrics.STATUS_CODE)
+      );
     } else {
-      Assert.assertEquals(200, stubServiceEmitter.getMetricEvents("query/time").get(0).toMap().get(DruidMetrics.STATUS_CODE));
+      Assert.assertEquals(
+          200,
+          stubServiceEmitter.getMetricEvents("query/time").get(0).toMap().get(DruidMetrics.STATUS_CODE)
+      );
     }
 
     // This test is mostly about verifying that the servlet calls the right methods the right number of times.

--- a/services/src/test/java/org/apache/druid/server/AsyncQueryForwardingServletTest.java
+++ b/services/src/test/java/org/apache/druid/server/AsyncQueryForwardingServletTest.java
@@ -646,7 +646,7 @@ public class AsyncQueryForwardingServletTest extends BaseJettyTest
       @Override
       public int getStatus()
       {
-        return 0;
+        return isFailure ? 500 : 200;
       }
 
       @Override
@@ -725,9 +725,9 @@ public class AsyncQueryForwardingServletTest extends BaseJettyTest
       Assert.assertEquals("dummy", stubServiceEmitter.getEvents().get(0).toMap().get("id"));
     }
     if (isFailure) {
-      Assert.assertEquals(500, stubServiceEmitter.getMetricEvents("query/time").get(0).toMap().get(DruidMetrics.CODE));
+      Assert.assertEquals(500, stubServiceEmitter.getMetricEvents("query/time").get(0).toMap().get(DruidMetrics.STATUS_CODE));
     } else {
-      Assert.assertEquals(200, stubServiceEmitter.getMetricEvents("query/time").get(0).toMap().get(DruidMetrics.CODE));
+      Assert.assertEquals(200, stubServiceEmitter.getMetricEvents("query/time").get(0).toMap().get(DruidMetrics.STATUS_CODE));
     }
 
     // This test is mostly about verifying that the servlet calls the right methods the right number of times.

--- a/services/src/test/java/org/apache/druid/server/AsyncQueryForwardingServletTest.java
+++ b/services/src/test/java/org/apache/druid/server/AsyncQueryForwardingServletTest.java
@@ -51,6 +51,7 @@ import org.apache.druid.java.util.common.jackson.JacksonUtils;
 import org.apache.druid.java.util.common.lifecycle.Lifecycle;
 import org.apache.druid.java.util.metrics.StubServiceEmitter;
 import org.apache.druid.query.DefaultGenericQueryMetricsFactory;
+import org.apache.druid.query.DruidMetrics;
 import org.apache.druid.query.Druids;
 import org.apache.druid.query.MapQueryToolChestWarehouse;
 import org.apache.druid.query.Query;
@@ -719,9 +720,14 @@ public class AsyncQueryForwardingServletTest extends BaseJettyTest
     }
     catch (NullPointerException ignored) {
     }
-    Assert.assertEquals("query/time", stubServiceEmitter.getEvents().get(0).toMap().get("metric"));
+    stubServiceEmitter.verifyEmitted("query/time", 1);
     if (!isJDBCSql) {
       Assert.assertEquals("dummy", stubServiceEmitter.getEvents().get(0).toMap().get("id"));
+    }
+    if (isFailure) {
+      Assert.assertEquals(500, stubServiceEmitter.getMetricEvents("query/time").get(0).toMap().get(DruidMetrics.CODE));
+    } else {
+      Assert.assertEquals(200, stubServiceEmitter.getMetricEvents("query/time").get(0).toMap().get(DruidMetrics.CODE));
     }
 
     // This test is mostly about verifying that the servlet calls the right methods the right number of times.

--- a/sql/src/main/java/org/apache/druid/sql/SqlExecutionReporter.java
+++ b/sql/src/main/java/org/apache/druid/sql/SqlExecutionReporter.java
@@ -124,7 +124,7 @@ public class SqlExecutionReporter
       metricBuilder.setDimension("success", String.valueOf(success));
 
       final int statusCode = DruidMetrics.computeStatusCode(e);
-      metricBuilder.setDimension(DruidMetrics.CODE, statusCode);
+      metricBuilder.setDimension(DruidMetrics.STATUS_CODE, statusCode);
 
       emitter.emit(metricBuilder.setMetric("sqlQuery/time", TimeUnit.NANOSECONDS.toMillis(queryTimeNs)));
       if (bytesWritten >= 0) {
@@ -158,7 +158,7 @@ public class SqlExecutionReporter
       statsMap.put("query/rowsScanned", numRowsScanned);
       statsMap.put("query/cpu/time", cpuTimeInMillis);
       statsMap.put("success", success);
-      statsMap.put(DruidMetrics.CODE, statusCode);
+      statsMap.put(DruidMetrics.STATUS_CODE, statusCode);
       Map<String, Object> queryContext = stmt.queryContext;
       if (plannerContext != null) {
         statsMap.put("identity", plannerContext.getAuthenticationResult().getIdentity());

--- a/sql/src/main/java/org/apache/druid/sql/SqlExecutionReporter.java
+++ b/sql/src/main/java/org/apache/druid/sql/SqlExecutionReporter.java
@@ -122,7 +122,10 @@ public class SqlExecutionReporter
       }
       metricBuilder.setDimension("remoteAddress", StringUtils.nullToEmptyNonDruidDataString(remoteAddress));
       metricBuilder.setDimension("success", String.valueOf(success));
-      metricBuilder.setDimension(DruidMetrics.CODE, DruidMetrics.computeStatusCode(e));
+
+      final int statusCode = DruidMetrics.computeStatusCode(e);
+      metricBuilder.setDimension(DruidMetrics.CODE, statusCode);
+
       emitter.emit(metricBuilder.setMetric("sqlQuery/time", TimeUnit.NANOSECONDS.toMillis(queryTimeNs)));
       if (bytesWritten >= 0) {
         emitter.emit(metricBuilder.setMetric("sqlQuery/bytes", bytesWritten));
@@ -155,7 +158,7 @@ public class SqlExecutionReporter
       statsMap.put("query/rowsScanned", numRowsScanned);
       statsMap.put("query/cpu/time", cpuTimeInMillis);
       statsMap.put("success", success);
-      statsMap.put(DruidMetrics.CODE, DruidMetrics.computeStatusCode(e));
+      statsMap.put(DruidMetrics.CODE, statusCode);
       Map<String, Object> queryContext = stmt.queryContext;
       if (plannerContext != null) {
         statsMap.put("identity", plannerContext.getAuthenticationResult().getIdentity());

--- a/sql/src/main/java/org/apache/druid/sql/SqlExecutionReporter.java
+++ b/sql/src/main/java/org/apache/druid/sql/SqlExecutionReporter.java
@@ -24,6 +24,7 @@ import org.apache.druid.java.util.common.StringUtils;
 import org.apache.druid.java.util.common.logger.Logger;
 import org.apache.druid.java.util.emitter.service.ServiceEmitter;
 import org.apache.druid.java.util.emitter.service.ServiceMetricEvent;
+import org.apache.druid.query.DruidMetrics;
 import org.apache.druid.query.QueryInterruptedException;
 import org.apache.druid.query.QueryTimeoutException;
 import org.apache.druid.server.QueryStats;
@@ -121,6 +122,7 @@ public class SqlExecutionReporter
       }
       metricBuilder.setDimension("remoteAddress", StringUtils.nullToEmptyNonDruidDataString(remoteAddress));
       metricBuilder.setDimension("success", String.valueOf(success));
+      metricBuilder.setDimension(DruidMetrics.CODE, DruidMetrics.computeStatusCode(e));
       emitter.emit(metricBuilder.setMetric("sqlQuery/time", TimeUnit.NANOSECONDS.toMillis(queryTimeNs)));
       if (bytesWritten >= 0) {
         emitter.emit(metricBuilder.setMetric("sqlQuery/bytes", bytesWritten));
@@ -153,6 +155,7 @@ public class SqlExecutionReporter
       statsMap.put("query/rowsScanned", numRowsScanned);
       statsMap.put("query/cpu/time", cpuTimeInMillis);
       statsMap.put("success", success);
+      statsMap.put(DruidMetrics.CODE, DruidMetrics.computeStatusCode(e));
       Map<String, Object> queryContext = stmt.queryContext;
       if (plannerContext != null) {
         statsMap.put("identity", plannerContext.getAuthenticationResult().getIdentity());

--- a/sql/src/test/java/org/apache/druid/sql/http/SqlResourceTest.java
+++ b/sql/src/test/java/org/apache/druid/sql/http/SqlResourceTest.java
@@ -416,7 +416,7 @@ public class SqlResourceTest extends CalciteTestBase
     checkSqlRequestLog(true);
     Assert.assertTrue(lifecycleManager.getAll("id").isEmpty());
     stubServiceEmitter.verifyEmitted("sqlQuery/time", 1);
-    Assert.assertEquals(200, stubServiceEmitter.getMetricEvents("sqlQuery/time").get(0).toMap().get(DruidMetrics.CODE));
+    Assert.assertEquals(200, stubServiceEmitter.getMetricEvents("sqlQuery/time").get(0).toMap().get(DruidMetrics.STATUS_CODE));
   }
 
   @Test
@@ -499,7 +499,7 @@ public class SqlResourceTest extends CalciteTestBase
     stubServiceEmitter.verifyEmitted("sqlQuery/time", 1);
     stubServiceEmitter.verifyValue("sqlQuery/bytes", 27L);
     stubServiceEmitter.verifyEmitted("sqlQuery/planningTimeMs", 1);
-    Assert.assertEquals(200, stubServiceEmitter.getMetricEvents("sqlQuery/time").get(0).toMap().get(DruidMetrics.CODE));
+    Assert.assertEquals(200, stubServiceEmitter.getMetricEvents("sqlQuery/time").get(0).toMap().get(DruidMetrics.STATUS_CODE));
   }
 
 
@@ -1509,7 +1509,7 @@ public class SqlResourceTest extends CalciteTestBase
     checkSqlRequestLog(false);
     Assert.assertTrue(lifecycleManager.getAll("id").isEmpty());
     stubServiceEmitter.verifyEmitted("sqlQuery/time", 1);
-    Assert.assertEquals(400, stubServiceEmitter.getMetricEvents("sqlQuery/time").get(0).toMap().get(DruidMetrics.CODE));
+    Assert.assertEquals(400, stubServiceEmitter.getMetricEvents("sqlQuery/time").get(0).toMap().get(DruidMetrics.STATUS_CODE));
   }
 
   @Test
@@ -1532,7 +1532,7 @@ public class SqlResourceTest extends CalciteTestBase
     checkSqlRequestLog(false);
     Assert.assertTrue(lifecycleManager.getAll("id").isEmpty());
     stubServiceEmitter.verifyEmitted("sqlQuery/time", 1);
-    Assert.assertEquals(400, stubServiceEmitter.getMetricEvents("sqlQuery/time").get(0).toMap().get(DruidMetrics.CODE));
+    Assert.assertEquals(400, stubServiceEmitter.getMetricEvents("sqlQuery/time").get(0).toMap().get(DruidMetrics.STATUS_CODE));
   }
 
   /**
@@ -1556,7 +1556,7 @@ public class SqlResourceTest extends CalciteTestBase
     checkSqlRequestLog(false);
     Assert.assertTrue(lifecycleManager.getAll("id").isEmpty());
     stubServiceEmitter.verifyEmitted("sqlQuery/time", 1);
-    Assert.assertEquals(400, stubServiceEmitter.getMetricEvents("sqlQuery/time").get(0).toMap().get(DruidMetrics.CODE));
+    Assert.assertEquals(400, stubServiceEmitter.getMetricEvents("sqlQuery/time").get(0).toMap().get(DruidMetrics.STATUS_CODE));
   }
 
   @Test
@@ -1745,7 +1745,7 @@ public class SqlResourceTest extends CalciteTestBase
     );
     Assert.assertTrue(lifecycleManager.getAll("id").isEmpty());
     stubServiceEmitter.verifyEmitted("sqlQuery/time", 1);
-    Assert.assertEquals(400, stubServiceEmitter.getMetricEvents("sqlQuery/time").get(0).toMap().get(DruidMetrics.CODE));
+    Assert.assertEquals(400, stubServiceEmitter.getMetricEvents("sqlQuery/time").get(0).toMap().get(DruidMetrics.STATUS_CODE));
   }
 
   @Test
@@ -1845,7 +1845,7 @@ public class SqlResourceTest extends CalciteTestBase
     stubServiceEmitter.verifyEmitted("sqlQuery/time", 3);
     Map<Integer, Long> codeFrequencies = stubServiceEmitter.getMetricEvents("sqlQuery/time").stream()
                                                            .map(event -> event.toMap())
-                                                           .map(map -> (int) map.get(DruidMetrics.CODE))
+                                                           .map(map -> (int) map.get(DruidMetrics.STATUS_CODE))
                                                            .collect(Collectors.groupingBy(
                                                                code -> code,
                                                                Collectors.counting()
@@ -1885,7 +1885,7 @@ public class SqlResourceTest extends CalciteTestBase
     );
     Assert.assertTrue(lifecycleManager.getAll(sqlQueryId).isEmpty());
     stubServiceEmitter.verifyEmitted("sqlQuery/time", 1);
-    Assert.assertEquals(504, stubServiceEmitter.getMetricEvents("sqlQuery/time").get(0).toMap().get(DruidMetrics.CODE));
+    Assert.assertEquals(504, stubServiceEmitter.getMetricEvents("sqlQuery/time").get(0).toMap().get(DruidMetrics.STATUS_CODE));
   }
 
   @Test
@@ -1922,7 +1922,7 @@ public class SqlResourceTest extends CalciteTestBase
         ""
     );
     stubServiceEmitter.verifyEmitted("sqlQuery/time", 1);
-    Assert.assertEquals(500, stubServiceEmitter.getMetricEvents("sqlQuery/time").get(0).toMap().get(DruidMetrics.CODE));
+    Assert.assertEquals(500, stubServiceEmitter.getMetricEvents("sqlQuery/time").get(0).toMap().get(DruidMetrics.STATUS_CODE));
   }
 
   @Test
@@ -1952,7 +1952,7 @@ public class SqlResourceTest extends CalciteTestBase
     ErrorResponse exception = deserializeResponse(queryResponse, ErrorResponse.class);
     validateLegacyQueryExceptionErrorResponse(exception, "Query cancelled", null, "");
     stubServiceEmitter.verifyEmitted("sqlQuery/time", 1);
-    Assert.assertEquals(500, stubServiceEmitter.getMetricEvents("sqlQuery/time").get(0).toMap().get(DruidMetrics.CODE));
+    Assert.assertEquals(500, stubServiceEmitter.getMetricEvents("sqlQuery/time").get(0).toMap().get(DruidMetrics.STATUS_CODE));
   }
 
   @Test
@@ -2036,7 +2036,7 @@ public class SqlResourceTest extends CalciteTestBase
     checkSqlRequestLog(false);
     Assert.assertTrue(lifecycleManager.getAll(sqlQueryId).isEmpty());
     stubServiceEmitter.verifyEmitted("sqlQuery/time", 1);
-    Assert.assertEquals(400, stubServiceEmitter.getMetricEvents("sqlQuery/time").get(0).toMap().get(DruidMetrics.CODE));
+    Assert.assertEquals(400, stubServiceEmitter.getMetricEvents("sqlQuery/time").get(0).toMap().get(DruidMetrics.STATUS_CODE));
   }
 
   @Test
@@ -2054,7 +2054,7 @@ public class SqlResourceTest extends CalciteTestBase
     );
     checkSqlRequestLog(false);
     stubServiceEmitter.verifyEmitted("sqlQuery/time", 1);
-    Assert.assertEquals(400, stubServiceEmitter.getMetricEvents("sqlQuery/time").get(0).toMap().get(DruidMetrics.CODE));
+    Assert.assertEquals(400, stubServiceEmitter.getMetricEvents("sqlQuery/time").get(0).toMap().get(DruidMetrics.STATUS_CODE));
   }
 
   private void checkSqlRequestLog(boolean success)

--- a/sql/src/test/java/org/apache/druid/sql/http/SqlResourceTest.java
+++ b/sql/src/test/java/org/apache/druid/sql/http/SqlResourceTest.java
@@ -54,6 +54,7 @@ import org.apache.druid.math.expr.ExprMacroTable;
 import org.apache.druid.query.BadQueryContextException;
 import org.apache.druid.query.BaseQuery;
 import org.apache.druid.query.DefaultQueryConfig;
+import org.apache.druid.query.DruidMetrics;
 import org.apache.druid.query.Query;
 import org.apache.druid.query.QueryCapacityExceededException;
 import org.apache.druid.query.QueryContexts;
@@ -414,6 +415,8 @@ public class SqlResourceTest extends CalciteTestBase
     );
     checkSqlRequestLog(true);
     Assert.assertTrue(lifecycleManager.getAll("id").isEmpty());
+    stubServiceEmitter.verifyEmitted("sqlQuery/time", 1);
+    Assert.assertEquals(200, stubServiceEmitter.getMetricEvents("sqlQuery/time").get(0).toMap().get(DruidMetrics.CODE));
   }
 
   @Test
@@ -496,6 +499,7 @@ public class SqlResourceTest extends CalciteTestBase
     stubServiceEmitter.verifyEmitted("sqlQuery/time", 1);
     stubServiceEmitter.verifyValue("sqlQuery/bytes", 27L);
     stubServiceEmitter.verifyEmitted("sqlQuery/planningTimeMs", 1);
+    Assert.assertEquals(200, stubServiceEmitter.getMetricEvents("sqlQuery/time").get(0).toMap().get(DruidMetrics.CODE));
   }
 
 
@@ -1504,6 +1508,8 @@ public class SqlResourceTest extends CalciteTestBase
     );
     checkSqlRequestLog(false);
     Assert.assertTrue(lifecycleManager.getAll("id").isEmpty());
+    stubServiceEmitter.verifyEmitted("sqlQuery/time", 1);
+    Assert.assertEquals(400, stubServiceEmitter.getMetricEvents("sqlQuery/time").get(0).toMap().get(DruidMetrics.CODE));
   }
 
   @Test
@@ -1525,6 +1531,8 @@ public class SqlResourceTest extends CalciteTestBase
     );
     checkSqlRequestLog(false);
     Assert.assertTrue(lifecycleManager.getAll("id").isEmpty());
+    stubServiceEmitter.verifyEmitted("sqlQuery/time", 1);
+    Assert.assertEquals(400, stubServiceEmitter.getMetricEvents("sqlQuery/time").get(0).toMap().get(DruidMetrics.CODE));
   }
 
   /**
@@ -1547,6 +1555,8 @@ public class SqlResourceTest extends CalciteTestBase
     );
     checkSqlRequestLog(false);
     Assert.assertTrue(lifecycleManager.getAll("id").isEmpty());
+    stubServiceEmitter.verifyEmitted("sqlQuery/time", 1);
+    Assert.assertEquals(400, stubServiceEmitter.getMetricEvents("sqlQuery/time").get(0).toMap().get(DruidMetrics.CODE));
   }
 
   @Test
@@ -1734,6 +1744,8 @@ public class SqlResourceTest extends CalciteTestBase
             .expectMessageIs("Calcite assertion violated: [not a literal: assertion_error()]")
     );
     Assert.assertTrue(lifecycleManager.getAll("id").isEmpty());
+    stubServiceEmitter.verifyEmitted("sqlQuery/time", 1);
+    Assert.assertEquals(400, stubServiceEmitter.getMetricEvents("sqlQuery/time").get(0).toMap().get(DruidMetrics.CODE));
   }
 
   @Test
@@ -1830,6 +1842,15 @@ public class SqlResourceTest extends CalciteTestBase
     Assert.assertEquals(1, limited);
     Assert.assertEquals(3, testRequestLogger.getSqlQueryLogs().size());
     Assert.assertTrue(lifecycleManager.getAll(sqlQueryId).isEmpty());
+    stubServiceEmitter.verifyEmitted("sqlQuery/time", 3);
+    Map<Integer, Long> codeFrequencies = stubServiceEmitter.getMetricEvents("sqlQuery/time").stream()
+                                                           .map(event -> event.toMap())
+                                                           .map(map -> (int) map.get(DruidMetrics.CODE))
+                                                           .collect(Collectors.groupingBy(
+                                                               code -> code,
+                                                               Collectors.counting()
+                                                           ));
+    Assert.assertEquals(Map.of(200, 2L, 429, 1L), codeFrequencies);
   }
 
   @Test
@@ -1863,6 +1884,8 @@ public class SqlResourceTest extends CalciteTestBase
         ""
     );
     Assert.assertTrue(lifecycleManager.getAll(sqlQueryId).isEmpty());
+    stubServiceEmitter.verifyEmitted("sqlQuery/time", 1);
+    Assert.assertEquals(504, stubServiceEmitter.getMetricEvents("sqlQuery/time").get(0).toMap().get(DruidMetrics.CODE));
   }
 
   @Test
@@ -1898,6 +1921,8 @@ public class SqlResourceTest extends CalciteTestBase
         null,
         ""
     );
+    stubServiceEmitter.verifyEmitted("sqlQuery/time", 1);
+    Assert.assertEquals(500, stubServiceEmitter.getMetricEvents("sqlQuery/time").get(0).toMap().get(DruidMetrics.CODE));
   }
 
   @Test
@@ -1926,6 +1951,8 @@ public class SqlResourceTest extends CalciteTestBase
 
     ErrorResponse exception = deserializeResponse(queryResponse, ErrorResponse.class);
     validateLegacyQueryExceptionErrorResponse(exception, "Query cancelled", null, "");
+    stubServiceEmitter.verifyEmitted("sqlQuery/time", 1);
+    Assert.assertEquals(500, stubServiceEmitter.getMetricEvents("sqlQuery/time").get(0).toMap().get(DruidMetrics.CODE));
   }
 
   @Test
@@ -2008,6 +2035,8 @@ public class SqlResourceTest extends CalciteTestBase
     );
     checkSqlRequestLog(false);
     Assert.assertTrue(lifecycleManager.getAll(sqlQueryId).isEmpty());
+    stubServiceEmitter.verifyEmitted("sqlQuery/time", 1);
+    Assert.assertEquals(400, stubServiceEmitter.getMetricEvents("sqlQuery/time").get(0).toMap().get(DruidMetrics.CODE));
   }
 
   @Test
@@ -2024,6 +2053,8 @@ public class SqlResourceTest extends CalciteTestBase
         "Query context parameter [sqlInsertSegmentGranularity] is not allowed"
     );
     checkSqlRequestLog(false);
+    stubServiceEmitter.verifyEmitted("sqlQuery/time", 1);
+    Assert.assertEquals(400, stubServiceEmitter.getMetricEvents("sqlQuery/time").get(0).toMap().get(DruidMetrics.CODE));
   }
 
   private void checkSqlRequestLog(boolean success)


### PR DESCRIPTION
<!-- Thanks for trying to help us make Apache Druid be the best it can be! Please fill out as much of the following information as is possible (where relevant, and remove it when irrelevant) to help make the intention and scope of this PR clear in order to ease review. -->

<!-- Please read the doc for contribution (https://github.com/apache/druid/blob/master/CONTRIBUTING.md) before making this PR. Also, once you open a PR, please _avoid using force pushes and rebasing_ since these make it difficult for reviewers to see what you've changed in response to their reviews. See [the 'If your pull request shows conflicts with master' section](https://github.com/apache/druid/blob/master/CONTRIBUTING.md#if-your-pull-request-shows-conflicts-with-master) for more details. -->

Backport #18699: Fix extra router statusCode metric edge cases

<!-- Replace XXXX with the id of the issue fixed in this PR. Remove this section if there is no corresponding issue. Don't reference the issue in the title of this pull-request. -->

<!-- If you are a committer, follow the PR action item checklist for committers:
https://github.com/apache/druid/blob/master/dev/committer-instructions.md#pr-and-issue-action-item-checklist-for-committers. -->


<hr>

<!-- Check the items by putting "x" in the brackets for the done things. Not all of these items apply to every PR. Remove the items which are not done or not relevant to the PR. None of the items from the checklist below are strictly necessary, but it would be very helpful if you at least self-review the PR. -->

This PR has:

- [x] been self-reviewed.
   - [ ] using the [concurrency checklist](https://github.com/apache/druid/blob/master/dev/code-review/concurrency.md) (Remove this item if the PR doesn't have any relation to concurrency.)
- [ ] added documentation for new or modified features or behaviors.
- [ ] a release note entry in the PR description.
- [ ] added Javadocs for most classes and all non-trivial methods. Linked related entities via Javadoc links.
- [ ] added or updated version, license, or notice information in [licenses.yaml](https://github.com/apache/druid/blob/master/dev/license.md)
- [ ] added comments explaining the "why" and the intent of the code wherever would not be obvious for an unfamiliar reader.
- [ ] added unit tests or modified existing tests to cover new code paths, ensuring the threshold for [code coverage](https://github.com/apache/druid/blob/master/dev/code-review/code-coverage.md) is met.
- [ ] added integration tests.
- [ ] been tested in a test Druid cluster.
