### PR TITLE
Backport OBSDATA-5553 and OBSDATA-14262 to 37.0.0-confluent

### DIFF
--- a/extensions-core/s3-extensions/src/main/java/org/apache/druid/storage/s3/S3Utils.java
+++ b/extensions-core/s3-extensions/src/main/java/org/apache/druid/storage/s3/S3Utils.java
@@ -115,7 +115,12 @@ public class S3Utils
         Thread.interrupted(); // Clear interrupted state and not retry
         return false;
       } else if (e instanceof SdkException) {
-        return AWSClientUtil.isClientExceptionRecoverable((SdkException) e);
+        if (AWSClientUtil.isClientExceptionRecoverable((SdkException) e)) {
+          return true;
+        }
+        // The recoverable error may be hidden behind a generic wrapper (e.g. SdkClientException wrapping
+        // a retryable S3Exception). Walk the cause chain before concluding non-retryable.
+        return apply(e.getCause());
       } else {
         return apply(e.getCause());
       }

--- a/extensions-core/s3-extensions/src/test/java/org/apache/druid/storage/s3/S3UtilsTest.java
+++ b/extensions-core/s3-extensions/src/test/java/org/apache/druid/storage/s3/S3UtilsTest.java
@@ -126,6 +126,77 @@ public class S3UtilsTest
   }
 
   @Test
