### PR TITLE
OBSDATA-13340 Add Druid router metrics druid.router.http.numRequestsQueued, druid.router.http.numActiveConnections

### DIFF
--- a/docs/operations/metrics.md
+++ b/docs/operations/metrics.md
@@ -46,7 +46,8 @@ Most metric values reset each emission period, as specified in `druid.monitoring
 |Metric|Description|Dimensions|Normal value|
 |------|-----------|----------|------------|
 |`query/time`|Milliseconds taken to complete a query.|Native Query: `dataSource`, `type`, `interval`, `hasFilters`, `duration`, `context`, `remoteAddress`, `id`.|< 1s|
-|`router/http/numRequestsQueued`|Total number of outbound HTTP requests currently queued across all destinations on the Router's HTTP client.|None.|0; sustained high values indicate backpressure toward downstream Brokers.|
+|`router/http/numRequestsQueued`|Number of outbound HTTP requests currently queued for a destination on the Router's HTTP client, waiting for a connection slot.|`destination`|0; sustained high values indicate backpressure toward downstream Brokers.|
+|`router/http/numActiveConnections`|Number of outbound HTTP connections currently carrying a request to a destination on the Router's HTTP client.|`destination`|Varies with load; approaching `druid.router.http.numConnections` indicates the connection pool is near saturation.|
 
 ### Broker
 

--- a/docs/operations/metrics.md
+++ b/docs/operations/metrics.md
@@ -46,6 +46,7 @@ Most metric values reset each emission period, as specified in `druid.monitoring
 |Metric|Description|Dimensions|Normal value|
 |------|-----------|----------|------------|
 |`query/time`|Milliseconds taken to complete a query.|Native Query: `dataSource`, `type`, `interval`, `hasFilters`, `duration`, `context`, `remoteAddress`, `id`.|< 1s|
+|`router/http/numRequestsQueued`|Total number of outbound HTTP requests currently queued across all destinations on the Router's HTTP client.|None.|0; sustained high values indicate backpressure toward downstream Brokers.|
 
 ### Broker
 

--- a/extensions-contrib/statsd-emitter/src/main/resources/defaultMetricDimensions.json
+++ b/extensions-contrib/statsd-emitter/src/main/resources/defaultMetricDimensions.json
@@ -197,5 +197,7 @@
   "killTask/maxSlot/count" : { "dimensions" : [], "type" : "count" },
   "killTask/task/count" : { "dimensions" : [], "type" : "count" },
 
-  "router/http/numRequestsQueued" : { "dimensions" : [], "type" : "gauge" }
+  "router/http/numRequestsQueued" : { "dimensions" : ["destination"], "type" : "gauge" },
+
+  "router/http/numActiveConnections" : { "dimensions" : ["destination"], "type" : "gauge" }
 }

--- a/extensions-contrib/statsd-emitter/src/main/resources/defaultMetricDimensions.json
+++ b/extensions-contrib/statsd-emitter/src/main/resources/defaultMetricDimensions.json
@@ -195,9 +195,5 @@
 
   "killTask/availableSlot/count" : { "dimensions" : [], "type" : "count" },
   "killTask/maxSlot/count" : { "dimensions" : [], "type" : "count" },
-  "killTask/task/count" : { "dimensions" : [], "type" : "count" },
-
-  "router/http/numRequestsQueued" : { "dimensions" : ["destination"], "type" : "gauge" },
-
-  "router/http/numActiveConnections" : { "dimensions" : ["destination"], "type" : "gauge" }
+  "killTask/task/count" : { "dimensions" : [], "type" : "count" }
 }

--- a/extensions-contrib/statsd-emitter/src/main/resources/defaultMetricDimensions.json
+++ b/extensions-contrib/statsd-emitter/src/main/resources/defaultMetricDimensions.json
@@ -195,5 +195,7 @@
 
   "killTask/availableSlot/count" : { "dimensions" : [], "type" : "count" },
   "killTask/maxSlot/count" : { "dimensions" : [], "type" : "count" },
