### PR TITLE
OBSDATA-14262 Retry S3 uploads when retryable errors are wrapped

### DIFF
--- a/cloud/aws-common/src/main/java/org/apache/druid/common/aws/AWSClientUtil.java
+++ b/cloud/aws-common/src/main/java/org/apache/druid/common/aws/AWSClientUtil.java
@@ -78,9 +78,11 @@ public class AWSClientUtil
       return true;
     }
 
-    // A special check carried forwarded from previous implementation.
+    // S3 can return a recoverable error code with a non-5xx HTTP status. For example, completeMultipartUpload
+    // may fail with error code "InternalError" inside a 200 OK response, which the status-code based checks
+    // below would miss. Match the error code against the curated recoverable set for any service exception.
     if (exception instanceof AmazonServiceException
-        && "RequestTimeout".equals(((AmazonServiceException) exception).getErrorCode())) {
+        && RECOVERABLE_ERROR_CODES.contains(((AmazonServiceException) exception).getErrorCode())) {
       return true;
     }
 

--- a/cloud/aws-common/src/test/java/org/apache/druid/common/aws/AWSClientUtilTest.java
+++ b/cloud/aws-common/src/test/java/org/apache/druid/common/aws/AWSClientUtilTest.java
@@ -85,6 +85,16 @@ public class AWSClientUtilTest
   }
 
   @Test
+  public void testRecoverableException_InternalErrorInOkResponse()
+  {
+    // S3 completeMultipartUpload can fail with a recoverable error code inside a 200 OK response.
+    AmazonServiceException ex = new AmazonServiceException(null);
+    ex.setStatusCode(200);
+    ex.setErrorCode("InternalError");
+    Assert.assertTrue(AWSClientUtil.isClientExceptionRecoverable(ex));
+  }
+
+  @Test
   public void testRecoverableException_MultiObjectDeleteException()
   {
     MultiObjectDeleteException.DeleteError retryableError = new MultiObjectDeleteException.DeleteError();

--- a/extensions-core/s3-extensions/src/main/java/org/apache/druid/storage/s3/S3Utils.java
+++ b/extensions-core/s3-extensions/src/main/java/org/apache/druid/storage/s3/S3Utils.java
@@ -100,7 +100,15 @@ public class S3Utils
         Thread.interrupted(); // Clear interrupted state and not retry
         return false;
       } else if (e instanceof AmazonClientException) {
-        return AWSClientUtil.isClientExceptionRecoverable((AmazonClientException) e);
+        if (AWSClientUtil.isClientExceptionRecoverable((AmazonClientException) e)) {
+          return true;
+        }
+        // The recoverable error may be hidden behind a generic wrapper that is itself an AmazonClientException.
+        // For example, when a multipart upload part fails, TransferManager throws
+        // SdkClientException("Unable to complete multi-part upload. Individual part upload failed: ...") whose
+        // retryable AmazonS3Exception (e.g. a 503) is only present as the cause. Check the cause chain before
+        // concluding the operation is not retryable.
+        return apply(e.getCause());
       } else {
         return apply(e.getCause());
       }

--- a/extensions-core/s3-extensions/src/test/java/org/apache/druid/storage/s3/S3UtilsTest.java
+++ b/extensions-core/s3-extensions/src/test/java/org/apache/druid/storage/s3/S3UtilsTest.java
@@ -111,6 +111,94 @@ public class S3UtilsTest
   }
 
   @Test