+  public void testRetryWith5XXErrorsWrappedInSdkClientException() throws Exception
+  {
+    // Mimics a multipart upload part failure: a generic SdkClientException wraps the retryable
+    // S3Exception (503), leaving the retryable cause only on the cause chain.
+    final int maxRetries = 3;
+    final AtomicInteger count = new AtomicInteger();
+    S3Utils.retryS3Operation(
+        () -> {
+          if (count.incrementAndGet() >= maxRetries) {
+            return "hey";
+          } else {
+            S3Exception s3Exception = (S3Exception) S3Exception.builder()
+                .message("Service Unavailable")
+                .statusCode(503)
+                .build();
+            throw SdkClientException.builder()
+                .message("Unable to complete multi-part upload. Individual part upload failed: Service Unavailable")
+                .cause(s3Exception)
+                .build();
+          }
+        },
+        maxRetries
+    );
+    Assert.assertEquals(maxRetries, count.get());
+  }
+
+  @Test
+  public void testNoRetryWith4XXErrorsWrappedInSdkClientException()
+  {
+    final AtomicInteger count = new AtomicInteger();
+    Assert.assertThrows(
+        Exception.class,
+        () -> S3Utils.retryS3Operation(
+            () -> {
+              count.incrementAndGet();
+              S3Exception s3Exception = (S3Exception) S3Exception.builder()
+                  .message("Access Denied")
+                  .statusCode(403)
+                  .build();
+              throw SdkClientException.builder()
+                  .message("Unable to complete multi-part upload. Individual part upload failed: Access Denied")
+                  .cause(s3Exception)
+                  .build();
+            },
+            3
+        )
+    );
+    Assert.assertEquals(1, count.get());
+  }
+
+  @Test
+  public void testNoRetryWithInterruptedExceptionWrappedInSdkClientException()
+  {
+    final AtomicInteger count = new AtomicInteger();
+    Assert.assertThrows(
+        Exception.class,
+        () -> S3Utils.retryS3Operation(
+            () -> {
+              count.incrementAndGet();
+              throw SdkClientException.builder()
+                  .message("Upload aborted")
+                  .cause(new InterruptedException())
+                  .build();
+            },
+            3
+        )
+    );
+    Assert.assertEquals(1, count.get());
+  }
+
+  @Test
   public void testRetryWithSdkClientException() throws Exception
   {
     final int maxRetries = 3;

--- a/server/src/main/java/org/apache/druid/rpc/ServiceLocation.java
+++ b/server/src/main/java/org/apache/druid/rpc/ServiceLocation.java
@@ -73,7 +73,7 @@ public class ServiceLocation
    */
   public static ServiceLocation fromDruidNode(final DruidNode druidNode)
   {
-    return new ServiceLocation(druidNode.getHost(), druidNode.getPlaintextPort(), druidNode.getTlsPort(), "");
+    return new ServiceLocation(druidNode.getHost(), druidNode.getAdvertisedPlaintextPort(), druidNode.getTlsPort(), "");
   }
 
   /**

--- a/server/src/main/java/org/apache/druid/server/DruidNode.java
+++ b/server/src/main/java/org/apache/druid/server/DruidNode.java
@@ -130,6 +130,36 @@ public class DruidNode
     this(serviceName, host, bindOnHost, plaintextPort, port, tlsPort, enablePlaintextPort, enableTlsPort, null, null);
   }
 
+  public DruidNode(
+      String serviceName,
+      String host,
+      boolean bindOnHost,
+      Integer plaintextPort,
+      Integer port,
+      Integer tlsPort,
+      Boolean enablePlaintextPort,
+      boolean enableTlsPort,
+      Map<String, String> labels
+  )
+  {
+    this(serviceName, host, bindOnHost, plaintextPort, port, tlsPort, enablePlaintextPort, enableTlsPort, labels, null);
+  }
+
+  public DruidNode(
+      String serviceName,
+      String host,
+      boolean bindOnHost,
+      Integer plaintextPort,
+      Integer port,
+      Integer tlsPort,
+      Boolean enablePlaintextPort,
+      boolean enableTlsPort,
+      Integer advertisedPlaintextPort
+  )
+  {
+    this(serviceName, host, bindOnHost, plaintextPort, port, tlsPort, enablePlaintextPort, enableTlsPort, null, advertisedPlaintextPort);
+  }
+
   /**
    * host = null     , port = null -> host = _default_, port = -1
    * host = "abc:123", port = null -> host = abc, port = 123

--- a/server/src/main/java/org/apache/druid/server/DruidNode.java
+++ b/server/src/main/java/org/apache/druid/server/DruidNode.java
@@ -99,6 +99,10 @@ public class DruidNode
   @JsonProperty
   private Map<String, String> labels;
 
+  @JsonProperty
+  @Max(0xffff)
+  private int advertisedPlaintextPort = -1;
+
   public DruidNode(
       String serviceName,
       String host,
@@ -109,7 +113,21 @@ public class DruidNode
       boolean enableTlsPort
   )
   {
-    this(serviceName, host, bindOnHost, plaintextPort, null, tlsPort, enablePlaintextPort, enableTlsPort, null);
+    this(serviceName, host, bindOnHost, plaintextPort, null, tlsPort, enablePlaintextPort, enableTlsPort, null, null);
+  }
+
+  public DruidNode(
+      String serviceName,
+      String host,
+      boolean bindOnHost,
+      Integer plaintextPort,
+      Integer port,
+      Integer tlsPort,
+      Boolean enablePlaintextPort,
+      boolean enableTlsPort
+  )
+  {
+    this(serviceName, host, bindOnHost, plaintextPort, port, tlsPort, enablePlaintextPort, enableTlsPort, null, null);
   }
 
   /**
@@ -138,7 +156,8 @@ public class DruidNode
       @JacksonInject @Named("tlsServicePort") @JsonProperty("tlsPort") Integer tlsPort,
       @JsonProperty("enablePlaintextPort") Boolean enablePlaintextPort,
       @JsonProperty("enableTlsPort") boolean enableTlsPort,
-      @JsonProperty("labels") @Nullable Map<String, String> labels
+      @JsonProperty("labels") @Nullable Map<String, String> labels,
+      @JsonProperty("advertisedPlaintextPort") Integer advertisedPlaintextPort
   )
   {
     init(
@@ -149,7 +168,8 @@ public class DruidNode
         tlsPort,
         enablePlaintextPort == null || enablePlaintextPort.booleanValue(),
         enableTlsPort,
-        labels
+        labels,
+        advertisedPlaintextPort
     );
   }
 
@@ -161,7 +181,8 @@ public class DruidNode
       Integer tlsPort,
       boolean enablePlaintextPort,
       boolean enableTlsPort,
-      Map<String, String> labels
+      Map<String, String> labels,
+      Integer advertisedPlaintextPort
   )
   {
     Preconditions.checkNotNull(serviceName);
@@ -209,8 +230,12 @@ public class DruidNode
         }
       }
       this.plaintextPort = plainTextPort;
+      this.advertisedPlaintextPort = advertisedPlaintextPort != null && advertisedPlaintextPort > 0
+                                     ? advertisedPlaintextPort
+                                     : this.plaintextPort;
     } else {
       this.plaintextPort = -1;
+      this.advertisedPlaintextPort = -1;
     }
     if (enableTlsPort) {
       this.tlsPort = tlsPort;
@@ -275,9 +300,14 @@ public class DruidNode
     return buildRevision;
   }
 
+  public int getAdvertisedPlaintextPort()
+  {
+    return advertisedPlaintextPort;
+  }
+
   public DruidNode withService(String service)
   {
-    return new DruidNode(service, host, bindOnHost, plaintextPort, tlsPort, enablePlaintextPort, enableTlsPort);
+    return new DruidNode(service, host, bindOnHost, plaintextPort, null, tlsPort, enablePlaintextPort, enableTlsPort, labels, advertisedPlaintextPort);
   }
 
   public String getServiceScheme()
@@ -291,10 +321,10 @@ public class DruidNode
   public String getHostAndPort()
   {
     if (enablePlaintextPort) {
-      if (plaintextPort < 0) {
+      if (advertisedPlaintextPort < 0) {
         return HostAndPort.fromString(host).toString();
       } else {
-        return HostAndPort.fromParts(host, plaintextPort).toString();
+        return HostAndPort.fromParts(host, advertisedPlaintextPort).toString();
       }
     }
     return null;
@@ -358,6 +388,7 @@ public class DruidNode
            enablePlaintextPort == druidNode.enablePlaintextPort &&
            tlsPort == druidNode.tlsPort &&
            enableTlsPort == druidNode.enableTlsPort &&
+           advertisedPlaintextPort == druidNode.advertisedPlaintextPort &&
            Objects.equals(serviceName, druidNode.serviceName) &&
            Objects.equals(host, druidNode.host) &&
            Objects.equals(labels, druidNode.labels);
@@ -366,7 +397,7 @@ public class DruidNode
   @Override
   public int hashCode()
   {
-    return Objects.hash(serviceName, host, port, plaintextPort, enablePlaintextPort, tlsPort, enableTlsPort, labels);
+    return Objects.hash(serviceName, host, port, plaintextPort, enablePlaintextPort, tlsPort, enableTlsPort, labels, advertisedPlaintextPort);
   }
 
   @Override
@@ -378,6 +409,7 @@ public class DruidNode
            ", bindOnHost=" + bindOnHost +
            ", port=" + port +
            ", plaintextPort=" + plaintextPort +
+           ", advertisedPlaintextPort=" + advertisedPlaintextPort +
            ", enablePlaintextPort=" + enablePlaintextPort +
            ", tlsPort=" + tlsPort +
            ", enableTlsPort=" + enableTlsPort +

--- a/server/src/test/java/org/apache/druid/discovery/DiscoveryDruidNodeTest.java
+++ b/server/src/test/java/org/apache/druid/discovery/DiscoveryDruidNodeTest.java
@@ -33,6 +33,7 @@ import org.junit.Assert;
 import org.junit.Test;
 
 import java.util.Collection;
+import java.util.Map;
 
 public class DiscoveryDruidNodeTest
 {
@@ -113,7 +114,7 @@ public class DiscoveryDruidNodeTest
             8282,
             true,
             true,
-            null
+            (Map<String, String>) null
         ),
         NodeRole.BROKER,
         ImmutableMap.of(

--- a/server/src/test/java/org/apache/druid/server/DruidNodeTest.java
+++ b/server/src/test/java/org/apache/druid/server/DruidNodeTest.java
@@ -188,6 +188,118 @@ public class DruidNodeTest
     Assert.assertEquals(-1, node.getTlsPort());
   }
 
+  @Test
+  public void testAdvertisedPlaintextPort()
+  {
+    // When not set, advertisedPlaintextPort defaults to plaintextPort
+    DruidNode node = new DruidNode("test", "host", false, 8082, null, true, false);
+    Assert.assertEquals(8082, node.getPlaintextPort());
+    Assert.assertEquals(8082, node.getAdvertisedPlaintextPort());
+    Assert.assertEquals("host:8082", node.getHostAndPort());
+    Assert.assertEquals("host:8082", node.getHostAndPortToUse());
+
+    // When set, advertisedPlaintextPort overrides in getHostAndPort() but not getPlaintextPort()
+    node = new DruidNode("test", "host", false, 8082, null, 9443, true, false, 9443);
+    Assert.assertEquals(8082, node.getPlaintextPort());
+    Assert.assertEquals(9443, node.getAdvertisedPlaintextPort());
+    Assert.assertEquals("host:9443", node.getHostAndPort());
+    Assert.assertEquals("host:9443", node.getHostAndPortToUse());
+    // getPortToUse() still returns the bind port
+    Assert.assertEquals(8082, node.getPortToUse());
+  }
+
+  @Test
+  public void testAdvertisedPlaintextPortWithTls()
+  {
+    // advertisedPlaintextPort with TLS enabled — getHostAndPortToUse() prefers TLS
+    DruidNode node = new DruidNode("test", "host", false, 8082, null, 8443, true, true, 9443);
+    Assert.assertEquals(8082, node.getPlaintextPort());
+    Assert.assertEquals(9443, node.getAdvertisedPlaintextPort());
+    Assert.assertEquals(8443, node.getTlsPort());
+    Assert.assertEquals("host:9443", node.getHostAndPort());
+    Assert.assertEquals("host:8443", node.getHostAndTlsPort());
+    Assert.assertEquals("host:8443", node.getHostAndPortToUse());
+  }
+
+  @Test
+  public void testAdvertisedPlaintextPortDisabledPlaintext()
+  {
+    // When plaintext is disabled, advertisedPlaintextPort is -1 regardless
+    DruidNode node = new DruidNode("test", "host", false, null, null, 8443, false, true, 9443);
+    Assert.assertEquals(-1, node.getPlaintextPort());
+    Assert.assertEquals(-1, node.getAdvertisedPlaintextPort());
+    Assert.assertNull(node.getHostAndPort());
+  }
+
+  @Test
+  public void testAdvertisedPlaintextPortSerde() throws Exception
+  {
+    // Serialization roundtrip preserves advertisedPlaintextPort
+    DruidNode original = new DruidNode("service", "host", true, 8082, null, 5678, true, true, 9443);
+    DruidNode actual = mapper.readValue(mapper.writeValueAsString(original), DruidNode.class);
+    Assert.assertEquals(8082, actual.getPlaintextPort());
+    Assert.assertEquals(9443, actual.getAdvertisedPlaintextPort());
+    Assert.assertEquals(5678, actual.getTlsPort());
+    Assert.assertEquals("host:9443", actual.getHostAndPort());
+  }
+
+  @Test
+  public void testAdvertisedPlaintextPortBackwardCompatDeserialization() throws Exception
+  {
+    // Old JSON without advertisedPlaintextPort — should default to plaintextPort
+    String json = "{\n"
+                  + "  \"service\":\"service\",\n"
+                  + "  \"host\":\"host\",\n"
+                  + "  \"plaintextPort\":8082,\n"
+                  + "  \"enablePlaintextPort\":true,\n"
+                  + "  \"enableTlsPort\":false\n"
+                  + "}\n";
+    DruidNode actual = mapper.readValue(json, DruidNode.class);
+    Assert.assertEquals(8082, actual.getPlaintextPort());
+    Assert.assertEquals(8082, actual.getAdvertisedPlaintextPort());
+    Assert.assertEquals("host:8082", actual.getHostAndPort());
+  }
+
+  @Test
+  public void testAdvertisedPlaintextPortDeserialization() throws Exception
+  {
+    // JSON with advertisedPlaintextPort set
+    String json = "{\n"
+                  + "  \"service\":\"service\",\n"
+                  + "  \"host\":\"host\",\n"
+                  + "  \"plaintextPort\":8082,\n"
+                  + "  \"advertisedPlaintextPort\":9443,\n"
+                  + "  \"enablePlaintextPort\":true,\n"
+                  + "  \"enableTlsPort\":false\n"
+                  + "}\n";
+    DruidNode actual = mapper.readValue(json, DruidNode.class);
+    Assert.assertEquals(8082, actual.getPlaintextPort());
+    Assert.assertEquals(9443, actual.getAdvertisedPlaintextPort());
+    Assert.assertEquals("host:9443", actual.getHostAndPort());
+    Assert.assertEquals("host:9443", actual.getHostAndPortToUse());
+  }
+
+  @Test
+  public void testAdvertisedPlaintextPortWithService()
+  {
+    DruidNode node = new DruidNode("test", "host", false, 8082, null, 9443, true, false, 9443);
+    DruidNode copy = node.withService("other");
+    Assert.assertEquals("other", copy.getServiceName());
+    Assert.assertEquals(8082, copy.getPlaintextPort());
+    Assert.assertEquals(9443, copy.getAdvertisedPlaintextPort());
+  }
+
+  @Test
+  public void testAdvertisedPlaintextPortEquality()
+  {
+    DruidNode a = new DruidNode("test", "host", false, 8082, null, 9443, true, false, 9443);
+    DruidNode b = new DruidNode("test", "host", false, 8082, null, 9443, true, false, 9443);
+    DruidNode c = new DruidNode("test", "host", false, 8082, null, true, false);
+    Assert.assertEquals(a, b);
+    Assert.assertNotEquals(a, c);
+    Assert.assertEquals(a.hashCode(), b.hashCode());
+  }
+
   @Test(expected = IllegalArgumentException.class)
   public void testConflictingPorts()
   {

--- a/server/src/test/java/org/apache/druid/server/DruidNodeTest.java
+++ b/server/src/test/java/org/apache/druid/server/DruidNodeTest.java
@@ -426,7 +426,7 @@ public class DruidNodeTest
   public void testSerde2() throws Exception
   {
     DruidNode actual = mapper.readValue(
-        mapper.writeValueAsString(new DruidNode("service", "host", false, 1234, null, 5678, null, false, null)),
+        mapper.writeValueAsString(new DruidNode("service", "host", false, 1234, null, 5678, null, false, (Map<String, String>) null)),
         DruidNode.class
     );
     Assert.assertEquals("service", actual.getServiceName());
@@ -493,7 +493,7 @@ public class DruidNodeTest
 
 
     DruidNode actual = mapper.readValue(json, DruidNode.class);
-    Assert.assertEquals(new DruidNode("service", "host", false, 1234, null, 5678, true, false, null), actual);
+    Assert.assertEquals(new DruidNode("service", "host", false, 1234, null, 5678, true, false, (Map<String, String>) null), actual);
 
     Assert.assertEquals("http", actual.getServiceScheme());
     Assert.assertEquals("host:1234", actual.getHostAndPort());
@@ -513,7 +513,7 @@ public class DruidNodeTest
 
 
     DruidNode actual = mapper.readValue(json, DruidNode.class);
-    Assert.assertEquals(new DruidNode("service", "host", false, 1234, null, 5678, null, false, null), actual);
+    Assert.assertEquals(new DruidNode("service", "host", false, 1234, null, 5678, null, false, (Map<String, String>) null), actual);
 
     Assert.assertEquals("http", actual.getServiceScheme());
     Assert.assertEquals("host:1234", actual.getHostAndPort());
@@ -533,7 +533,7 @@ public class DruidNodeTest
 
 
     DruidNode actual = mapper.readValue(json, DruidNode.class);
-    Assert.assertEquals(new DruidNode("service", "host", false, null, 1234, 5678, null, false, null), actual);
+    Assert.assertEquals(new DruidNode("service", "host", false, null, 1234, 5678, null, false, (Map<String, String>) null), actual);
 
     Assert.assertEquals("http", actual.getServiceScheme());
     Assert.assertEquals("host:1234", actual.getHostAndPort());


### PR DESCRIPTION
## Summary

Backport of two commits from `34.0.0-confluent` to `37.0.0-confluent`:

- **OBSDATA-5553** Add `advertisedPlaintextPort` to `DruidNode` (#454)
- **OBSDATA-14262** Retry S3 uploads when retryable errors are wrapped (#457)

## Conflict resolution

**OBSDATA-5553 (`DruidNode.java`):** 37.0.0-confluent already has `labels`, `version`, and `buildRevision` fields. Merged both sets of changes — `advertisedPlaintextPort` added alongside existing fields. `CompressionUtilsTest.java` conflict resolved by keeping the 37.0.0-confluent version.

**OBSDATA-14262 (S3 retry):** 37.0.0-confluent uses AWS SDK V2. The fix was adapted accordingly:
- `AWSClientUtil.java`: Kept HEAD — SDK V2 already checks error codes for any `AwsServiceException`
- `S3Utils.java`: Added cause chain walking when `isClientExceptionRecoverable` returns false for `SdkException` (same logic as the SDK V1 fix, adapted for V2 types)
- `AWSClientUtilTest.java`: Kept HEAD; incoming tests used SDK V1 classes
- `S3UtilsTest.java`: Replaced incoming SDK V1 tests with SDK V2 equivalents

## Test plan

- [ ] `mvn test -pl server -Dtest=DruidNodeTest`
- [ ] `mvn test -pl extensions-core/s3-extensions -Dtest=S3UtilsTest`
- [ ] `mvn test -pl cloud/aws-common -Dtest=AWSClientUtilTest`

🤖 Generated with [Claude Code](https://claude.com/claude-code)