### PR TITLE
Fix KafkaIndexFaultToleranceTest flake and re-enable it in E2E CI

### DIFF
--- a/.semaphore/semaphore.yml
+++ b/.semaphore/semaphore.yml
@@ -158,9 +158,6 @@ blocks:
 
         # Keep -Dmaven.repo.local=.m2 (else deps resolve to upstream 37.0.0 from Central, not our build);
         # reuseForks=false runs each test class in a fresh JVM so embedded-tests heap doesn't accumulate.
-        # KafkaIndexFaultToleranceTest is re-enabled here (it was excluded in #453): its earlier CI stall
-        # was a producer-side OUT_OF_ORDER_SEQUENCE_NUMBER storm after a topic-partition increase, now
-        # fixed in KafkaResource.produceRecordsWithoutTransaction (max.in.flight=1 + block on delivery).
         - name: "Druid E2E Tests"
           env_vars:
               - name: MAVEN_PROJECTS

--- a/.semaphore/semaphore.yml
+++ b/.semaphore/semaphore.yml
@@ -158,15 +158,15 @@ blocks:
 
         # Keep -Dmaven.repo.local=.m2 (else deps resolve to upstream 37.0.0 from Central, not our build);
         # reuseForks=false runs each test class in a fresh JVM so embedded-tests heap doesn't accumulate.
-        # -Dtest=!KafkaIndexFaultToleranceTest: this upstream supervisor-recovery test stalls only on the
-        # CI agent (passes locally in isolation + under CPU load; never reproducible here). It is pure
-        # upstream and covered by apache's own docker-tests CI, so it's excluded from this pipeline.
+        # KafkaIndexFaultToleranceTest is re-enabled here (it was excluded in #453): its earlier CI stall
+        # was a producer-side OUT_OF_ORDER_SEQUENCE_NUMBER storm after a topic-partition increase, now
+        # fixed in KafkaResource.produceRecordsWithoutTransaction (max.in.flight=1 + block on delivery).
         - name: "Druid E2E Tests"
           env_vars:
               - name: MAVEN_PROJECTS
                 value: 'quidem-ut,embedded-tests'
               - name: MAVEN_OPTS
-                value: "-Dmaven.repo.local=.m2 -DforkCount=1 -DreuseForks=false -Dtest=!KafkaIndexFaultToleranceTest"
+                value: "-Dmaven.repo.local=.m2 -DforkCount=1 -DreuseForks=false"
           commands: *run_tests
 
         - name: "Other Tests"

--- a/extensions-core/kafka-indexing-service/src/test/java/org/apache/druid/indexing/kafka/simulate/KafkaResource.java
+++ b/extensions-core/kafka-indexing-service/src/test/java/org/apache/druid/indexing/kafka/simulate/KafkaResource.java
@@ -30,6 +30,7 @@ import org.apache.kafka.clients.admin.NewTopic;
 import org.apache.kafka.clients.producer.KafkaProducer;
 import org.apache.kafka.clients.producer.ProducerConfig;
 import org.apache.kafka.clients.producer.ProducerRecord;
+import org.apache.kafka.clients.producer.RecordMetadata;
 import org.apache.kafka.common.serialization.ByteArraySerializer;
 import org.testcontainers.kafka.KafkaContainer;
 
@@ -38,6 +39,7 @@ import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
 import java.util.Set;
+import java.util.concurrent.Future;
 import java.util.concurrent.ThreadLocalRandom;
 
 /**
@@ -213,10 +215,22 @@ public class KafkaResource extends StreamIngestResource<KafkaContainer>
   {
     final Map<String, Object> props = producerProperties();
     props.remove(ProducerConfig.TRANSACTIONAL_ID_CONFIG);
+    // Pin in-flight requests to 1 for strict per-partition ordering. When records are produced right
+    // after a topic partition increase, sends to a new partition can transiently fail (NOT_LEADER_OR_
+    // FOLLOWER) before its leader is ready; with the default (up to 5) in-flight batches the failed
+    // batch leaves an idempotent-sequence gap, so every later batch is rejected OUT_OF_ORDER_SEQUENCE_
+    // NUMBER and never recovers. With a single in-flight batch, a failed send simply retries in place.
+    props.put(ProducerConfig.MAX_IN_FLIGHT_REQUESTS_PER_CONNECTION, 1);
 
     try (final KafkaProducer<byte[], byte[]> kafkaProducer = new KafkaProducer<>(props)) {
+      final List<Future<RecordMetadata>> futures = new ArrayList<>(records.size());
       for (ProducerRecord<byte[], byte[]> record : records) {
-        kafkaProducer.send(record);
+        futures.add(kafkaProducer.send(record));
+      }
+      // Block on delivery so a genuine produce failure surfaces here instead of silently dropping
+      // records (which would later manifest as an opaque ingestion-count timeout).
+      for (Future<RecordMetadata> future : futures) {
+        future.get();
       }
     }
     catch (Exception e) {


### PR DESCRIPTION
## What
Fixes the flake that caused `KafkaIndexFaultToleranceTest` to be excluded from the Druid E2E Semaphore job in #453, and re-enables the test so CI exercises it.

## Root cause
`test_supervisorRecovers_afterChangeInTopicPartitions[useTransactions=false]` stalled in CI. The non-transactional publish path uses an **idempotent** producer (`enable.idempotence=true`). When records are produced immediately after a topic **partition increase (2→4)**, a send to a not-yet-ready new partition transiently fails with `NOT_LEADER_OR_FOLLOWER`. With the default of up to 5 in-flight batches, that failed batch leaves an idempotent-**sequence gap**, so every later batch is rejected with `OUT_OF_ORDER_SEQUENCE_NUMBER` and the producer never recovers (~1150 retries observed). Because the test never checked the send futures, the records were **silently dropped** — only half the rows ingested, and the teardown's published-rows wait timed out.

This is producer-side, in upstream test code (`KafkaResource`), independent of the Confluent ingestion patches.

## Fix
In `KafkaResource.produceRecordsWithoutTransaction`:
- `max.in.flight.requests.per.connection=1` → strict per-partition ordering, so a failed batch can't leave a sequence gap. Idempotence stays on, so no duplicates (the exact row-count assertion holds).
- Block on the send futures (`future.get()`) so a genuine produce failure surfaces immediately instead of as an opaque ingestion-count timeout.

Re-enables the test in `.semaphore/semaphore.yml` (removes the `-Dtest=!KafkaIndexFaultToleranceTest` exclusion added in #453). The `LatchableEmitter` timeout is intentionally left at upstream's 60s, so a green CI run is unambiguous proof the producer fix works rather than just extra headroom.

## Validation
Locally, both parameterizations of the previously-failing test pass in ~64s (was 240s + error):
```
Tests run: 2, Failures: 0, Errors: 0, Skipped: 0, Time elapsed: 64.27 s
```
Re-enabling here so Semaphore confirms it on the CI agent.

## Note
This touches upstream test code; worth proposing the same fix upstream to Apache, since the flake exists there too.

🤖 Generated with [Claude Code](https://claude.com/claude-code)