-  "killTask/task/count" : { "dimensions" : [], "type" : "count" }
+  "killTask/task/count" : { "dimensions" : [], "type" : "count" },
+
+  "router/http/numRequestsQueued" : { "dimensions" : [], "type" : "gauge" }
 }

--- a/server/src/main/java/org/apache/druid/server/metrics/RouterHttpClientMonitor.java
+++ b/server/src/main/java/org/apache/druid/server/metrics/RouterHttpClientMonitor.java
@@ -1,0 +1,62 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+package org.apache.druid.server.metrics;
+
+import com.google.inject.Inject;
+import com.google.inject.Provider;
+import org.apache.druid.java.util.emitter.service.ServiceEmitter;
+import org.apache.druid.java.util.emitter.service.ServiceMetricEvent;
+import org.apache.druid.java.util.metrics.AbstractMonitor;
+import org.apache.druid.server.router.Router;
+import org.eclipse.jetty.client.HttpClient;
+import org.eclipse.jetty.client.HttpDestination;
+import org.eclipse.jetty.client.api.Destination;
+
+/**
+ * Monitor that emits the total number of outbound HTTP requests currently queued
+ * across all destinations on the Router's Jetty HttpClient.
+ */
+public class RouterHttpClientMonitor extends AbstractMonitor
+{
+  private final Provider<HttpClient> httpClientProvider;
+
+  @Inject
+  public RouterHttpClientMonitor(@Router Provider<HttpClient> httpClientProvider)
+  {
+    this.httpClientProvider = httpClientProvider;
+  }
+
+  @Override
+  public boolean doMonitor(ServiceEmitter emitter)
+  {
+    final HttpClient httpClient = httpClientProvider.get();
+
+    int totalQueuedRequests = 0;
+    for (Destination destination : httpClient.getDestinations()) {
+      if (destination instanceof HttpDestination) {
+        totalQueuedRequests += ((HttpDestination) destination).getQueuedRequestCount();
+      }
+    }
+
+    emitter.emit(new ServiceMetricEvent.Builder().setMetric("router/http/numRequestsQueued", totalQueuedRequests));
+
+    return true;
+  }
+}

--- a/server/src/main/java/org/apache/druid/server/metrics/RouterHttpClientMonitor.java
+++ b/server/src/main/java/org/apache/druid/server/metrics/RouterHttpClientMonitor.java
@@ -64,7 +64,6 @@ public class RouterHttpClientMonitor extends AbstractMonitor
         emitter.emit(builder.setMetric("router/http/numRequestsQueued", httpDest.getQueuedRequestCount()));
 
         final ConnectionPool pool = httpDest.getConnectionPool();
-        log.debug("destination[%s] pool type[%s]", dest, pool == null ? "null" : pool.getClass().getName());
         if (pool instanceof AbstractConnectionPool) {
           emitter.emit(builder.setMetric("router/http/numActiveConnections", ((AbstractConnectionPool) pool).getActiveConnectionCount()));
         }

--- a/server/src/main/java/org/apache/druid/server/metrics/RouterHttpClientMonitor.java
+++ b/server/src/main/java/org/apache/druid/server/metrics/RouterHttpClientMonitor.java
@@ -25,13 +25,16 @@ import org.apache.druid.java.util.emitter.service.ServiceEmitter;
 import org.apache.druid.java.util.emitter.service.ServiceMetricEvent;
 import org.apache.druid.java.util.metrics.AbstractMonitor;
 import org.apache.druid.server.router.Router;
