### PR TITLE
Backport OBSDATA-5553 and OBSDATA-14262 to druid-30

### DIFF
--- a/cloud/aws-common/src/main/java/org/apache/druid/common/aws/AWSClientUtil.java
+++ b/cloud/aws-common/src/main/java/org/apache/druid/common/aws/AWSClientUtil.java
@@ -78,9 +78,11 @@ public class AWSClientUtil
       return true;
     }
 
-    // A special check carried forwarded from previous implementation.
+    // S3 can return a recoverable error code with a non-5xx HTTP status. For example, completeMultipartUpload
+    // may fail with error code "InternalError" inside a 200 OK response, which the status-code based checks
+    // below would miss. Match the error code against the curated recoverable set for any service exception.
     if (exception instanceof AmazonServiceException
-        && "RequestTimeout".equals(((AmazonServiceException) exception).getErrorCode())) {
+        && RECOVERABLE_ERROR_CODES.contains(((AmazonServiceException) exception).getErrorCode())) {
       return true;
     }
 

--- a/cloud/aws-common/src/test/java/org/apache/druid/common/aws/AWSClientUtilTest.java
+++ b/cloud/aws-common/src/test/java/org/apache/druid/common/aws/AWSClientUtilTest.java
@@ -85,6 +85,16 @@ public class AWSClientUtilTest
   }
 
   @Test
+  public void testRecoverableException_InternalErrorInOkResponse()
+  {
+    // S3 completeMultipartUpload can fail with a recoverable error code inside a 200 OK response.
+    AmazonServiceException ex = new AmazonServiceException(null);
+    ex.setStatusCode(200);
+    ex.setErrorCode("InternalError");
+    Assert.assertTrue(AWSClientUtil.isClientExceptionRecoverable(ex));
+  }
+
+  @Test
   public void testRecoverableException_MultiObjectDeleteException()
   {
     MultiObjectDeleteException.DeleteError retryableError = new MultiObjectDeleteException.DeleteError();

--- a/extensions-core/s3-extensions/src/main/java/org/apache/druid/storage/s3/S3Utils.java
+++ b/extensions-core/s3-extensions/src/main/java/org/apache/druid/storage/s3/S3Utils.java
@@ -92,6 +92,12 @@ public class S3Utils
       } else if (e instanceof SdkClientException && e.getMessage().contains("Unable to execute HTTP request")) {
         // This is likely due to a temporary DNS issue and can be retried.
         return true;
+      } else if (e instanceof SdkClientException
+                 && e.getMessage() != null
+                 && e.getMessage().contains("Unable to find a region")) {
+        // This can happen sometimes when AWS isn't able to obtain the credentials for some service:
+        // https://github.com/aws/aws-sdk-java/issues/2285
+        return true;
       } else if (e instanceof InterruptedException) {
         Thread.interrupted(); // Clear interrupted state and not retry
         return false;

--- a/extensions-core/s3-extensions/src/main/java/org/apache/druid/storage/s3/S3Utils.java
+++ b/extensions-core/s3-extensions/src/main/java/org/apache/druid/storage/s3/S3Utils.java
@@ -96,7 +96,15 @@ public class S3Utils
         Thread.interrupted(); // Clear interrupted state and not retry
         return false;
       } else if (e instanceof AmazonClientException) {
-        return AWSClientUtil.isClientExceptionRecoverable((AmazonClientException) e);
+        if (AWSClientUtil.isClientExceptionRecoverable((AmazonClientException) e)) {
+          return true;
+        }
+        // The recoverable error may be hidden behind a generic wrapper that is itself an AmazonClientException.
+        // For example, when a multipart upload part fails, TransferManager throws
+        // SdkClientException("Unable to complete multi-part upload. Individual part upload failed: ...") whose
+        // retryable AmazonS3Exception (e.g. a 503) is only present as the cause. Check the cause chain before
+        // concluding the operation is not retryable.
+        return apply(e.getCause());
       } else {
         return apply(e.getCause());
       }

--- a/extensions-core/s3-extensions/src/test/java/org/apache/druid/storage/s3/S3UtilsTest.java
+++ b/extensions-core/s3-extensions/src/test/java/org/apache/druid/storage/s3/S3UtilsTest.java
@@ -19,6 +19,7 @@
 
 package org.apache.druid.storage.s3;
 
+import com.amazonaws.SdkClientException;
 import com.amazonaws.services.s3.model.AmazonS3Exception;
 import org.junit.Assert;
 import org.junit.Test;

