### PR TITLE
OBSDATA-13070 Bake awscli and async-prof tools into dockerfile

### DIFF
--- a/distribution/docker/Dockerfile
+++ b/distribution/docker/Dockerfile
@@ -116,12 +116,33 @@ RUN if [ ! -x "$(command -v ip)" ]; then \
       fi; \
     fi;
 
-RUN if [ -x "$(command -v apt)" ]; then \
-    apt update \
-      && apt install -y curl htop strace bind-tools netcat ; \
-    else \
-      apk add --no-cache curl htop strace bind-tools netcat-openbsd  ; \
-    fi;
+# OBSDATA-13070: Bake AWS CLI v2 and async-profiler into the image.
+# Shoreline notebooks previously downloaded these at runtime from the public internet
+# without integrity verification. Installing at build time eliminates supply chain risk.
+ARG AWS_CLI_VERSION=2.34.11
+ARG ASYNC_PROFILER_VERSION=4.3
+RUN set -e \
+    && if [ "$TARGETARCH" = "arm64" ]; then ARCH=aarch64; AP_ARCH=arm64; else ARCH=x86_64; AP_ARCH=x64; fi \
+    && if [ -x "$(command -v apt)" ]; then \
+         apt-get update && apt-get install -y --no-install-recommends curl htop strace bind-tools netcat unzip \
+         && CLEANUP="apt-get purge -y unzip && apt-get autoremove -y && rm -rf /var/lib/apt/lists/*"; \
+       else \
+         apk add --no-cache curl htop strace bind-tools netcat-openbsd unzip \
+         && CLEANUP="apk del unzip"; \
+       fi \
+    && curl -fsSL "https://awscli.amazonaws.com/awscli-exe-linux-${ARCH}-${AWS_CLI_VERSION}.zip" -o /tmp/awscli.zip \
+    && unzip -q /tmp/awscli.zip -d /tmp \
+    && /tmp/aws/install \
+    && rm -rf /tmp/aws /tmp/awscli.zip \
+    && curl -fsSL "https://github.com/async-profiler/async-profiler/releases/download/v${ASYNC_PROFILER_VERSION}/async-profiler-${ASYNC_PROFILER_VERSION}-linux-${AP_ARCH}.tar.gz" \
+       -o /tmp/ap.tar.gz \
+    && mkdir -p /opt/async-profiler \
+    && tar xzf /tmp/ap.tar.gz -C /opt/async-profiler --strip-components=1 \
+    && rm /tmp/ap.tar.gz \
+    && ln -s /opt/async-profiler/bin/asprof /usr/local/bin/asprof \
+    && eval "$CLEANUP" \
+    && aws --version \
+    && asprof --version
 
 USER druid
 VOLUME /opt/druid/var


### PR DESCRIPTION
Backport of 34.0.0-confluent changes (PRs #439 + #441) to 30.0.1-confluent.

### Description
- awscli and async-prof tools were downloaded at runtime, creating a supply chain security issue
- These tools are now version-pinned and downloaded at Docker image build time
- Includes the arm64 async-profiler URL fix

#### Release note
N/A — infrastructure-only change.

<hr>

##### Key changed/added classes in this PR
 * `distribution/docker/Dockerfile`

<hr>

This PR has:

- [x] been self-reviewed.

🤖 Generated with [Claude Code](https://claude.com/claude-code)