+import org.eclipse.jetty.client.AbstractConnectionPool;
+import org.eclipse.jetty.client.ConnectionPool;
 import org.eclipse.jetty.client.Destination;
 import org.eclipse.jetty.client.HttpClient;
 import org.eclipse.jetty.client.transport.HttpDestination;
 
 /**
- * Monitor that emits the total number of outbound HTTP requests currently queued
- * across all destinations on the Router's Jetty HttpClient.
+ * Monitor that emits per-destination outbound HTTP metrics for the Router's Jetty HttpClient:
+ * - router/http/numRequestsQueued: requests waiting for a connection slot
+ * - router/http/numActiveConnections: connections currently carrying a request
  */
 public class RouterHttpClientMonitor extends AbstractMonitor
 {
@@ -48,14 +51,21 @@ public class RouterHttpClientMonitor extends AbstractMonitor
   {
     final HttpClient httpClient = httpClientProvider.get();
 
-    int totalQueuedRequests = 0;
     for (Destination destination : httpClient.getDestinations()) {
       if (destination instanceof HttpDestination) {
-        totalQueuedRequests += ((HttpDestination) destination).getQueuedRequestCount();
+        final HttpDestination httpDest = (HttpDestination) destination;
+        final String dest = httpDest.getOrigin().asString();
+        final ServiceMetricEvent.Builder builder = new ServiceMetricEvent.Builder()
+            .setDimension("destination", dest);
+
+        emitter.emit(builder.setMetric("router/http/numRequestsQueued", httpDest.getQueuedRequestCount()));
+
+        final ConnectionPool pool = httpDest.getConnectionPool();
+        if (pool instanceof AbstractConnectionPool) {
+          emitter.emit(builder.setMetric("router/http/numActiveConnections", ((AbstractConnectionPool) pool).getActiveConnectionCount()));
+        }
       }
     }
-
-    emitter.emit(new ServiceMetricEvent.Builder().setMetric("router/http/numRequestsQueued", totalQueuedRequests));
 
     return true;
   }

--- a/server/src/main/java/org/apache/druid/server/metrics/RouterHttpClientMonitor.java
+++ b/server/src/main/java/org/apache/druid/server/metrics/RouterHttpClientMonitor.java
@@ -25,9 +25,9 @@ import org.apache.druid.java.util.emitter.service.ServiceEmitter;
 import org.apache.druid.java.util.emitter.service.ServiceMetricEvent;
 import org.apache.druid.java.util.metrics.AbstractMonitor;
 import org.apache.druid.server.router.Router;
+import org.eclipse.jetty.client.Destination;
 import org.eclipse.jetty.client.HttpClient;
-import org.eclipse.jetty.client.HttpDestination;
-import org.eclipse.jetty.client.api.Destination;
+import org.eclipse.jetty.client.transport.HttpDestination;
 
 /**
  * Monitor that emits the total number of outbound HTTP requests currently queued

--- a/server/src/main/java/org/apache/druid/server/metrics/RouterHttpClientMonitor.java
+++ b/server/src/main/java/org/apache/druid/server/metrics/RouterHttpClientMonitor.java
@@ -21,7 +21,6 @@ package org.apache.druid.server.metrics;
 
 import com.google.inject.Inject;
 import com.google.inject.Provider;
-import org.apache.druid.java.util.common.logger.Logger;
 import org.apache.druid.java.util.emitter.service.ServiceEmitter;
 import org.apache.druid.java.util.emitter.service.ServiceMetricEvent;
 import org.apache.druid.java.util.metrics.AbstractMonitor;
@@ -39,8 +38,6 @@ import org.eclipse.jetty.client.transport.HttpDestination;
  */
 public class RouterHttpClientMonitor extends AbstractMonitor
 {
-  private static final Logger log = new Logger(RouterHttpClientMonitor.class);
-
   private final Provider<HttpClient> httpClientProvider;
 
   @Inject

--- a/server/src/main/java/org/apache/druid/server/metrics/RouterHttpClientMonitor.java
+++ b/server/src/main/java/org/apache/druid/server/metrics/RouterHttpClientMonitor.java
@@ -21,6 +21,7 @@ package org.apache.druid.server.metrics;
 
 import com.google.inject.Inject;
 import com.google.inject.Provider;
+import org.apache.druid.java.util.common.logger.Logger;
 import org.apache.druid.java.util.emitter.service.ServiceEmitter;
 import org.apache.druid.java.util.emitter.service.ServiceMetricEvent;
 import org.apache.druid.java.util.metrics.AbstractMonitor;
@@ -38,6 +39,8 @@ import org.eclipse.jetty.client.transport.HttpDestination;
  */
 public class RouterHttpClientMonitor extends AbstractMonitor
 {
+  private static final Logger log = new Logger(RouterHttpClientMonitor.class);
+
   private final Provider<HttpClient> httpClientProvider;
 
   @Inject
@@ -61,6 +64,7 @@ public class RouterHttpClientMonitor extends AbstractMonitor
         emitter.emit(builder.setMetric("router/http/numRequestsQueued", httpDest.getQueuedRequestCount()));
 
         final ConnectionPool pool = httpDest.getConnectionPool();
+        log.debug("destination[%s] pool type[%s]", dest, pool == null ? "null" : pool.getClass().getName());
         if (pool instanceof AbstractConnectionPool) {
           emitter.emit(builder.setMetric("router/http/numActiveConnections", ((AbstractConnectionPool) pool).getActiveConnectionCount()));
         }

--- a/server/src/test/java/org/apache/druid/server/metrics/RouterHttpClientMonitorTest.java
+++ b/server/src/test/java/org/apache/druid/server/metrics/RouterHttpClientMonitorTest.java
@@ -21,9 +21,9 @@ package org.apache.druid.server.metrics;
 
 import com.google.inject.Provider;
 import org.apache.druid.java.util.metrics.StubServiceEmitter;
+import org.eclipse.jetty.client.Destination;
 import org.eclipse.jetty.client.HttpClient;
-import org.eclipse.jetty.client.HttpDestination;
-import org.eclipse.jetty.client.api.Destination;
+import org.eclipse.jetty.client.transport.HttpDestination;
 import org.junit.Assert;
 import org.junit.Before;
 import org.junit.Test;

--- a/server/src/test/java/org/apache/druid/server/metrics/RouterHttpClientMonitorTest.java
+++ b/server/src/test/java/org/apache/druid/server/metrics/RouterHttpClientMonitorTest.java
@@ -21,8 +21,11 @@ package org.apache.druid.server.metrics;
 
 import com.google.inject.Provider;
 import org.apache.druid.java.util.metrics.StubServiceEmitter;
+import org.eclipse.jetty.client.AbstractConnectionPool;
+import org.eclipse.jetty.client.ConnectionPool;
 import org.eclipse.jetty.client.Destination;
 import org.eclipse.jetty.client.HttpClient;
+import org.eclipse.jetty.client.Origin;
 import org.eclipse.jetty.client.transport.HttpDestination;
 import org.junit.Assert;
 import org.junit.Before;
@@ -31,6 +34,7 @@ import org.mockito.Mockito;
 
 import java.util.Arrays;
 import java.util.Collections;
+import java.util.List;
 import java.util.Map;
 
 public class RouterHttpClientMonitorTest
@@ -54,48 +58,106 @@ public class RouterHttpClientMonitorTest
   }
 
   @Test
-  public void testNoDestinationsEmitsZero()
+  public void testNoDestinationsEmitsNoEvents()
   {
     Mockito.when(httpClient.getDestinations()).thenReturn(Collections.emptyList());
     final StubServiceEmitter emitter = new StubServiceEmitter("router", "localhost");
     monitor.doMonitor(emitter);
 
-    Assert.assertEquals(1, emitter.getEvents().size());
-    Map<String, Object> event = emitter.getEvents().get(0).toMap();
-    Assert.assertEquals("router/http/numRequestsQueued", event.get("metric"));
-    Assert.assertEquals(0, event.get("value"));
+    Assert.assertTrue(emitter.getEvents().isEmpty());
   }
 
   @Test
-  public void testMultipleDestinationsQueueCountSummed()
+  public void testMultipleDestinationsEmitsPerDestinationMetrics()
   {
-    HttpDestination dest1 = mockDest(3);
-    HttpDestination dest2 = mockDest(5);
+    HttpDestination dest1 = mockDest("http://host1:8082", 3, 2);
+    HttpDestination dest2 = mockDest("http://host2:8082", 5, 2);
     Mockito.when(httpClient.getDestinations()).thenReturn(Arrays.asList(dest1, dest2));
     final StubServiceEmitter emitter = new StubServiceEmitter("router", "localhost");
     monitor.doMonitor(emitter);
 
-    Assert.assertEquals(1, emitter.getEvents().size());
-    Assert.assertEquals(8, emitter.getEvents().get(0).toMap().get("value"));
+    // 2 metrics per destination: numRequestsQueued + numActiveConnections
+    Assert.assertEquals(4, emitter.getEvents().size());
+
+    List<Map<String, Object>> events = emitter.getEvents().stream()
+                                              .map(e -> e.toMap())
+                                              .collect(java.util.stream.Collectors.toList());
+
+    Assert.assertTrue(events.stream().anyMatch(e ->
+        "router/http/numRequestsQueued".equals(e.get("metric")) &&
+        "http://host1:8082".equals(e.get("destination")) &&
+        Integer.valueOf(3).equals(e.get("value"))
+    ));
+    Assert.assertTrue(events.stream().anyMatch(e ->
+        "router/http/numActiveConnections".equals(e.get("metric")) &&
+        "http://host1:8082".equals(e.get("destination")) &&
+        Integer.valueOf(2).equals(e.get("value"))
+    ));
+    Assert.assertTrue(events.stream().anyMatch(e ->
+        "router/http/numRequestsQueued".equals(e.get("metric")) &&
+        "http://host2:8082".equals(e.get("destination")) &&
+        Integer.valueOf(5).equals(e.get("value"))
+    ));
+    Assert.assertTrue(events.stream().anyMatch(e ->
+        "router/http/numActiveConnections".equals(e.get("metric")) &&
+        "http://host2:8082".equals(e.get("destination")) &&
+        Integer.valueOf(2).equals(e.get("value"))
+    ));
   }
 
   @Test
   public void testNonHttpDestinationIsSkipped()
   {
     Destination plainDest = Mockito.mock(Destination.class);
-    HttpDestination httpDest = mockDest(4);
+    HttpDestination httpDest = mockDest("http://host:8082", 4, 1);
     Mockito.when(httpClient.getDestinations()).thenReturn(Arrays.asList(plainDest, httpDest));
     final StubServiceEmitter emitter = new StubServiceEmitter("router", "localhost");
     monitor.doMonitor(emitter);
 
-    Assert.assertEquals(1, emitter.getEvents().size());
-    Assert.assertEquals(4, emitter.getEvents().get(0).toMap().get("value"));
+    // Only the HttpDestination emits: numRequestsQueued + numActiveConnections
+    Assert.assertEquals(2, emitter.getEvents().size());
+    List<Map<String, Object>> events = emitter.getEvents().stream()
+                                              .map(e -> e.toMap())
+                                              .collect(java.util.stream.Collectors.toList());
+    Assert.assertTrue(events.stream().anyMatch(e ->
+        "router/http/numRequestsQueued".equals(e.get("metric")) &&
+        Integer.valueOf(4).equals(e.get("value"))
+    ));
+    Assert.assertTrue(events.stream().anyMatch(e ->
+        "router/http/numActiveConnections".equals(e.get("metric")) &&
+        Integer.valueOf(1).equals(e.get("value"))
+    ));
   }
 
-  private static HttpDestination mockDest(int queuedCount)
+  @Test
+  public void testNonAbstractConnectionPoolSkipsActiveConnections()
+  {
+    HttpDestination dest = mockDest("http://host:8082", 2, Mockito.mock(ConnectionPool.class));
+    Mockito.when(httpClient.getDestinations()).thenReturn(Collections.singletonList(dest));
+
+    final StubServiceEmitter emitter = new StubServiceEmitter("router", "localhost");
+    monitor.doMonitor(emitter);
+
+    // Only numRequestsQueued is emitted; numActiveConnections is skipped
+    Assert.assertEquals(1, emitter.getEvents().size());
+    Assert.assertEquals("router/http/numRequestsQueued", emitter.getEvents().get(0).toMap().get("metric"));
+  }
+
+  private static HttpDestination mockDest(String destinationStr, int queuedCount, int activeCount)
+  {
+    AbstractConnectionPool pool = Mockito.mock(AbstractConnectionPool.class);
+    Mockito.when(pool.getActiveConnectionCount()).thenReturn(activeCount);
+    return mockDest(destinationStr, queuedCount, pool);
+  }
+
+  private static HttpDestination mockDest(String destinationStr, int queuedCount, ConnectionPool pool)
   {
     HttpDestination dest = Mockito.mock(HttpDestination.class);
     Mockito.when(dest.getQueuedRequestCount()).thenReturn(queuedCount);
+    Origin origin = Mockito.mock(Origin.class);
+    Mockito.when(origin.asString()).thenReturn(destinationStr);
+    Mockito.when(dest.getOrigin()).thenReturn(origin);
+    Mockito.when(dest.getConnectionPool()).thenReturn(pool);
     return dest;
   }
 }

--- a/server/src/test/java/org/apache/druid/server/metrics/RouterHttpClientMonitorTest.java
+++ b/server/src/test/java/org/apache/druid/server/metrics/RouterHttpClientMonitorTest.java
@@ -1,0 +1,101 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+package org.apache.druid.server.metrics;
+
+import com.google.inject.Provider;
+import org.apache.druid.java.util.metrics.StubServiceEmitter;
+import org.eclipse.jetty.client.HttpClient;
+import org.eclipse.jetty.client.HttpDestination;
+import org.eclipse.jetty.client.api.Destination;
+import org.junit.Assert;
+import org.junit.Before;
+import org.junit.Test;
+import org.mockito.Mockito;
+
+import java.util.Arrays;
+import java.util.Collections;
+import java.util.Map;
+
+public class RouterHttpClientMonitorTest
+{
+  private HttpClient httpClient;
+  private RouterHttpClientMonitor monitor;
+
+  @Before
+  public void setUp()
+  {
+    httpClient = Mockito.mock(HttpClient.class);
+    Provider<HttpClient> httpClientProvider = () -> httpClient;
+    monitor = new RouterHttpClientMonitor(httpClientProvider);
+  }
+
+  @Test
+  public void testDoMonitorReturnsTrue()
+  {
+    Mockito.when(httpClient.getDestinations()).thenReturn(Collections.emptyList());
+    Assert.assertTrue(monitor.doMonitor(new StubServiceEmitter("router", "localhost")));
+  }
+
+  @Test
+  public void testNoDestinationsEmitsZero()
+  {
+    Mockito.when(httpClient.getDestinations()).thenReturn(Collections.emptyList());
+    final StubServiceEmitter emitter = new StubServiceEmitter("router", "localhost");
+    monitor.doMonitor(emitter);
+
+    Assert.assertEquals(1, emitter.getEvents().size());
+    Map<String, Object> event = emitter.getEvents().get(0).toMap();
+    Assert.assertEquals("router/http/numRequestsQueued", event.get("metric"));
+    Assert.assertEquals(0, event.get("value"));
+  }
+
+  @Test
+  public void testMultipleDestinationsQueueCountSummed()
+  {
+    HttpDestination dest1 = mockDest(3);
+    HttpDestination dest2 = mockDest(5);
+    Mockito.when(httpClient.getDestinations()).thenReturn(Arrays.asList(dest1, dest2));
+    final StubServiceEmitter emitter = new StubServiceEmitter("router", "localhost");
+    monitor.doMonitor(emitter);
+
+    Assert.assertEquals(1, emitter.getEvents().size());
+    Assert.assertEquals(8, emitter.getEvents().get(0).toMap().get("value"));
+  }
+
+  @Test
+  public void testNonHttpDestinationIsSkipped()
+  {
+    Destination plainDest = Mockito.mock(Destination.class);
+    HttpDestination httpDest = mockDest(4);
+    Mockito.when(httpClient.getDestinations()).thenReturn(Arrays.asList(plainDest, httpDest));
+    final StubServiceEmitter emitter = new StubServiceEmitter("router", "localhost");
+    monitor.doMonitor(emitter);
+
+    Assert.assertEquals(1, emitter.getEvents().size());
+    Assert.assertEquals(4, emitter.getEvents().get(0).toMap().get("value"));
+  }
+
+  private static HttpDestination mockDest(int queuedCount)
+  {
+    HttpDestination dest = Mockito.mock(HttpDestination.class);
+    Mockito.when(dest.getQueuedRequestCount()).thenReturn(queuedCount);
+    return dest;
+  }
+}

--- a/server/src/test/java/org/apache/druid/server/metrics/RouterHttpClientMonitorTest.java
+++ b/server/src/test/java/org/apache/druid/server/metrics/RouterHttpClientMonitorTest.java
@@ -143,19 +143,19 @@ public class RouterHttpClientMonitorTest
     Assert.assertEquals("router/http/numRequestsQueued", emitter.getEvents().get(0).toMap().get("metric"));
   }
 
