### PR TITLE
Bump async-http-client 2.12.4 -> 2.15.0 to fix CVE-2026-45300

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -983,7 +983,8 @@
                 <groupId>org.asynchttpclient</groupId>
                 <artifactId>async-http-client</artifactId>
                 <!-- Uses Netty 4.1.x -->
-                <version>2.12.4</version>
+                <!-- 2.15.0 fixes CVE-2026-45300 (Cookie header leakage on cross-origin redirects) -->
+                <version>2.15.0</version>
             </dependency>
             <dependency>
                 <groupId>net.java.dev.jna</groupId>

--- a/pom.xml
+++ b/pom.xml
@@ -983,7 +983,6 @@
                 <groupId>org.asynchttpclient</groupId>
                 <artifactId>async-http-client</artifactId>
                 <!-- Uses Netty 4.1.x -->
-                <!-- 2.15.0 fixes CVE-2026-45300 (Cookie header leakage on cross-origin redirects) -->
                 <version>2.15.0</version>
             </dependency>
             <dependency>

--- a/processing/src/test/java/org/apache/druid/java/util/common/CompressionUtilsTest.java
+++ b/processing/src/test/java/org/apache/druid/java/util/common/CompressionUtilsTest.java
@@ -33,6 +33,7 @@ import org.apache.commons.compress.compressors.zstandard.ZstdCompressorOutputStr
 import org.apache.druid.utils.CompressionUtils;
 import org.junit.Assert;
 import org.junit.Before;
+import org.junit.Ignore;
 import org.junit.Rule;
 import org.junit.Test;
 import org.junit.rules.TemporaryFolder;
@@ -551,7 +552,7 @@ public class CompressionUtilsTest
   }
 
   // If this ever passes, er... fails to fail... then the bug is fixed
-  @Ignore
+  @Ignore("This test fails in JDK 21, looks like the bug was fixed in 21.0.9 at least.")
   @Test(expected = AssertionError.class)
   // http://bugs.java.com/bugdatabase/view_bug.do?bug_id=7036144
   public void testGunzipBug() throws IOException

--- a/processing/src/test/java/org/apache/druid/java/util/common/CompressionUtilsTest.java
+++ b/processing/src/test/java/org/apache/druid/java/util/common/CompressionUtilsTest.java
@@ -552,7 +552,7 @@ public class CompressionUtilsTest
   }
 
   // If this ever passes, er... fails to fail... then the bug is fixed
-  @Ignore("This test fails in JDK 21, looks like the bug was fixed in 21.0.9 at least.")
+  @Ignore("This test fails in JDK 17.0.19+ as the bug in the JDK was fixed")
   @Test(expected = AssertionError.class)
   // http://bugs.java.com/bugdatabase/view_bug.do?bug_id=7036144
   public void testGunzipBug() throws IOException

--- a/processing/src/test/java/org/apache/druid/java/util/common/CompressionUtilsTest.java
+++ b/processing/src/test/java/org/apache/druid/java/util/common/CompressionUtilsTest.java
@@ -551,6 +551,7 @@ public class CompressionUtilsTest
   }
 
   // If this ever passes, er... fails to fail... then the bug is fixed
+  @Ignore
   @Test(expected = AssertionError.class)
   // http://bugs.java.com/bugdatabase/view_bug.do?bug_id=7036144
   public void testGunzipBug() throws IOException


### PR DESCRIPTION
### Description

Upgrade AsyncHttpClient to 2.15 to fix CVE-2026-45300 .

Also Ignore testGunzipBug canary broken by JDK 7036144 fix (17.0.18 -> 17.0.19). CompressionUtilsTest.testGunzipBug is a canary for JDK bug 7036144 (GZIPInputStream "read terminated too soon"). It uses @Test(expected = AssertionError.class), i.e. it asserts the JDK bug is STILL present.

 Since the CI agents have been bumped to Java 17 toolchain patch from 17.0.18 to 17.0.19, where 7036144 is fixed. The gunzip now reads correctly, no AssertionError is thrown, and the canary fails on every PR built on the new agents — unrelated to this branch's async-http-client CVE bump.





