### PR TITLE
OBSDATA-13855 Add Druid broker metrics druid.broker.http.numRequestsQueued, druid.broker.http.numActiveConnections

### DIFF
--- a/docs/operations/metrics.md
+++ b/docs/operations/metrics.md
@@ -74,6 +74,8 @@ Most metric values reset each emission period, as specified in `druid.monitoring
 |`sqlQuery/planningTimeMs`|Milliseconds taken to plan a SQL to native query.|`id`, `nativeQueryIds`, `dataSource`, `remoteAddress`, `success`| |
 |`sqlQuery/bytes`|Number of bytes returned in the SQL query response.|`id`, `nativeQueryIds`, `dataSource`, `remoteAddress`, `success`| |
 |`httpClient/channelAcquire/timeNs`|Time in nanoseconds spent by the httpclient to acquire the channel.| |
+|`broker/http/numActiveConnections`|Number of outbound HTTP connections currently checked out from the Broker's HTTP client pool and carrying a request to a destination (typically a Historical or Indexer).|`destination`|Varies with load; approaching `druid.broker.http.numConnections` indicates the per-destination pool is near saturation.|
+|`broker/http/numRequestsQueued`|Number of threads on the Broker currently blocked waiting to acquire a connection from the HTTP client pool for a destination.|`destination`|0; sustained non-zero values indicate the per-destination pool size is too small or downstream nodes are saturated.|
 |`sqlQuery/time`|Milliseconds taken to complete a SQL query.|`id`, `nativeQueryIds`, `dataSource`, `remoteAddress`, `success`, `engine`|< 1s|
 |`sqlQuery/planningTimeMs`|Milliseconds taken to plan a SQL to native query.|`id`, `nativeQueryIds`, `dataSource`, `remoteAddress`, `success`, `engine`| |
 |`sqlQuery/bytes`|Number of bytes returned in the SQL query response.|`id`, `nativeQueryIds`, `dataSource`, `remoteAddress`, `success`, `engine`| |

--- a/processing/src/main/java/org/apache/druid/java/util/http/client/NettyHttpClient.java
+++ b/processing/src/main/java/org/apache/druid/java/util/http/client/NettyHttpClient.java
@@ -106,6 +106,11 @@ public class NettyHttpClient extends AbstractHttpClient
     pool.close();
   }
 
+  public ResourcePool<String, ChannelFuture> getPool()
+  {
+    return pool;
+  }
+
   @Override
   public <Intermediate, Final> ListenableFuture<Final> go(
       final Request request,

--- a/processing/src/main/java/org/apache/druid/java/util/http/client/pool/DefaultResourcePoolImpl.java
+++ b/processing/src/main/java/org/apache/druid/java/util/http/client/pool/DefaultResourcePoolImpl.java
@@ -32,6 +32,7 @@ import javax.annotation.Nullable;
 import java.io.Closeable;
 import java.io.IOException;
 import java.util.ArrayDeque;
+import java.util.HashMap;
 import java.util.Iterator;
 import java.util.Map;
 import java.util.concurrent.ConcurrentMap;
@@ -148,6 +149,17 @@ public class DefaultResourcePoolImpl<K, V> implements ResourcePool<K, V>
   }
 
   @Override
+  public Map<K, PoolStats> getStats()
+  {
+    final Map<K, PoolStats> snapshot = new HashMap<>();
+    for (Map.Entry<K, ResourceHolderPerKey<K, V>> entry : pool.asMap().entrySet()) {
+      final ResourceHolderPerKey<K, V> holder = entry.getValue();
+      snapshot.put(entry.getKey(), new PoolStats(holder.getNumLent(), holder.getNumWaiting()));
+    }
+    return snapshot;
+  }
+
+  @Override
   public void close()
   {
     closed.set(true);
@@ -215,6 +227,8 @@ public class DefaultResourcePoolImpl<K, V> implements ResourcePool<K, V>
     protected final ArrayDeque<ResourceHolder<V>> resourceHolderList;
     // To keep track of resources that have been successfully returned to caller.
     private int numLentResources = 0;
+    // Number of threads currently blocked in get() waiting for a resource slot to free up.
+    private int numWaitingThreads = 0;
     private boolean closed = false;
 
     protected ResourceHolderPerKey(
@@ -246,7 +260,13 @@ public class DefaultResourcePoolImpl<K, V> implements ResourcePool<K, V>
         while (!closed && (numLentResources == maxSize)) {
           try {
             log.debug("Thread [%s] is blocked waiting for resource for key [%s]", Thread.currentThread().getName(), key);
-            this.wait();
+            numWaitingThreads++;
+            try {
+              this.wait();
+            }
+            finally {
+              numWaitingThreads--;
+            }
           }
           catch (InterruptedException e) {
             Thread.currentThread().interrupt();
@@ -342,6 +362,16 @@ public class DefaultResourcePoolImpl<K, V> implements ResourcePool<K, V>
     private boolean holderListContains(V object)
     {
       return resourceHolderList.stream().anyMatch(a -> a.getResource().equals(object));
+    }
+
+    synchronized int getNumLent()
+    {
+      return numLentResources;
+    }
+
+    synchronized int getNumWaiting()
+    {
+      return numWaitingThreads;
     }
 
     @Override

--- a/processing/src/main/java/org/apache/druid/java/util/http/client/pool/MetricsEmittingResourcePoolImpl.java
+++ b/processing/src/main/java/org/apache/druid/java/util/http/client/pool/MetricsEmittingResourcePoolImpl.java
@@ -24,6 +24,7 @@ import org.apache.druid.java.util.emitter.service.ServiceEmitter;
 import org.apache.druid.java.util.emitter.service.ServiceMetricEvent;
 
 import java.io.IOException;
+import java.util.Map;
 
 public class MetricsEmittingResourcePoolImpl<K, V> implements ResourcePool<K, V>
 {
@@ -45,6 +46,12 @@ public class MetricsEmittingResourcePoolImpl<K, V> implements ResourcePool<K, V>
     long totalduration = System.nanoTime() - startTime;
     emitter.emit(ServiceMetricEvent.builder().setDimension("server", key.toString()).setMetric("httpClient/channelAcquire/timeNs", totalduration));
     return retVal;
+  }
+
+  @Override
+  public Map<K, PoolStats> getStats()
+  {
+    return resourcePool.getStats();
   }
 
   @Override

--- a/processing/src/main/java/org/apache/druid/java/util/http/client/pool/PoolStats.java
+++ b/processing/src/main/java/org/apache/druid/java/util/http/client/pool/PoolStats.java
@@ -19,20 +19,33 @@
 
 package org.apache.druid.java.util.http.client.pool;
 
-import java.io.Closeable;
-import java.util.Collections;
-import java.util.Map;
-
-public interface ResourcePool<K, V> extends Closeable
+/**
+ * Snapshot of per-key {@link ResourcePool} state.
+ */
+public class PoolStats
 {
+  private final int numActive;
+  private final int numQueued;
 
-  ResourceContainer<V> take(K key);
+  public PoolStats(int numActive, int numQueued)
+  {
+    this.numActive = numActive;
+    this.numQueued = numQueued;
+  }
 
   /**
-   * Snapshot of per-key pool state. Implementations that do not track stats return an empty map.
+   * Number of resources currently checked out from the pool (in active use).
    */
-  default Map<K, PoolStats> getStats()
+  public int getNumActive()
   {
-    return Collections.emptyMap();
+    return numActive;
+  }
+
+  /**
+   * Number of threads blocked waiting to acquire a resource because the pool is at its per-key max.
+   */
+  public int getNumQueued()
+  {
+    return numQueued;
   }
 }

--- a/processing/src/test/java/org/apache/druid/java/util/http/client/pool/ResourcePoolTest.java
+++ b/processing/src/test/java/org/apache/druid/java/util/http/client/pool/ResourcePoolTest.java
@@ -451,6 +451,65 @@ public class ResourcePoolTest
     EasyMock.reset(resourceFactory);
   }
 
+  @Test
+  public void testGetStatsTracksActiveAndQueued() throws Exception
+  {
+    primePool();
+    EasyMock.expect(resourceFactory.isGood("billy1")).andReturn(true).times(1);
+    EasyMock.expect(resourceFactory.isGood("billy0")).andReturn(true).times(1);
+    EasyMock.replay(resourceFactory);
+
+    Assert.assertEquals(0, pool.getStats().get("billy").getNumActive());
+    Assert.assertEquals(0, pool.getStats().get("billy").getNumQueued());
+
+    CountDownLatch latch1 = new CountDownLatch(1);
+    CountDownLatch latch2 = new CountDownLatch(1);
+    CountDownLatch latch3 = new CountDownLatch(1);
+
+    MyThread t1 = new MyThread(latch1, "billy");
+    t1.start();
+    t1.waitForValueToBeGotten(1, TimeUnit.SECONDS);
+
+    MyThread t2 = new MyThread(latch2, "billy");
+    t2.start();
+    t2.waitForValueToBeGotten(1, TimeUnit.SECONDS);
+
+    // Both slots taken; this thread will block in wait()
+    MyThread blocked = new MyThread(latch3, "billy");
+    blocked.start();
+
+    // Wait until the blocked thread reaches wait(); poll briefly.
+    long deadline = System.nanoTime() + TimeUnit.SECONDS.toNanos(2);
+    while (pool.getStats().get("billy").getNumQueued() < 1 && System.nanoTime() < deadline) {
+      Thread.sleep(10);
+    }
+
+    PoolStats stats = pool.getStats().get("billy");
+    Assert.assertEquals(2, stats.getNumActive());
+    Assert.assertEquals(1, stats.getNumQueued());
+
+    EasyMock.verify(resourceFactory);
+    EasyMock.reset(resourceFactory);
+    EasyMock.expect(resourceFactory.isGood("billy0")).andReturn(true).times(1);
+    EasyMock.replay(resourceFactory);
+
+    latch2.countDown();
+    blocked.waitForValueToBeGotten(1, TimeUnit.SECONDS);
+
+    PoolStats afterUnblock = pool.getStats().get("billy");
+    Assert.assertEquals(2, afterUnblock.getNumActive());
+    Assert.assertEquals(0, afterUnblock.getNumQueued());
+
+    latch1.countDown();
+    latch3.countDown();
+    t1.join();
+    t2.join();
+    blocked.join();
+
+    EasyMock.verify(resourceFactory);
+    EasyMock.reset(resourceFactory);
+  }
+
   private static class StringIncrementingAnswer implements IAnswer<String>
   {
     int count = 0;

--- a/server/src/main/java/org/apache/druid/guice/http/HttpClientModule.java
+++ b/server/src/main/java/org/apache/druid/guice/http/HttpClientModule.java
@@ -35,6 +35,7 @@ import org.apache.druid.java.util.emitter.service.ServiceEmitter;
 import org.apache.druid.java.util.http.client.HttpClient;
 import org.apache.druid.java.util.http.client.HttpClientConfig;
 import org.apache.druid.java.util.http.client.HttpClientInit;
+import org.apache.druid.java.util.http.client.NettyHttpClient;
 import org.apache.druid.server.security.Escalator;
 
 import javax.net.ssl.SSLContext;
@@ -77,9 +78,13 @@ public class HttpClientModule implements Module
   public void configure(Binder binder)
   {
     JsonConfigProvider.bind(binder, propertyPrefix, DruidHttpClientConfig.class, annotationClazz);
+    final OutboundHttpClientPool poolHolder = new OutboundHttpClientPool();
+    binder.bind(OutboundHttpClientPool.class)
+          .annotatedWith(annotationClazz)
+          .toInstance(poolHolder);
     binder.bind(HttpClient.class)
           .annotatedWith(annotationClazz)
-          .toProvider(new HttpClientProvider(annotationClazz, isEscalated, eagerByDefault))
+          .toProvider(new HttpClientProvider(annotationClazz, isEscalated, eagerByDefault, poolHolder))
           .in(LazySingleton.class);
   }
 
@@ -87,15 +92,22 @@ public class HttpClientModule implements Module
   {
     private final boolean isEscalated;
     private final boolean eagerByDefault;
+    private final OutboundHttpClientPool poolHolder;
     private Escalator escalator;
     private ServiceEmitter emitter;
 
 
-    public HttpClientProvider(Class<? extends Annotation> annotationClazz, boolean isEscalated, boolean eagerByDefault)
+    public HttpClientProvider(
+        Class<? extends Annotation> annotationClazz,
+        boolean isEscalated,
+        boolean eagerByDefault,
+        OutboundHttpClientPool poolHolder
+    )
     {
       super(annotationClazz);
       this.isEscalated = isEscalated;
       this.eagerByDefault = eagerByDefault;
+      this.poolHolder = poolHolder;
     }
 
     @Inject
@@ -132,6 +144,10 @@ public class HttpClientModule implements Module
           getLifecycleProvider().get(),
           emitter
       );
+
+      if (client instanceof NettyHttpClient) {
+        poolHolder.register(((NettyHttpClient) client).getPool());
+      }
 
       if (isEscalated) {
         return escalator.createEscalatedClient(client);

--- a/server/src/main/java/org/apache/druid/guice/http/OutboundHttpClientPool.java
+++ b/server/src/main/java/org/apache/druid/guice/http/OutboundHttpClientPool.java
@@ -17,22 +17,34 @@
  * under the License.
  */
 
-package org.apache.druid.java.util.http.client.pool;
+package org.apache.druid.guice.http;
 
-import java.io.Closeable;
+import org.apache.druid.java.util.http.client.pool.PoolStats;
+import org.apache.druid.java.util.http.client.pool.ResourcePool;
+
 import java.util.Collections;
 import java.util.Map;
 
-public interface ResourcePool<K, V> extends Closeable
+/**
+ * Guice-bindable handle to the underlying {@link ResourcePool} of an outbound Netty HTTP client.
+ * Populated by {@link HttpClientModule.HttpClientProvider} when the client is constructed, then
+ * read by monitors that emit per-destination pool stats.
+ */
+public class OutboundHttpClientPool
 {
+  private volatile ResourcePool<String, ?> pool;
 
-  ResourceContainer<V> take(K key);
+  public void register(ResourcePool<String, ?> pool)
+  {
+    this.pool = pool;
+  }
 
   /**
-   * Snapshot of per-key pool state. Implementations that do not track stats return an empty map.
+   * Returns a snapshot of per-destination pool state, or an empty map if no pool has been registered yet.
    */
-  default Map<K, PoolStats> getStats()
+  public Map<String, PoolStats> getStats()
   {
-    return Collections.emptyMap();
+    final ResourcePool<String, ?> p = pool;
+    return p == null ? Collections.emptyMap() : p.getStats();
   }
 }

--- a/server/src/main/java/org/apache/druid/server/metrics/BrokerHttpClientMonitor.java
+++ b/server/src/main/java/org/apache/druid/server/metrics/BrokerHttpClientMonitor.java
@@ -1,0 +1,60 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+package org.apache.druid.server.metrics;
+
+import com.google.inject.Inject;
+import org.apache.druid.guice.annotations.EscalatedClient;
+import org.apache.druid.guice.http.OutboundHttpClientPool;
+import org.apache.druid.java.util.emitter.service.ServiceEmitter;
+import org.apache.druid.java.util.emitter.service.ServiceMetricEvent;
+import org.apache.druid.java.util.http.client.pool.PoolStats;
+import org.apache.druid.java.util.metrics.AbstractMonitor;
+
+import java.util.Map;
+
+/**
+ * Monitor that emits per-destination outbound HTTP metrics for the Broker's Netty HttpClient:
+ * - broker/http/numActiveConnections: connections currently checked out and carrying a request
+ * - broker/http/numRequestsQueued: threads blocked waiting to acquire a connection
+ */
+public class BrokerHttpClientMonitor extends AbstractMonitor
+{
+  private final OutboundHttpClientPool pool;
+
+  @Inject
+  public BrokerHttpClientMonitor(@EscalatedClient OutboundHttpClientPool pool)
+  {
+    this.pool = pool;
+  }
+
+  @Override
+  public boolean doMonitor(ServiceEmitter emitter)
+  {
+    for (Map.Entry<String, PoolStats> entry : pool.getStats().entrySet()) {
+      final ServiceMetricEvent.Builder builder = new ServiceMetricEvent.Builder()
+          .setDimension("destination", entry.getKey());
+
+      emitter.emit(builder.setMetric("broker/http/numActiveConnections", entry.getValue().getNumActive()));
+      emitter.emit(builder.setMetric("broker/http/numRequestsQueued", entry.getValue().getNumQueued()));
+    }
+
+    return true;
+  }
+}

--- a/server/src/test/java/org/apache/druid/server/metrics/BrokerHttpClientMonitorTest.java
+++ b/server/src/test/java/org/apache/druid/server/metrics/BrokerHttpClientMonitorTest.java
@@ -1,0 +1,111 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+package org.apache.druid.server.metrics;
+
+import com.google.common.collect.ImmutableMap;
+import org.apache.druid.guice.http.OutboundHttpClientPool;
+import org.apache.druid.java.util.http.client.pool.PoolStats;
+import org.apache.druid.java.util.http.client.pool.ResourcePool;
+import org.apache.druid.java.util.metrics.StubServiceEmitter;
+import org.junit.Assert;
+import org.junit.Before;
+import org.junit.Test;
+import org.mockito.Mockito;
+
+import java.util.Collections;
+import java.util.List;
+import java.util.Map;
+
+public class BrokerHttpClientMonitorTest
+{
+  private OutboundHttpClientPool poolHolder;
+  private BrokerHttpClientMonitor monitor;
+
+  @Before
+  public void setUp()
+  {
+    poolHolder = new OutboundHttpClientPool();
+    monitor = new BrokerHttpClientMonitor(poolHolder);
+  }
+
+  @Test
+  public void testDoMonitorReturnsTrueWithNoPoolRegistered()
+  {
+    Assert.assertTrue(monitor.doMonitor(new StubServiceEmitter("broker", "localhost")));
+  }
+
+  @Test
+  public void testEmptyPoolEmitsNoEvents()
+  {
+    @SuppressWarnings("unchecked")
+    ResourcePool<String, Object> pool = (ResourcePool<String, Object>) Mockito.mock(ResourcePool.class);
+    Mockito.when(pool.getStats()).thenReturn(Collections.emptyMap());
+    poolHolder.register(pool);
+
+    final StubServiceEmitter emitter = new StubServiceEmitter("broker", "localhost");
+    monitor.doMonitor(emitter);
+
+    Assert.assertTrue(emitter.getEvents().isEmpty());
+  }
+
+  @Test
+  public void testMultipleDestinationsEmitsPerDestinationMetrics()
+  {
+    @SuppressWarnings("unchecked")
+    ResourcePool<String, Object> pool = (ResourcePool<String, Object>) Mockito.mock(ResourcePool.class);
+    Map<String, PoolStats> stats = ImmutableMap.of(
+        "http://host1:8083", new PoolStats(2, 3),
+        "http://host2:8083", new PoolStats(5, 1)
+    );
+    Mockito.when(pool.getStats()).thenReturn(stats);
+    poolHolder.register(pool);
+
+    final StubServiceEmitter emitter = new StubServiceEmitter("broker", "localhost");
+    monitor.doMonitor(emitter);
+
+    // 2 metrics per destination
+    Assert.assertEquals(4, emitter.getEvents().size());
+
+    List<Map<String, Object>> events = emitter.getEvents().stream()
+                                              .map(e -> e.toMap())
+                                              .collect(java.util.stream.Collectors.toList());
+
+    Assert.assertTrue(events.stream().anyMatch(e ->
+        "broker/http/numActiveConnections".equals(e.get("metric")) &&
+        "http://host1:8083".equals(e.get("destination")) &&
+        Integer.valueOf(2).equals(e.get("value"))
+    ));
+    Assert.assertTrue(events.stream().anyMatch(e ->
+        "broker/http/numRequestsQueued".equals(e.get("metric")) &&
+        "http://host1:8083".equals(e.get("destination")) &&
+        Integer.valueOf(3).equals(e.get("value"))
+    ));
+    Assert.assertTrue(events.stream().anyMatch(e ->
+        "broker/http/numActiveConnections".equals(e.get("metric")) &&
+        "http://host2:8083".equals(e.get("destination")) &&
+        Integer.valueOf(5).equals(e.get("value"))
+    ));
+    Assert.assertTrue(events.stream().anyMatch(e ->
+        "broker/http/numRequestsQueued".equals(e.get("metric")) &&
+        "http://host2:8083".equals(e.get("destination")) &&
+        Integer.valueOf(1).equals(e.get("value"))
+    ));
+  }
+}

--- a/services/src/main/java/org/apache/druid/cli/CliBroker.java
+++ b/services/src/main/java/org/apache/druid/cli/CliBroker.java
@@ -70,6 +70,8 @@ import org.apache.druid.server.http.HistoricalResource;
 import org.apache.druid.server.http.SegmentListerResource;
 import org.apache.druid.server.http.SelfDiscoveryResource;
 import org.apache.druid.server.initialization.jetty.JettyServerInitializer;
+import org.apache.druid.server.metrics.BrokerHttpClientMonitor;
+import org.apache.druid.server.metrics.MetricsModule;
 import org.apache.druid.server.metrics.QueryCountStatsProvider;
 import org.apache.druid.server.metrics.SubqueryCountStatsProvider;
 import org.apache.druid.server.router.TieredBrokerConfig;
@@ -149,6 +151,7 @@ public class CliBroker extends ServerRunnable
           binder.bind(QuerySegmentWalker.class).to(ClientQuerySegmentWalker.class).in(LazySingleton.class);
 
           binder.bind(JettyServerInitializer.class).to(QueryJettyServerInitializer.class).in(LazySingleton.class);
+          MetricsModule.register(binder, BrokerHttpClientMonitor.class);
 
           binder.bind(BrokerQueryResource.class).in(LazySingleton.class);
           Jerseys.addResource(binder, BrokerQueryResource.class);


### PR DESCRIPTION
Add two metrics as given below:
1. Number of active connections per destination on broker’s http client for outgoing requests
2. Number of outgoing requests queued per destination on broker’s http client for outgoing requests

More details including testing:
https://confluentinc.atlassian.net/wiki/spaces/~62be365dc9f2df7b608c58d2/pages/5610570223/Broker+metrics