+  public void testRetryWith5XXErrorsWrappedInSdkClientException() throws Exception
+  {
+    // Mimics a multipart upload part failure: TransferManager wraps the retryable AmazonS3Exception in a
+    // generic SdkClientException, leaving the 503 only on the cause chain.
+    final int maxRetries = 3;
+    final AtomicInteger count = new AtomicInteger();
+    S3Utils.retryS3Operation(
+        () -> {
+          if (count.incrementAndGet() >= maxRetries) {
+            return "hey";
+          } else {
+            AmazonS3Exception s3Exception = new AmazonS3Exception("Service Unavailable");
+            s3Exception.setStatusCode(503);
+            throw new SdkClientException(
+                "Unable to complete multi-part upload. Individual part upload failed: Service Unavailable",
+                s3Exception
+            );
+          }
+        },
+        maxRetries
+    );
+    Assert.assertEquals(maxRetries, count.get());
+  }
+
+  @Test
+  public void testRetryWithInternalErrorInOkResponse() throws Exception
+  {
+    // Mimics completeMultipartUpload failing with error code "InternalError" inside a 200 OK response,
+    // surfaced wrapped in an IOException.
+    final int maxRetries = 3;
+    final AtomicInteger count = new AtomicInteger();
+    S3Utils.retryS3Operation(
+        () -> {
+          if (count.incrementAndGet() >= maxRetries) {
+            return "hey";
+          } else {
+            AmazonS3Exception s3Exception =
+                new AmazonS3Exception("We encountered an internal error. Please try again.");
+            s3Exception.setStatusCode(200);
+            s3Exception.setErrorCode("InternalError");
+            throw new IOException(s3Exception);
+          }
+        },
+        maxRetries
+    );
+    Assert.assertEquals(maxRetries, count.get());
+  }
+
+  @Test
+  public void testNoRetryWith4XXErrorsWrappedInSdkClientException()
+  {
+    final AtomicInteger count = new AtomicInteger();
+    Assert.assertThrows(
+        SdkClientException.class,
+        () -> S3Utils.retryS3Operation(
+            () -> {
+              count.incrementAndGet();
+              AmazonS3Exception s3Exception = new AmazonS3Exception("Access Denied");
+              s3Exception.setStatusCode(403);
+              throw new SdkClientException(
+                  "Unable to complete multi-part upload. Individual part upload failed: Access Denied",
+                  s3Exception
+              );
+            },
+            3
+        )
+    );
+    Assert.assertEquals(1, count.get());
+  }
+
+  @Test
+  public void testNoRetryWithInterruptedExceptionWrappedInSdkClientException()
+  {
+    final AtomicInteger count = new AtomicInteger();
+    Assert.assertThrows(
+        SdkClientException.class,
+        () -> S3Utils.retryS3Operation(
+            () -> {
+              count.incrementAndGet();
+              throw new SdkClientException("Upload aborted", new InterruptedException());
+            },
+            3
+        )
+    );
+    Assert.assertEquals(1, count.get());
+  }
+
+  @Test
   public void testRetryWithSdkClientException() throws Exception
   {
     final int maxRetries = 3;


### PR DESCRIPTION
## Summary

Indexing tasks were failing on the **first** S3 segment-push attempt even though Druid's retry wrapper (`S3Utils.retryS3Operation`, 10 tries with exponential backoff) had retries available. This PR fixes two retryability-classification gaps so that transient S3 errors hidden inside wrapper exceptions are retried.

## Root cause

**1. Multipart upload failures were never retried.** When a multipart part upload fails (segment zips > `druid.storage.transfer.multipartUploadThreshold` go through AWS `TransferManager`), the SDK wraps the underlying `AmazonS3Exception` (e.g. 503 SlowDown) in a generic `SdkClientException("Unable to complete multi-part upload. Individual part upload failed: ...")`. The `S3RETRY` predicate classified retryability from the top-level exception only — the `AmazonClientException` branch returned `AWSClientUtil.isClientExceptionRecoverable()` without ever walking the cause chain — so the retryable 503 was invisible and the task failed on try 1. A bare (single-PUT) `AmazonS3Exception(503)` was already retried correctly; the asymmetry depended purely on whether the segment crossed the multipart threshold.

**2. Recoverable error codes inside non-5xx responses were never retried.** S3 `completeMultipartUpload` can fail with error code `InternalError` inside a **200 OK** response. `AWSClientUtil.isClientExceptionRecoverable` only consulted its `RECOVERABLE_ERROR_CODES` set for `MultiObjectDeleteException`, and the 5xx status check doesn't match a 200, so these failed on try 1 as well.

## Production evidence

- Task `index_kafka_telemetry_metrics_1b9cf8482b2a072_hbagdcjp` (druid-prod-358af, 2026-06-11 05:20 UTC) failed 1.7s into its only push attempt with the exact multipart-503 signature — zero `Retrying (N of M)` lines in 922 task log lines.
- 30-day log census: **100%** of druid-prod-de587 task failures (18/18) and **136/454** on druid-prod-358af are S3-attributable; 132 of those 136 match gap 1 (37 direct + 95 downstream metadata-inconsistency cascades) and the remaining 4 match gap 2.
- Top-level 503s already survive today (112 successful `Retrying (1 of 9)` events on de587 in 7 days), confirming the retry budget is adequate once classification is fixed.

## Changes

- `S3Utils.java` — `S3RETRY` falls through to `apply(e.getCause())` when a top-level `AmazonClientException` is not recoverable, so retryable causes anywhere on the chain are found. The `InterruptedException` short-circuit stays ahead of the cause walk, so interrupted operations (e.g. `pushExecutor.shutdownNow()` during task teardown) are still never retried.
- `AWSClientUtil.java` — the `RECOVERABLE_ERROR_CODES` check now applies to any `AmazonServiceException` (covers the 200-OK/`InternalError` case and subsumes the previous `RequestTimeout` special case, since `RequestTimeout` is in the set).

## Testing

New unit tests:
- `S3UtilsTest`: wrapped 503 (`SdkClientException` → `AmazonS3Exception(503)`) is retried to success; wrapped 403 is not retried; wrapped `InterruptedException` is not retried; `IOException` → `AmazonS3Exception(200, InternalError)` is retried to success.
- `AWSClientUtilTest`: `AmazonServiceException(status=200, errorCode=InternalError)` is recoverable.

🤖 Generated with [Claude Code](https://claude.com/claude-code)