### PR TITLE
OBSDATA-13070 Fix download url of async-prof

### DIFF
--- a/distribution/docker/Dockerfile
+++ b/distribution/docker/Dockerfile
@@ -122,7 +122,7 @@ RUN if [ ! -x "$(command -v ip)" ]; then \
 ARG AWS_CLI_VERSION=2.34.11
 ARG ASYNC_PROFILER_VERSION=4.3
 RUN set -e \
-    && if [ "$TARGETARCH" = "arm64" ]; then ARCH=aarch64; AP_ARCH=aarch64; else ARCH=x86_64; AP_ARCH=x64; fi \
+    && if [ "$TARGETARCH" = "arm64" ]; then ARCH=aarch64; AP_ARCH=arm64; else ARCH=x86_64; AP_ARCH=x64; fi \
     && if [ -x "$(command -v apt)" ]; then \
          apt-get update && apt-get install -y --no-install-recommends curl htop strace bind-tools netcat unzip \
          && CLEANUP="apt-get purge -y unzip && apt-get autoremove -y && rm -rf /var/lib/apt/lists/*"; \


### PR DESCRIPTION
Fixes download URL of async-prof

### Description
- async-prof changed their download URL path for arch arm64


#### Release note
<!-- Give your best effort to summarize your changes in a couple of sentences aimed toward Druid users. 

If your change doesn't have end user impact, you can skip this section.

-->
For tips about how to write a good release note, see [Release notes](https://github.com/apache/druid/blob/master/CONTRIBUTING.md#release-notes).


<hr>

##### Key changed/added classes in this PR
 * `MyFoo`
 * `OurBar`
 * `TheirBaz`

<hr>

<!-- Check the items by putting "x" in the brackets for the done things. Not all of these items apply to every PR. Remove the items which are not done or not relevant to the PR. None of the items from the checklist below are strictly necessary, but it would be very helpful if you at least self-review the PR. -->

This PR has:

- [ ] been self-reviewed.
   - [ ] using the [concurrency checklist](https://github.com/apache/druid/blob/master/dev/code-review/concurrency.md) (Remove this item if the PR doesn't have any relation to concurrency.)
- [ ] added documentation for new or modified features or behaviors.
- [ ] a release note entry in the PR description.
- [ ] added Javadocs for most classes and all non-trivial methods. Linked related entities via Javadoc links.
- [ ] added or updated version, license, or notice information in [licenses.yaml](https://github.com/apache/druid/blob/master/dev/license.md)
- [ ] added comments explaining the "why" and the intent of the code wherever would not be obvious for an unfamiliar reader.
- [ ] added unit tests or modified existing tests to cover new code paths, ensuring the threshold for [code coverage](https://github.com/apache/druid/blob/master/dev/code-review/code-coverage.md) is met.
- [ ] added integration tests.
- [ ] been tested in a test Druid cluster.