--- a/extensions-core/s3-extensions/src/test/java/org/apache/druid/storage/s3/S3UtilsTest.java
+++ b/extensions-core/s3-extensions/src/test/java/org/apache/druid/storage/s3/S3UtilsTest.java
@@ -108,4 +108,113 @@ public class S3UtilsTest
     );
     Assert.assertEquals(maxRetries, count.get());
   }
+
+  @Test
+  public void testRetryWith5XXErrorsWrappedInSdkClientException() throws Exception
+  {
+    // Mimics a multipart upload part failure: TransferManager wraps the retryable AmazonS3Exception in a
+    // generic SdkClientException, leaving the 503 only on the cause chain.
+    final int maxRetries = 3;
+    final AtomicInteger count = new AtomicInteger();
+    S3Utils.retryS3Operation(
+        () -> {
+          if (count.incrementAndGet() >= maxRetries) {
+            return "hey";
+          } else {
+            AmazonS3Exception s3Exception = new AmazonS3Exception("Service Unavailable");
+            s3Exception.setStatusCode(503);
+            throw new SdkClientException(
+                "Unable to complete multi-part upload. Individual part upload failed: Service Unavailable",
+                s3Exception
+            );
+          }
+        },
+        maxRetries
+    );
+    Assert.assertEquals(maxRetries, count.get());
+  }
+
+  @Test
+  public void testRetryWithInternalErrorInOkResponse() throws Exception
+  {
+    // Mimics completeMultipartUpload failing with error code "InternalError" inside a 200 OK response,
+    // surfaced wrapped in an IOException.
+    final int maxRetries = 3;
+    final AtomicInteger count = new AtomicInteger();
+    S3Utils.retryS3Operation(
+        () -> {
+          if (count.incrementAndGet() >= maxRetries) {
+            return "hey";
+          } else {
+            AmazonS3Exception s3Exception =
+                new AmazonS3Exception("We encountered an internal error. Please try again.");
+            s3Exception.setStatusCode(200);
+            s3Exception.setErrorCode("InternalError");
+            throw new IOException(s3Exception);
+          }
+        },
+        maxRetries
+    );
+    Assert.assertEquals(maxRetries, count.get());
+  }
+
+  @Test
+  public void testNoRetryWith4XXErrorsWrappedInSdkClientException()
+  {
+    final AtomicInteger count = new AtomicInteger();
+    Assert.assertThrows(
+        SdkClientException.class,
+        () -> S3Utils.retryS3Operation(
+            () -> {
+              count.incrementAndGet();
+              AmazonS3Exception s3Exception = new AmazonS3Exception("Access Denied");
+              s3Exception.setStatusCode(403);
+              throw new SdkClientException(
+                  "Unable to complete multi-part upload. Individual part upload failed: Access Denied",
+                  s3Exception
+              );
+            },
+            3
+        )
+    );
+    Assert.assertEquals(1, count.get());
+  }
+
+  @Test
+  public void testNoRetryWithInterruptedExceptionWrappedInSdkClientException()
+  {
+    final AtomicInteger count = new AtomicInteger();
+    Assert.assertThrows(
+        SdkClientException.class,
+        () -> S3Utils.retryS3Operation(
+            () -> {
+              count.incrementAndGet();
+              throw new SdkClientException("Upload aborted", new InterruptedException());
+            },
+            3
+        )
+    );
+    Assert.assertEquals(1, count.get());
+  }
+
+  @Test
+  public void testRetryWithSdkClientException() throws Exception
+  {
+    final int maxRetries = 3;
+    final AtomicInteger count = new AtomicInteger();
+    S3Utils.retryS3Operation(
+        () -> {
+          if (count.incrementAndGet() >= maxRetries) {
+            return "hey";
+          } else {
+            throw new SdkClientException(
+                "Unable to find a region via the region provider chain. "
+                + "Must provide an explicit region in the builder or setup environment to supply a region."
+            );
+          }
+        },
+        maxRetries
+    );
+    Assert.assertEquals(maxRetries, count.get());
+  }
 }

