### PR TITLE
OBSDATA-5553 Propagate advertisedPlaintextPort in ServiceAnnouncingChatHandlerProvider

### DIFF
--- a/server/src/main/java/org/apache/druid/segment/realtime/ServiceAnnouncingChatHandlerProvider.java
+++ b/server/src/main/java/org/apache/druid/segment/realtime/ServiceAnnouncingChatHandlerProvider.java
@@ -124,9 +124,11 @@ public class ServiceAnnouncingChatHandlerProvider implements ChatHandlerProvider
         node.getHost(),
         node.isBindOnHost(),
         node.getPlaintextPort(),
+        null,
         node.getTlsPort(),
         node.isEnablePlaintextPort(),
-        node.isEnableTlsPort()
+        node.isEnableTlsPort(),
+        node.getAdvertisedPlaintextPort()
     );
   }
 }

--- a/server/src/test/java/org/apache/druid/segment/realtime/ServiceAnnouncingChatHandlerProviderTest.java
+++ b/server/src/test/java/org/apache/druid/segment/realtime/ServiceAnnouncingChatHandlerProviderTest.java
@@ -41,6 +41,7 @@ public class ServiceAnnouncingChatHandlerProviderTest extends EasyMockSupport
   private static final String TEST_SERVICE_NAME = "test-service-name";
   private static final String TEST_HOST = "test-host";
   private static final int TEST_PORT = 1234;
+  private static final int TEST_ADVERTISED_PORT = 5678;
 
   private ServiceAnnouncingChatHandlerProvider chatHandlerProvider;
 
@@ -91,6 +92,7 @@ public class ServiceAnnouncingChatHandlerProviderTest extends EasyMockSupport
     EasyMock.expect(node.getHost()).andReturn(TEST_HOST);
     EasyMock.expect(node.isBindOnHost()).andReturn(false);
     EasyMock.expect(node.getPlaintextPort()).andReturn(TEST_PORT);
+    EasyMock.expect(node.getAdvertisedPlaintextPort()).andReturn(TEST_ADVERTISED_PORT);
     EasyMock.expect(node.isEnablePlaintextPort()).andReturn(true);
     EasyMock.expect(node.isEnableTlsPort()).andReturn(false);
     EasyMock.expect(node.getTlsPort()).andReturn(-1);
@@ -110,6 +112,8 @@ public class ServiceAnnouncingChatHandlerProviderTest extends EasyMockSupport
     Assert.assertEquals(TEST_SERVICE_NAME, param.getServiceName());
     Assert.assertEquals(TEST_HOST, param.getHost());
     Assert.assertEquals(TEST_PORT, param.getPlaintextPort());
+    Assert.assertEquals(TEST_ADVERTISED_PORT, param.getAdvertisedPlaintextPort());
+    Assert.assertEquals(TEST_HOST + ":" + TEST_ADVERTISED_PORT, param.getHostAndPort());
     Assert.assertEquals(-1, param.getTlsPort());
     Assert.assertEquals(null, param.getHostAndTlsPort());
     Assert.assertTrue("chatHandler did not register", chatHandlerProvider.get(TEST_SERVICE_NAME).isPresent());
@@ -120,6 +124,7 @@ public class ServiceAnnouncingChatHandlerProviderTest extends EasyMockSupport
     EasyMock.expect(node.getHost()).andReturn(TEST_HOST);
     EasyMock.expect(node.isBindOnHost()).andReturn(false);
     EasyMock.expect(node.getPlaintextPort()).andReturn(TEST_PORT);
+    EasyMock.expect(node.getAdvertisedPlaintextPort()).andReturn(TEST_ADVERTISED_PORT);
     EasyMock.expect(node.isEnablePlaintextPort()).andReturn(true);
     EasyMock.expect(node.getTlsPort()).andReturn(-1);
     EasyMock.expect(node.isEnableTlsPort()).andReturn(false);
@@ -133,6 +138,8 @@ public class ServiceAnnouncingChatHandlerProviderTest extends EasyMockSupport
     Assert.assertEquals(TEST_SERVICE_NAME, param.getServiceName());
     Assert.assertEquals(TEST_HOST, param.getHost());
     Assert.assertEquals(TEST_PORT, param.getPlaintextPort());
+    Assert.assertEquals(TEST_ADVERTISED_PORT, param.getAdvertisedPlaintextPort());
+    Assert.assertEquals(TEST_HOST + ":" + TEST_ADVERTISED_PORT, param.getHostAndPort());
     Assert.assertEquals(-1, param.getTlsPort());
     Assert.assertEquals(null, param.getHostAndTlsPort());
     Assert.assertFalse("chatHandler did not deregister", chatHandlerProvider.get(TEST_SERVICE_NAME).isPresent());


### PR DESCRIPTION
## What
`ServiceAnnouncingChatHandlerProvider.makeDruidNode()` rebuilt the announced node via a `DruidNode` constructor overload that dropped `advertisedPlaintextPort` (silently defaulting it back to the bind `plaintextPort`).

Same fix as #463 (30.0.1-confluent). For S2S, all traffic must eventually route through the advertised listener port, so chat-handler-announced nodes (peon/task chat handlers) must carry it like every other node.

## Change
Switch to the 9-arg constructor and propagate `node.getAdvertisedPlaintextPort()`, mirroring `DruidNode.withService()`.

## Test
Extended `ServiceAnnouncingChatHandlerProviderTest` to mock a distinct advertised port and assert it propagates (`getAdvertisedPlaintextPort()` / `getHostAndPort()`). 3/3 pass under Java 17.

🤖 Generated with [Claude Code](https://claude.com/claude-code)