-  private static HttpDestination mockDest(String destinationStr, int queuedCount, int activeCount)
+  private static HttpDestination mockDest(String originStr, int queuedCount, int activeCount)
   {
     AbstractConnectionPool pool = Mockito.mock(AbstractConnectionPool.class);
     Mockito.when(pool.getActiveConnectionCount()).thenReturn(activeCount);
-    return mockDest(destinationStr, queuedCount, pool);
+    return mockDest(originStr, queuedCount, pool);
   }
 
-  private static HttpDestination mockDest(String destinationStr, int queuedCount, ConnectionPool pool)
+  private static HttpDestination mockDest(String originStr, int queuedCount, ConnectionPool pool)
   {
     HttpDestination dest = Mockito.mock(HttpDestination.class);
     Mockito.when(dest.getQueuedRequestCount()).thenReturn(queuedCount);
     Origin origin = Mockito.mock(Origin.class);
-    Mockito.when(origin.asString()).thenReturn(destinationStr);
+    Mockito.when(origin.asString()).thenReturn(originStr);
     Mockito.when(dest.getOrigin()).thenReturn(origin);
     Mockito.when(dest.getConnectionPool()).thenReturn(pool);
     return dest;

--- a/services/src/main/java/org/apache/druid/cli/CliRouter.java
+++ b/services/src/main/java/org/apache/druid/cli/CliRouter.java
@@ -46,7 +46,9 @@ import org.apache.druid.server.NoopQuerySegmentWalker;
 import org.apache.druid.server.http.RouterResource;
 import org.apache.druid.server.http.SelfDiscoveryResource;
 import org.apache.druid.server.initialization.jetty.JettyServerInitializer;
+import org.apache.druid.server.metrics.MetricsModule;
 import org.apache.druid.server.metrics.QueryCountStatsProvider;
+import org.apache.druid.server.metrics.RouterHttpClientMonitor;
 import org.apache.druid.server.router.AvaticaConnectionBalancer;
 import org.apache.druid.server.router.CoordinatorRuleManager;
 import org.apache.druid.server.router.ManagementProxyConfig;
@@ -116,6 +118,7 @@ public class CliRouter extends ServerRunnable
 
           binder.bind(QueryCountStatsProvider.class).to(AsyncQueryForwardingServlet.class).in(LazySingleton.class);
           binder.bind(JettyServerInitializer.class).to(RouterJettyServerInitializer.class).in(LazySingleton.class);
+          MetricsModule.register(binder, RouterHttpClientMonitor.class);
 
           Jerseys.addResource(binder, RouterResource.class);
 


### PR DESCRIPTION
Add two metrics as given below:
1. Number of active connections per destination on router’s http client for outgoing requests
2. Number of outgoing requests queued per destination on router’s http client for outgoing requests

More details:
https://confluentinc.atlassian.net/wiki/spaces/~62be365dc9f2df7b608c58d2/pages/5553651742/Router+metrics