--- a/server/src/main/java/org/apache/druid/rpc/ServiceLocation.java
+++ b/server/src/main/java/org/apache/druid/rpc/ServiceLocation.java
@@ -50,7 +50,7 @@ public class ServiceLocation
 
   public static ServiceLocation fromDruidNode(final DruidNode druidNode)
   {
-    return new ServiceLocation(druidNode.getHost(), druidNode.getPlaintextPort(), druidNode.getTlsPort(), "");
+    return new ServiceLocation(druidNode.getHost(), druidNode.getAdvertisedPlaintextPort(), druidNode.getTlsPort(), "");
   }
 
   private static final Splitter SPLITTER = Splitter.on(":").limit(2);

--- a/server/src/main/java/org/apache/druid/server/DruidNode.java
+++ b/server/src/main/java/org/apache/druid/server/DruidNode.java
@@ -80,6 +80,10 @@ public class DruidNode
   @JsonProperty
   private boolean enableTlsPort = false;
 
+  @JsonProperty
+  @Max(0xffff)
+  private int advertisedPlaintextPort = -1;
+
   public DruidNode(
       String serviceName,
       String host,
@@ -90,7 +94,21 @@ public class DruidNode
       boolean enableTlsPort
   )
   {
-    this(serviceName, host, bindOnHost, plaintextPort, null, tlsPort, enablePlaintextPort, enableTlsPort);
+    this(serviceName, host, bindOnHost, plaintextPort, null, tlsPort, enablePlaintextPort, enableTlsPort, null);
+  }
+
+  public DruidNode(
+      String serviceName,
+      String host,
+      boolean bindOnHost,
+      Integer plaintextPort,
+      Integer port,
+      Integer tlsPort,
+      Boolean enablePlaintextPort,
+      boolean enableTlsPort
+  )
+  {
+    this(serviceName, host, bindOnHost, plaintextPort, port, tlsPort, enablePlaintextPort, enableTlsPort, null);
   }
 
   /**
@@ -118,7 +136,8 @@ public class DruidNode
       @JacksonInject @Named("servicePort") @JsonProperty("port") Integer port,
       @JacksonInject @Named("tlsServicePort") @JsonProperty("tlsPort") Integer tlsPort,
       @JsonProperty("enablePlaintextPort") Boolean enablePlaintextPort,
-      @JsonProperty("enableTlsPort") boolean enableTlsPort
+      @JsonProperty("enableTlsPort") boolean enableTlsPort,
+      @JsonProperty("advertisedPlaintextPort") Integer advertisedPlaintextPort
   )
   {
     init(
@@ -128,7 +147,8 @@ public class DruidNode
         plaintextPort != null ? plaintextPort : port,
         tlsPort,
         enablePlaintextPort == null ? true : enablePlaintextPort.booleanValue(),
-        enableTlsPort
+        enableTlsPort,
+        advertisedPlaintextPort
     );
   }
 
@@ -139,7 +159,8 @@ public class DruidNode
       Integer plainTextPort,
       Integer tlsPort,
       boolean enablePlaintextPort,
-      boolean enableTlsPort
+      boolean enableTlsPort,
+      Integer advertisedPlaintextPort
   )
   {
     Preconditions.checkNotNull(serviceName);
@@ -187,8 +208,12 @@ public class DruidNode
         }
       }
       this.plaintextPort = plainTextPort;
+      this.advertisedPlaintextPort = advertisedPlaintextPort != null && advertisedPlaintextPort > 0
+                                     ? advertisedPlaintextPort
+                                     : this.plaintextPort;
     } else {
       this.plaintextPort = -1;
+      this.advertisedPlaintextPort = -1;
     }
     if (enableTlsPort) {
       this.tlsPort = tlsPort;
@@ -236,9 +261,14 @@ public class DruidNode
     return tlsPort;
   }
 
+  public int getAdvertisedPlaintextPort()
+  {
+    return advertisedPlaintextPort;
+  }
+
   public DruidNode withService(String service)
   {
-    return new DruidNode(service, host, bindOnHost, plaintextPort, tlsPort, enablePlaintextPort, enableTlsPort);
+    return new DruidNode(service, host, bindOnHost, plaintextPort, null, tlsPort, enablePlaintextPort, enableTlsPort, advertisedPlaintextPort);
   }
 
   public String getServiceScheme()
@@ -252,10 +282,10 @@ public class DruidNode
   public String getHostAndPort()
   {
     if (enablePlaintextPort) {
-      if (plaintextPort < 0) {
+      if (advertisedPlaintextPort < 0) {
         return HostAndPort.fromString(host).toString();
       } else {
-        return HostAndPort.fromParts(host, plaintextPort).toString();
+        return HostAndPort.fromParts(host, advertisedPlaintextPort).toString();
       }
     }
     return null;
@@ -319,6 +349,7 @@ public class DruidNode
            enablePlaintextPort == druidNode.enablePlaintextPort &&
            tlsPort == druidNode.tlsPort &&
            enableTlsPort == druidNode.enableTlsPort &&
+           advertisedPlaintextPort == druidNode.advertisedPlaintextPort &&
            Objects.equals(serviceName, druidNode.serviceName) &&
            Objects.equals(host, druidNode.host);
   }
@@ -326,7 +357,7 @@ public class DruidNode
   @Override
   public int hashCode()
   {
-    return Objects.hash(serviceName, host, port, plaintextPort, enablePlaintextPort, tlsPort, enableTlsPort);
+    return Objects.hash(serviceName, host, port, plaintextPort, enablePlaintextPort, tlsPort, enableTlsPort, advertisedPlaintextPort);
   }
 
   @Override
@@ -338,6 +369,7 @@ public class DruidNode
            ", bindOnHost=" + bindOnHost +
            ", port=" + port +
            ", plaintextPort=" + plaintextPort +
+           ", advertisedPlaintextPort=" + advertisedPlaintextPort +
            ", enablePlaintextPort=" + enablePlaintextPort +
            ", tlsPort=" + tlsPort +
            ", enableTlsPort=" + enableTlsPort +

--- a/server/src/test/java/org/apache/druid/server/DruidNodeTest.java
+++ b/server/src/test/java/org/apache/druid/server/DruidNodeTest.java
@@ -181,6 +181,118 @@ public class DruidNodeTest
     Assert.assertEquals(-1, node.getTlsPort());
   }
 
+  @Test
+  public void testAdvertisedPlaintextPort()
+  {
+    // When not set, advertisedPlaintextPort defaults to plaintextPort
+    DruidNode node = new DruidNode("test", "host", false, 8082, null, true, false);
+    Assert.assertEquals(8082, node.getPlaintextPort());
+    Assert.assertEquals(8082, node.getAdvertisedPlaintextPort());
+    Assert.assertEquals("host:8082", node.getHostAndPort());
+    Assert.assertEquals("host:8082", node.getHostAndPortToUse());
+
+    // When set, advertisedPlaintextPort overrides in getHostAndPort() but not getPlaintextPort()
+    node = new DruidNode("test", "host", false, 8082, null, 9443, true, false, 9443);
+    Assert.assertEquals(8082, node.getPlaintextPort());
+    Assert.assertEquals(9443, node.getAdvertisedPlaintextPort());
+    Assert.assertEquals("host:9443", node.getHostAndPort());
+    Assert.assertEquals("host:9443", node.getHostAndPortToUse());
+    // getPortToUse() still returns the bind port
+    Assert.assertEquals(8082, node.getPortToUse());
+  }
+
+  @Test
+  public void testAdvertisedPlaintextPortWithTls()
+  {
+    // advertisedPlaintextPort with TLS enabled — getHostAndPortToUse() prefers TLS
+    DruidNode node = new DruidNode("test", "host", false, 8082, null, 8443, true, true, 9443);
+    Assert.assertEquals(8082, node.getPlaintextPort());
+    Assert.assertEquals(9443, node.getAdvertisedPlaintextPort());
+    Assert.assertEquals(8443, node.getTlsPort());
+    Assert.assertEquals("host:9443", node.getHostAndPort());
+    Assert.assertEquals("host:8443", node.getHostAndTlsPort());
+    Assert.assertEquals("host:8443", node.getHostAndPortToUse());
+  }
+
+  @Test
+  public void testAdvertisedPlaintextPortDisabledPlaintext()
+  {
+    // When plaintext is disabled, advertisedPlaintextPort is -1 regardless
+    DruidNode node = new DruidNode("test", "host", false, null, null, 8443, false, true, 9443);
+    Assert.assertEquals(-1, node.getPlaintextPort());
+    Assert.assertEquals(-1, node.getAdvertisedPlaintextPort());
+    Assert.assertNull(node.getHostAndPort());
+  }
+
+  @Test
+  public void testAdvertisedPlaintextPortSerde() throws Exception
+  {
+    // Serialization roundtrip preserves advertisedPlaintextPort
+    DruidNode original = new DruidNode("service", "host", true, 8082, null, 5678, true, true, 9443);
+    DruidNode actual = mapper.readValue(mapper.writeValueAsString(original), DruidNode.class);
+    Assert.assertEquals(8082, actual.getPlaintextPort());
+    Assert.assertEquals(9443, actual.getAdvertisedPlaintextPort());
+    Assert.assertEquals(5678, actual.getTlsPort());
+    Assert.assertEquals("host:9443", actual.getHostAndPort());
+  }
+
+  @Test
+  public void testAdvertisedPlaintextPortBackwardCompatDeserialization() throws Exception
+  {
+    // Old JSON without advertisedPlaintextPort — should default to plaintextPort
+    String json = "{\n"
+                  + "  \"service\":\"service\",\n"
+                  + "  \"host\":\"host\",\n"
+                  + "  \"plaintextPort\":8082,\n"
+                  + "  \"enablePlaintextPort\":true,\n"
+                  + "  \"enableTlsPort\":false\n"
+                  + "}\n";
+    DruidNode actual = mapper.readValue(json, DruidNode.class);
+    Assert.assertEquals(8082, actual.getPlaintextPort());
+    Assert.assertEquals(8082, actual.getAdvertisedPlaintextPort());
+    Assert.assertEquals("host:8082", actual.getHostAndPort());
+  }
+
+  @Test
+  public void testAdvertisedPlaintextPortDeserialization() throws Exception
+  {
+    // JSON with advertisedPlaintextPort set
+    String json = "{\n"
+                  + "  \"service\":\"service\",\n"
+                  + "  \"host\":\"host\",\n"
+                  + "  \"plaintextPort\":8082,\n"
+                  + "  \"advertisedPlaintextPort\":9443,\n"
+                  + "  \"enablePlaintextPort\":true,\n"
+                  + "  \"enableTlsPort\":false\n"
+                  + "}\n";
+    DruidNode actual = mapper.readValue(json, DruidNode.class);
+    Assert.assertEquals(8082, actual.getPlaintextPort());
+    Assert.assertEquals(9443, actual.getAdvertisedPlaintextPort());
+    Assert.assertEquals("host:9443", actual.getHostAndPort());
+    Assert.assertEquals("host:9443", actual.getHostAndPortToUse());
+  }
+
+  @Test
+  public void testAdvertisedPlaintextPortWithService()
+  {
+    DruidNode node = new DruidNode("test", "host", false, 8082, null, 9443, true, false, 9443);
+    DruidNode copy = node.withService("other");
+    Assert.assertEquals("other", copy.getServiceName());
+    Assert.assertEquals(8082, copy.getPlaintextPort());
+    Assert.assertEquals(9443, copy.getAdvertisedPlaintextPort());
+  }
+
+  @Test
+  public void testAdvertisedPlaintextPortEquality()
+  {
+    DruidNode a = new DruidNode("test", "host", false, 8082, null, 9443, true, false, 9443);
+    DruidNode b = new DruidNode("test", "host", false, 8082, null, 9443, true, false, 9443);
+    DruidNode c = new DruidNode("test", "host", false, 8082, null, true, false);
+    Assert.assertEquals(a, b);
+    Assert.assertNotEquals(a, c);
+    Assert.assertEquals(a.hashCode(), b.hashCode());
+  }
+
   @Test(expected = IllegalArgumentException.class)
   public void testConflictingPorts()
   {


### PR DESCRIPTION
## Summary

Backport of two commits from `34.0.0-confluent` to `druid-30.0.1-confluent`:

- **OBSDATA-5553** Add `advertisedPlaintextPort` to `DruidNode` (#454)
- **OBSDATA-14262** Retry S3 uploads when retryable errors are wrapped (#457)

## Conflict resolution

`S3UtilsTest.java` had a minor conflict — the druid-30 base lacked the new test methods added in OBSDATA-14262. Resolved by accepting all new tests from the incoming commit.

## Test plan

- [ ] Existing S3Utils tests pass (`mvn test -pl extensions-core/s3-extensions`)
- [ ] New retry tests (`testRetryWith5XXErrorsWrappedInSdkClientException`, `testRetryWithInternalErrorInOkResponse`, `testNoRetryWith4XXErrorsWrappedInSdkClientException`, `testNoRetryWithInterruptedExceptionWrappedInSdkClientException`, `testRetryWithSdkClientException`) pass
- [ ] DruidNode tests pass (`mvn test -pl server -Dtest=DruidNodeTest`)

🤖 Generated with [Claude Code](https://claude.com/claude-code)