### PR TITLE
[30.0.1-confluent] Backport multi-supervisor single-datasource ingestion (#18082) + follow-ups

### DIFF
--- a/docs/ingestion/supervisor.md
+++ b/docs/ingestion/supervisor.md
@@ -37,11 +37,13 @@ The following table outlines the high-level configuration options for a supervis
 
 |Property|Type|Description|Required|
 |--------|----|-----------|--------|
+|`id`|String|The supervisor id. This should be a unique ID that will identify the supervisor.|Yes|
 |`type`|String|The supervisor type. One of `kafka`or `kinesis`.|Yes|
 |`spec`|Object|The container object for the supervisor configuration.|Yes|
 |`spec.dataSchema`|Object|The schema for the indexing task to use during ingestion. See [`dataSchema`](../ingestion/ingestion-spec.md#dataschema) for more information.|Yes|
 |`spec.ioConfig`|Object|The I/O configuration object to define the connection and I/O-related settings for the supervisor and indexing tasks.|Yes|
 |`spec.tuningConfig`|Object|The tuning configuration object to define performance-related settings for the supervisor and indexing tasks.|No|
+|`context`|Object|Allows for extra configuration of both the supervisor and the tasks it spawns.|No|
 
 ### I/O configuration
 
@@ -407,6 +409,10 @@ workerCapacity = 2 * replicas * taskCount
 This value is for the ideal situation in which there is at most one set of tasks publishing while another set is reading.
 In some circumstances, it is possible to have multiple sets of tasks publishing simultaneously. This would happen if the
 time-to-publish (generate segment, push to deep storage, load on Historical) is greater than `taskDuration`. This is a valid and correct scenario but requires additional worker capacity to support. In general, it is a good idea to have `taskDuration` be large enough that the previous set of tasks finishes publishing before the current set begins.
+
+## Multi-Supervisor Support
+Druid supports multiple stream supervisors ingesting into the same datasource. This means you can have any number of the configured stream supervisors (Kafka, Kinesis, etc.) ingesting into the same datasource at the same time.
+In order to ensure proper synchronization between ingestion tasks with multiple supervisors, it's important to set `useConcurrentLocks=true` in the `context` field of the supervisor spec.
 
 ## Learn more
 

--- a/docs/ingestion/supervisor.md
+++ b/docs/ingestion/supervisor.md
@@ -37,7 +37,7 @@ The following table outlines the high-level configuration options for a supervis
 
 |Property|Type|Description|Required|
 |--------|----|-----------|--------|
-|`id`|String|The supervisor id. This should be a unique ID that will identify the supervisor.|Yes|
+|`id`|String|The supervisor id. This should be a unique ID that will identify the supervisor. If unspecified, defaults to `spec.dataSchema.dataSource`.|No|
 |`type`|String|The supervisor type. One of `kafka`or `kinesis`.|Yes|
 |`spec`|Object|The container object for the supervisor configuration.|Yes|
 |`spec.dataSchema`|Object|The schema for the indexing task to use during ingestion. See [`dataSchema`](../ingestion/ingestion-spec.md#dataschema) for more information.|Yes|
@@ -410,9 +410,9 @@ This value is for the ideal situation in which there is at most one set of tasks
 In some circumstances, it is possible to have multiple sets of tasks publishing simultaneously. This would happen if the
 time-to-publish (generate segment, push to deep storage, load on Historical) is greater than `taskDuration`. This is a valid and correct scenario but requires additional worker capacity to support. In general, it is a good idea to have `taskDuration` be large enough that the previous set of tasks finishes publishing before the current set begins.
 
-## Multi-Supervisor Support
-Druid supports multiple stream supervisors ingesting into the same datasource. This means you can have any number of the configured stream supervisors (Kafka, Kinesis, etc.) ingesting into the same datasource at the same time.
-In order to ensure proper synchronization between ingestion tasks with multiple supervisors, it's important to set `useConcurrentLocks=true` in the `context` field of the supervisor spec.
+## Multi-Supervisor Support (Experimental)
+Druid supports multiple stream supervisors ingesting into the same datasource. This means you can have any number of stream supervisors (Kafka, Kinesis, etc.) ingesting into the same datasource at the same time.
+In order to ensure proper synchronization between ingestion tasks with multiple supervisors, it's important to set `useConcurrentLocks=true` in the `context` field of the supervisor spec. Read more [here](concurrent-append-replace.md).
 
 ## Learn more
 

--- a/docs/operations/metrics.md
+++ b/docs/operations/metrics.md
@@ -219,10 +219,10 @@ These metrics apply to the [Kafka indexing service](../ingestion/kafka-ingestion
 
 |Metric|Description|Dimensions|Normal value|
 |------|-----------|----------|------------|
-|`ingest/kafka/lag`|Total lag between the offsets consumed by the Kafka indexing tasks and latest offsets in Kafka brokers across all partitions. Minimum emission period for this metric is a minute.|`dataSource`, `stream`, `tags`|Greater than 0, should not be a very high number. |
-|`ingest/kafka/maxLag`|Max lag between the offsets consumed by the Kafka indexing tasks and latest offsets in Kafka brokers across all partitions. Minimum emission period for this metric is a minute.|`dataSource`, `stream`, `tags`|Greater than 0, should not be a very high number. |
-|`ingest/kafka/avgLag`|Average lag between the offsets consumed by the Kafka indexing tasks and latest offsets in Kafka brokers across all partitions. Minimum emission period for this metric is a minute.|`dataSource`, `stream`, `tags`|Greater than 0, should not be a very high number. |
-|`ingest/kafka/partitionLag`|Partition-wise lag between the offsets consumed by the Kafka indexing tasks and latest offsets in Kafka brokers. Minimum emission period for this metric is a minute.|`dataSource`, `stream`, `partition`, `tags`|Greater than 0, should not be a very high number. |
+|`ingest/kafka/lag`|Total lag between the offsets consumed by the Kafka indexing tasks and latest offsets in Kafka brokers across all partitions. Minimum emission period for this metric is a minute.|`supervisorId`, `dataSource`, `stream`, `tags`|Greater than 0, should not be a very high number. |
+|`ingest/kafka/maxLag`|Max lag between the offsets consumed by the Kafka indexing tasks and latest offsets in Kafka brokers across all partitions. Minimum emission period for this metric is a minute.|`supervisorId`, `dataSource`, `stream`, `tags`|Greater than 0, should not be a very high number. |
+|`ingest/kafka/avgLag`|Average lag between the offsets consumed by the Kafka indexing tasks and latest offsets in Kafka brokers across all partitions. Minimum emission period for this metric is a minute.|`supervisorId`, `dataSource`, `stream`, `tags`|Greater than 0, should not be a very high number. |
+|`ingest/kafka/partitionLag`|Partition-wise lag between the offsets consumed by the Kafka indexing tasks and latest offsets in Kafka brokers. Minimum emission period for this metric is a minute.|`supervisorId`, `dataSource`, `stream`, `partition`, `tags`|Greater than 0, should not be a very high number. |
 
 ### Ingestion metrics for Kinesis
 
@@ -230,10 +230,10 @@ These metrics apply to the [Kinesis indexing service](../ingestion/kinesis-inges
 
 |Metric|Description|Dimensions|Normal value|
 |------|-----------|----------|------------|
-|`ingest/kinesis/lag/time`|Total lag time in milliseconds between the current message sequence number consumed by the Kinesis indexing tasks and latest sequence number in Kinesis across all shards. Minimum emission period for this metric is a minute.|`dataSource`, `stream`, `tags`|Greater than 0, up to max Kinesis retention period in milliseconds. |
-|`ingest/kinesis/maxLag/time`|Max lag time in milliseconds between the current message sequence number consumed by the Kinesis indexing tasks and latest sequence number in Kinesis across all shards. Minimum emission period for this metric is a minute.|`dataSource`, `stream`, `tags`|Greater than 0, up to max Kinesis retention period in milliseconds. |
-|`ingest/kinesis/avgLag/time`|Average lag time in milliseconds between the current message sequence number consumed by the Kinesis indexing tasks and latest sequence number in Kinesis across all shards. Minimum emission period for this metric is a minute.|`dataSource`, `stream`, `tags`|Greater than 0, up to max Kinesis retention period in milliseconds. |
-|`ingest/kinesis/partitionLag/time`|Partition-wise lag time in milliseconds between the current message sequence number consumed by the Kinesis indexing tasks and latest sequence number in Kinesis. Minimum emission period for this metric is a minute.|`dataSource`, `stream`, `partition`, `tags`|Greater than 0, up to max Kinesis retention period in milliseconds. |
+|`ingest/kinesis/lag/time`|Total lag time in milliseconds between the current message sequence number consumed by the Kinesis indexing tasks and latest sequence number in Kinesis across all shards. Minimum emission period for this metric is a minute.|`supervisorId`, `dataSource`, `stream`, `tags`|Greater than 0, up to max Kinesis retention period in milliseconds. |
+|`ingest/kinesis/maxLag/time`|Max lag time in milliseconds between the current message sequence number consumed by the Kinesis indexing tasks and latest sequence number in Kinesis across all shards. Minimum emission period for this metric is a minute.|`supervisorId`, `dataSource`, `stream`, `tags`|Greater than 0, up to max Kinesis retention period in milliseconds. |
+|`ingest/kinesis/avgLag/time`|Average lag time in milliseconds between the current message sequence number consumed by the Kinesis indexing tasks and latest sequence number in Kinesis across all shards. Minimum emission period for this metric is a minute.|`supervisorId`, `dataSource`, `stream`, `tags`|Greater than 0, up to max Kinesis retention period in milliseconds. |
+|`ingest/kinesis/partitionLag/time`|Partition-wise lag time in milliseconds between the current message sequence number consumed by the Kinesis indexing tasks and latest sequence number in Kinesis. Minimum emission period for this metric is a minute.|`supervisorId`, `dataSource`, `stream`, `partition`, `tags`|Greater than 0, up to max Kinesis retention period in milliseconds. |
 
 ### Compaction metrics
 
@@ -269,11 +269,11 @@ batch ingestion emit the following metrics. These metrics are deltas for each em
 |`ingest/handoff/count`|Number of handoffs that happened.|`dataSource`, `taskId`, `taskType`, `groupId`, `tags`|Varies. Generally greater than 0 once every segment granular period if cluster operating normally.|
 |`ingest/sink/count`|Number of sinks not handed off.|`dataSource`, `taskId`, `taskType`, `groupId`, `tags`|1~3|
 |`ingest/events/messageGap`|Time gap in milliseconds between the latest ingested event timestamp and the current system timestamp of metrics emission. If the value is increasing but lag is low, Druid may not be receiving new data. This metric is reset as new tasks spawn up.|`dataSource`, `taskId`, `taskType`, `groupId`, `tags`|Greater than 0, depends on the time carried in event.|
-|`ingest/notices/queueSize`|Number of pending notices to be processed by the coordinator.|`dataSource`, `tags`|Typically 0 and occasionally in lower single digits. Should not be a very high number. |
-|`ingest/notices/time`|Milliseconds taken to process a notice by the supervisor.|`dataSource`, `tags`| < 1s |
+|`ingest/notices/queueSize`|Number of pending notices to be processed by the coordinator.|`supervisorId`, `dataSource`, `tags`|Typically 0 and occasionally in lower single digits. Should not be a very high number. |
+|`ingest/notices/time`|Milliseconds taken to process a notice by the supervisor.|`supervisorId`, `dataSource`, `tags`| < 1s |
 |`ingest/pause/time`|Milliseconds spent by a task in a paused state without ingesting.|`dataSource`, `taskId`, `tags`| < 10 seconds|
 |`ingest/handoff/time`|Total number of milliseconds taken to handoff a set of segments.|`dataSource`, `taskId`, `taskType`, `groupId`, `tags`|Depends on the coordinator cycle time.|
-|`task/autoScaler/requiredCount`|Count of required tasks based on the calculations of `lagBased` auto scaler.|`dataSource`, `stream`, `scalingSkipReason`|Depends on auto scaler config.|
+|`task/autoScaler/requiredCount`|Count of required tasks based on the calculations of `lagBased` auto scaler.|`supervisorId`, `dataSource`, `stream`, `scalingSkipReason`|Depends on auto scaler config.|
 
 If the JVM does not support CPU time measurement for the current thread, `ingest/merge/cpu` and `ingest/persists/cpu` will be 0.
 

--- a/docs/querying/sql-metadata-tables.md
+++ b/docs/querying/sql-metadata-tables.md
@@ -299,6 +299,7 @@ The supervisors table provides information about supervisors.
 |Column|Type|Notes|
 |------|-----|-----|
 |supervisor_id|VARCHAR|Supervisor task identifier|
+|datasource|VARCHAR|Datasource the supervisor operates on|
 |state|VARCHAR|Basic state of the supervisor. Available states: `UNHEALTHY_SUPERVISOR`, `UNHEALTHY_TASKS`, `PENDING`, `RUNNING`, `SUSPENDED`, `STOPPING`. See [Supervisor reference](../ingestion/supervisor.md) for more information.|
 |detailed_state|VARCHAR|Supervisor specific state. See documentation of the specific supervisor for details: [Kafka](../ingestion/kafka-ingestion.md) or [Kinesis](../ingestion/kinesis-ingestion.md).|
 |healthy|BIGINT|Boolean represented as long type where 1 = true, 0 = false. 1 indicates a healthy supervisor|

--- a/extensions-contrib/rabbit-stream-indexing-service/src/main/java/org/apache/druid/indexing/rabbitstream/RabbitStreamIndexTask.java
+++ b/extensions-contrib/rabbit-stream-indexing-service/src/main/java/org/apache/druid/indexing/rabbitstream/RabbitStreamIndexTask.java
@@ -25,6 +25,7 @@ import com.fasterxml.jackson.annotation.JsonProperty;
 import com.fasterxml.jackson.databind.ObjectMapper;
 import com.google.common.annotations.VisibleForTesting;
 import com.google.common.base.Preconditions;
+import org.apache.druid.common.config.Configs;
 import org.apache.druid.data.input.impl.ByteEntity;
 import org.apache.druid.indexer.TaskStatus;
 import org.apache.druid.indexing.common.TaskToolbox;
@@ -34,6 +35,7 @@ import org.apache.druid.indexing.seekablestream.SeekableStreamIndexTaskRunner;
 import org.apache.druid.segment.indexing.DataSchema;
 import org.apache.druid.utils.RuntimeInfo;
 
+import javax.annotation.Nullable;
 import java.util.HashMap;
 import java.util.Map;
 
@@ -48,21 +50,25 @@ public class RabbitStreamIndexTask extends SeekableStreamIndexTask<String, Long,
   @JsonCreator
   public RabbitStreamIndexTask(
       @JsonProperty("id") String id,
+      @JsonProperty("supervisorId") @Nullable String supervisorId,
       @JsonProperty("resource") TaskResource taskResource,
       @JsonProperty("dataSchema") DataSchema dataSchema,
       @JsonProperty("tuningConfig") RabbitStreamIndexTaskTuningConfig tuningConfig,
       @JsonProperty("ioConfig") RabbitStreamIndexTaskIOConfig ioConfig,
       @JsonProperty("context") Map<String, Object> context,
-      @JacksonInject ObjectMapper configMapper)
+      @JacksonInject ObjectMapper configMapper
+  )
   {
     super(
         getOrMakeId(id, dataSchema.getDataSource(), TYPE),
+        supervisorId,
         taskResource,
         dataSchema,
         tuningConfig,
         ioConfig,
         context,
-        getFormattedGroupId(dataSchema.getDataSource(), TYPE));
+        getFormattedGroupId(Configs.valueOrDefault(supervisorId, dataSchema.getDataSource()), TYPE)
+    );
     this.configMapper = configMapper;
 
     Preconditions.checkArgument(

--- a/extensions-contrib/rabbit-stream-indexing-service/src/main/java/org/apache/druid/indexing/rabbitstream/supervisor/RabbitStreamSupervisor.java
+++ b/extensions-contrib/rabbit-stream-indexing-service/src/main/java/org/apache/druid/indexing/rabbitstream/supervisor/RabbitStreamSupervisor.java
@@ -23,6 +23,7 @@ import com.fasterxml.jackson.core.JsonProcessingException;
 import com.fasterxml.jackson.core.type.TypeReference;
 import com.fasterxml.jackson.databind.ObjectMapper;
 import com.google.common.annotations.VisibleForTesting;
+import com.google.common.base.Objects;
 import org.apache.druid.common.utils.IdUtils;
 import org.apache.druid.data.input.impl.ByteEntity;
 import org.apache.druid.indexing.common.task.Task;
@@ -107,7 +108,7 @@ public class RabbitStreamSupervisor extends SeekableStreamSupervisor<String, Lon
       final RowIngestionMetersFactory rowIngestionMetersFactory)
   {
     super(
-        StringUtils.format("RabbitSupervisor-%s", spec.getDataSchema().getDataSource()),
+        StringUtils.format("RabbitSupervisor-%s", spec.getId()),
         taskStorage,
         taskMaster,
         indexerMetadataStorageCoordinator,
@@ -150,9 +151,14 @@ public class RabbitStreamSupervisor extends SeekableStreamSupervisor<String, Lon
   }
 
   @Override
-  protected boolean doesTaskTypeMatchSupervisor(Task task)
+  protected boolean doesTaskMatchSupervisor(Task task)
   {
-    return task instanceof RabbitStreamIndexTask;
+    if (task instanceof RabbitStreamIndexTask) {
+      final String supervisorId = ((RabbitStreamIndexTask) task).getSupervisorId();
+      return Objects.equal(supervisorId, spec.getId());
+    } else {
+      return false;
+    }
   }
 
   @Override
@@ -163,6 +169,7 @@ public class RabbitStreamSupervisor extends SeekableStreamSupervisor<String, Lon
     RabbitStreamSupervisorIOConfig ioConfig = spec.getIoConfig();
     Map<String, Long> partitionLag = getRecordLagPerPartitionInLatestSequences(getHighestCurrentOffsets());
     return new RabbitStreamSupervisorReportPayload(
+        spec.getId(),
         spec.getDataSchema().getDataSource(),
         ioConfig.getStream(),
         numPartitions,
@@ -224,12 +231,14 @@ public class RabbitStreamSupervisor extends SeekableStreamSupervisor<String, Lon
       String taskId = IdUtils.getRandomIdWithPrefix(baseSequenceName);
       taskList.add(new RabbitStreamIndexTask(
           taskId,
+          spec.getId(),
           new TaskResource(baseSequenceName, 1),
           spec.getDataSchema(),
           (RabbitStreamIndexTaskTuningConfig) taskTuningConfig,
           (RabbitStreamIndexTaskIOConfig) taskIoConfig,
           context,
-          sortingMapper));
+          sortingMapper
+      ));
     }
     return taskList;
   }

--- a/extensions-contrib/rabbit-stream-indexing-service/src/main/java/org/apache/druid/indexing/rabbitstream/supervisor/RabbitStreamSupervisorIngestionSpec.java
+++ b/extensions-contrib/rabbit-stream-indexing-service/src/main/java/org/apache/druid/indexing/rabbitstream/supervisor/RabbitStreamSupervisorIngestionSpec.java
@@ -34,7 +34,8 @@ public class RabbitStreamSupervisorIngestionSpec extends SeekableStreamSuperviso
   public RabbitStreamSupervisorIngestionSpec(
       @JsonProperty("dataSchema") DataSchema dataSchema,
       @JsonProperty("ioConfig") RabbitStreamSupervisorIOConfig ioConfig,
-      @JsonProperty("tuningConfig") RabbitStreamSupervisorTuningConfig tuningConfig)
+      @JsonProperty("tuningConfig") RabbitStreamSupervisorTuningConfig tuningConfig
+  )
   {
     super(dataSchema, ioConfig, tuningConfig);
     this.dataSchema = dataSchema;

--- a/extensions-contrib/rabbit-stream-indexing-service/src/main/java/org/apache/druid/indexing/rabbitstream/supervisor/RabbitStreamSupervisorReportPayload.java
+++ b/extensions-contrib/rabbit-stream-indexing-service/src/main/java/org/apache/druid/indexing/rabbitstream/supervisor/RabbitStreamSupervisorReportPayload.java
@@ -24,13 +24,13 @@ import org.apache.druid.indexing.seekablestream.supervisor.SeekableStreamSupervi
 import org.joda.time.DateTime;
 
 import javax.annotation.Nullable;
-
 import java.util.List;
 import java.util.Map;
 
 public class RabbitStreamSupervisorReportPayload extends SeekableStreamSupervisorReportPayload<String, Long>
 {
   public RabbitStreamSupervisorReportPayload(
+      String id,
       String dataSource,
       String stream,
       int partitions,
@@ -47,6 +47,7 @@ public class RabbitStreamSupervisorReportPayload extends SeekableStreamSuperviso
       List<SupervisorStateManager.ExceptionEvent> recentErrors)
   {
     super(
+        id,
         dataSource,
         stream,
         partitions,
@@ -69,7 +70,8 @@ public class RabbitStreamSupervisorReportPayload extends SeekableStreamSuperviso
   public String toString()
   {
     return "RabbitStreamSupervisorReportPayload{" +
-        "dataSource='" + getDataSource() + '\'' +
+       "id='" + getId() + '\'' +
+       ", dataSource='" + getDataSource() + '\'' +
         ", stream='" + getStream() + '\'' +
         ", partitions=" + getPartitions() +
         ", replicas=" + getReplicas() +

--- a/extensions-contrib/rabbit-stream-indexing-service/src/main/java/org/apache/druid/indexing/rabbitstream/supervisor/RabbitStreamSupervisorSpec.java
+++ b/extensions-contrib/rabbit-stream-indexing-service/src/main/java/org/apache/druid/indexing/rabbitstream/supervisor/RabbitStreamSupervisorSpec.java
@@ -37,7 +37,6 @@ import org.apache.druid.segment.incremental.RowIngestionMetersFactory;
 import org.apache.druid.segment.indexing.DataSchema;
 
 import javax.annotation.Nullable;
-
 import java.util.Map;
 
 public class RabbitStreamSupervisorSpec extends SeekableStreamSupervisorSpec
@@ -46,6 +45,7 @@ public class RabbitStreamSupervisorSpec extends SeekableStreamSupervisorSpec
 
   @JsonCreator
   public RabbitStreamSupervisorSpec(
+      @JsonProperty("id") @Nullable String id,
       @JsonProperty("spec") @Nullable RabbitStreamSupervisorIngestionSpec ingestionSchema,
       @JsonProperty("dataSchema") @Nullable DataSchema dataSchema,
       @JsonProperty("tuningConfig") @Nullable RabbitStreamSupervisorTuningConfig tuningConfig,
@@ -63,6 +63,7 @@ public class RabbitStreamSupervisorSpec extends SeekableStreamSupervisorSpec
       @JacksonInject SupervisorStateManagerConfig supervisorStateManagerConfig)
   {
     super(
+        id,
         ingestionSchema != null
             ? ingestionSchema
             : new RabbitStreamSupervisorIngestionSpec(
@@ -136,6 +137,7 @@ public class RabbitStreamSupervisorSpec extends SeekableStreamSupervisorSpec
   protected RabbitStreamSupervisorSpec toggleSuspend(boolean suspend)
   {
     return new RabbitStreamSupervisorSpec(
+        getId(),
         getSpec(),
         getDataSchema(),
         getTuningConfig(),

--- a/extensions-contrib/rabbit-stream-indexing-service/src/test/java/org/apache/druid/indexing/rabbitstream/supervisor/RabbitStreamSupervisorTest.java
+++ b/extensions-contrib/rabbit-stream-indexing-service/src/test/java/org/apache/druid/indexing/rabbitstream/supervisor/RabbitStreamSupervisorTest.java
@@ -216,6 +216,7 @@ public class RabbitStreamSupervisorTest extends EasyMockSupport
         OBJECT_MAPPER,
         new RabbitStreamSupervisorSpec(
             null,
+            null,
             dataSchema,
             tuningConfig,
             rabbitStreamSupervisorIOConfig,
@@ -278,6 +279,7 @@ public class RabbitStreamSupervisorTest extends EasyMockSupport
         clientFactory,
         OBJECT_MAPPER,
         new RabbitStreamSupervisorSpec(
+            null,
             null,
             dataSchema,
             tuningConfig,

--- a/extensions-core/kafka-indexing-service/src/main/java/org/apache/druid/indexing/kafka/KafkaIndexTask.java
+++ b/extensions-core/kafka-indexing-service/src/main/java/org/apache/druid/indexing/kafka/KafkaIndexTask.java
@@ -26,6 +26,7 @@ import com.fasterxml.jackson.annotation.JsonProperty;
 import com.fasterxml.jackson.databind.ObjectMapper;
 import com.google.common.annotations.VisibleForTesting;
 import com.google.common.base.Preconditions;
+import org.apache.druid.common.config.Configs;
 import org.apache.druid.data.input.kafka.KafkaRecordEntity;
 import org.apache.druid.data.input.kafka.KafkaTopicPartition;
 import org.apache.druid.indexing.common.TaskToolbox;
@@ -39,6 +40,7 @@ import org.apache.druid.server.security.ResourceAction;
 import org.apache.druid.server.security.ResourceType;
 
 import javax.annotation.Nonnull;
+import javax.annotation.Nullable;
 
 import java.util.Collections;
 import java.util.HashMap;
@@ -57,6 +59,7 @@ public class KafkaIndexTask extends SeekableStreamIndexTask<KafkaTopicPartition,
   @JsonCreator
   public KafkaIndexTask(
       @JsonProperty("id") String id,
+      @JsonProperty("supervisorId") @Nullable String supervisorId,
       @JsonProperty("resource") TaskResource taskResource,
       @JsonProperty("dataSchema") DataSchema dataSchema,
       @JsonProperty("tuningConfig") KafkaIndexTaskTuningConfig tuningConfig,
@@ -67,12 +70,13 @@ public class KafkaIndexTask extends SeekableStreamIndexTask<KafkaTopicPartition,
   {
     super(
         getOrMakeId(id, dataSchema.getDataSource(), TYPE),
+        supervisorId,
         taskResource,
         dataSchema,
         tuningConfig,
         ioConfig,
         context,
-        getFormattedGroupId(dataSchema.getDataSource(), TYPE)
+        getFormattedGroupId(Configs.valueOrDefault(supervisorId, dataSchema.getDataSource()), TYPE)
     );
     this.configMapper = configMapper;
 

--- a/extensions-core/kafka-indexing-service/src/main/java/org/apache/druid/indexing/kafka/supervisor/KafkaSupervisor.java
+++ b/extensions-core/kafka-indexing-service/src/main/java/org/apache/druid/indexing/kafka/supervisor/KafkaSupervisor.java
@@ -23,6 +23,7 @@ import com.fasterxml.jackson.core.JsonProcessingException;
 import com.fasterxml.jackson.core.type.TypeReference;
 import com.fasterxml.jackson.databind.ObjectMapper;
 import com.google.common.annotations.VisibleForTesting;
+import com.google.common.base.Objects;
 import org.apache.druid.common.utils.IdUtils;
 import org.apache.druid.data.input.kafka.KafkaRecordEntity;
 import org.apache.druid.data.input.kafka.KafkaTopicPartition;
@@ -113,7 +114,7 @@ public class KafkaSupervisor extends SeekableStreamSupervisor<KafkaTopicPartitio
   )
   {
     super(
-        StringUtils.format("KafkaSupervisor-%s", spec.getDataSchema().getDataSource()),
+        StringUtils.format("KafkaSupervisor-%s", spec.getId()),
         taskStorage,
         taskMaster,
         indexerMetadataStorageCoordinator,
@@ -161,9 +162,14 @@ public class KafkaSupervisor extends SeekableStreamSupervisor<KafkaTopicPartitio
   }
 
   @Override
-  protected boolean doesTaskTypeMatchSupervisor(Task task)
+  protected boolean doesTaskMatchSupervisor(Task task)
   {
-    return task instanceof KafkaIndexTask;
+    if (task instanceof KafkaIndexTask) {
+      final String supervisorId = ((KafkaIndexTask) task).getSupervisorId();
+      return Objects.equal(supervisorId, spec.getId());
+    } else {
+      return false;
+    }
   }
 
   @Override
@@ -175,6 +181,7 @@ public class KafkaSupervisor extends SeekableStreamSupervisor<KafkaTopicPartitio
     KafkaSupervisorIOConfig ioConfig = spec.getIoConfig();
     Map<KafkaTopicPartition, Long> partitionLag = getRecordLagPerPartitionInLatestSequences(getHighestCurrentOffsets());
     return new KafkaSupervisorReportPayload(
+        spec.getId(),
         spec.getDataSchema().getDataSource(),
         ioConfig.getStream(),
         numPartitions,
@@ -249,6 +256,7 @@ public class KafkaSupervisor extends SeekableStreamSupervisor<KafkaTopicPartitio
       String taskId = IdUtils.getRandomIdWithPrefix(baseSequenceName);
       taskList.add(new KafkaIndexTask(
           taskId,
+          spec.getId(),
           new TaskResource(baseSequenceName, 1),
           spec.getDataSchema(),
           (KafkaIndexTaskTuningConfig) taskTuningConfig,

--- a/extensions-core/kafka-indexing-service/src/main/java/org/apache/druid/indexing/kafka/supervisor/KafkaSupervisorReportPayload.java
+++ b/extensions-core/kafka-indexing-service/src/main/java/org/apache/druid/indexing/kafka/supervisor/KafkaSupervisorReportPayload.java
@@ -31,6 +31,7 @@ import java.util.Map;
 public class KafkaSupervisorReportPayload extends SeekableStreamSupervisorReportPayload<KafkaTopicPartition, Long>
 {
   public KafkaSupervisorReportPayload(
+      String id,
       String dataSource,
       String topic,
       int partitions,
@@ -48,6 +49,7 @@ public class KafkaSupervisorReportPayload extends SeekableStreamSupervisorReport
   )
   {
     super(
+        id,
         dataSource,
         topic,
         partitions,
@@ -71,7 +73,8 @@ public class KafkaSupervisorReportPayload extends SeekableStreamSupervisorReport
   public String toString()
   {
     return "KafkaSupervisorReportPayload{" +
-           "dataSource='" + getDataSource() + '\'' +
+           "id='" + getId() + '\'' +
+           ", dataSource='" + getDataSource() + '\'' +
            ", topic='" + getStream() + '\'' +
            ", partitions=" + getPartitions() +
            ", replicas=" + getReplicas() +

--- a/extensions-core/kafka-indexing-service/src/main/java/org/apache/druid/indexing/kafka/supervisor/KafkaSupervisorSpec.java
+++ b/extensions-core/kafka-indexing-service/src/main/java/org/apache/druid/indexing/kafka/supervisor/KafkaSupervisorSpec.java
@@ -53,6 +53,7 @@ public class KafkaSupervisorSpec extends SeekableStreamSupervisorSpec
 
   @JsonCreator
   public KafkaSupervisorSpec(
+      @JsonProperty("id") @Nullable String id,
       @JsonProperty("spec") @Nullable KafkaSupervisorIngestionSpec ingestionSchema,
       @JsonProperty("dataSchema") @Nullable DataSchema dataSchema,
       @JsonProperty("tuningConfig") @Nullable KafkaSupervisorTuningConfig tuningConfig,
@@ -71,6 +72,7 @@ public class KafkaSupervisorSpec extends SeekableStreamSupervisorSpec
   )
   {
     super(
+        id,
         ingestionSchema != null
         ? ingestionSchema
         : new KafkaSupervisorIngestionSpec(
@@ -158,6 +160,7 @@ public class KafkaSupervisorSpec extends SeekableStreamSupervisorSpec
   protected KafkaSupervisorSpec toggleSuspend(boolean suspend)
   {
     return new KafkaSupervisorSpec(
+        getId(),
         getSpec(),
         getDataSchema(),
         getTuningConfig(),

--- a/extensions-core/kafka-indexing-service/src/test/java/org/apache/druid/indexing/kafka/KafkaIndexTaskTest.java
+++ b/extensions-core/kafka-indexing-service/src/test/java/org/apache/druid/indexing/kafka/KafkaIndexTaskTest.java
@@ -2915,6 +2915,7 @@ public class KafkaIndexTaskTest extends SeekableStreamIndexTaskTestBase
     final KafkaIndexTask task = new KafkaIndexTask(
         taskId,
         null,
+        null,
         cloneDataSchema(dataSchema),
         tuningConfig,
         ioConfig,

--- a/extensions-core/kafka-indexing-service/src/test/java/org/apache/druid/indexing/kafka/KafkaSamplerSpecTest.java
+++ b/extensions-core/kafka-indexing-service/src/test/java/org/apache/druid/indexing/kafka/KafkaSamplerSpecTest.java
@@ -160,6 +160,7 @@ public class KafkaSamplerSpecTest extends InitializedNullHandlingTest
 
     KafkaSupervisorSpec supervisorSpec = new KafkaSupervisorSpec(
         null,
+        null,
         DATA_SCHEMA,
         null,
         new KafkaSupervisorIOConfig(
@@ -214,6 +215,7 @@ public class KafkaSamplerSpecTest extends InitializedNullHandlingTest
 
     KafkaSupervisorSpec supervisorSpec = new KafkaSupervisorSpec(
         null,
+        null,
         DATA_SCHEMA,
         null,
         new KafkaSupervisorIOConfig(
@@ -267,6 +269,7 @@ public class KafkaSamplerSpecTest extends InitializedNullHandlingTest
     insertData(generateRecords(TOPIC));
 
     KafkaSupervisorSpec supervisorSpec = new KafkaSupervisorSpec(
+        null,
         null,
         DATA_SCHEMA_KAFKA_TIMESTAMP,
         null,
@@ -380,6 +383,7 @@ public class KafkaSamplerSpecTest extends InitializedNullHandlingTest
     );
 
     KafkaSupervisorSpec supervisorSpec = new KafkaSupervisorSpec(
+        null,
         null,
         dataSchema,
         null,
@@ -563,6 +567,7 @@ public class KafkaSamplerSpecTest extends InitializedNullHandlingTest
   {
     KafkaSupervisorSpec supervisorSpec = new KafkaSupervisorSpec(
         null,
+        null,
         DATA_SCHEMA,
         null,
         new KafkaSupervisorIOConfig(
@@ -619,6 +624,7 @@ public class KafkaSamplerSpecTest extends InitializedNullHandlingTest
   public void testGetInputSourceResources()
   {
     KafkaSupervisorSpec supervisorSpec = new KafkaSupervisorSpec(
+        null,
         null,
         DATA_SCHEMA,
         null,

--- a/extensions-core/kafka-indexing-service/src/test/java/org/apache/druid/indexing/kafka/supervisor/KafkaSupervisorTest.java
+++ b/extensions-core/kafka-indexing-service/src/test/java/org/apache/druid/indexing/kafka/supervisor/KafkaSupervisorTest.java
@@ -63,6 +63,7 @@ import org.apache.druid.indexing.overlord.supervisor.SupervisorStateManager;
 import org.apache.druid.indexing.overlord.supervisor.SupervisorStateManagerConfig;
 import org.apache.druid.indexing.overlord.supervisor.autoscaler.SupervisorTaskAutoScaler;
 import org.apache.druid.indexing.seekablestream.SeekableStreamEndSequenceNumbers;
+import org.apache.druid.indexing.seekablestream.SeekableStreamIndexTask;
 import org.apache.druid.indexing.seekablestream.SeekableStreamIndexTaskClient;
 import org.apache.druid.indexing.seekablestream.SeekableStreamIndexTaskRunner.Status;
 import org.apache.druid.indexing.seekablestream.SeekableStreamIndexTaskTuningConfig;
@@ -121,6 +122,7 @@ import org.junit.Test;
 import org.junit.runner.RunWith;
 import org.junit.runners.Parameterized;
 
+import javax.annotation.Nullable;
 import java.io.IOException;
 import java.util.ArrayList;
 import java.util.Collection;
@@ -358,21 +360,22 @@ public class KafkaSupervisorTest extends EasyMockSupport
     EasyMock.replay(ingestionSchema);
 
     SeekableStreamSupervisorSpec testableSupervisorSpec = new KafkaSupervisorSpec(
-            ingestionSchema,
-            dataSchema,
-            tuningConfigOri,
-            kafkaSupervisorIOConfig,
-            null,
-            false,
-            taskStorage,
-            taskMaster,
-            indexerMetadataStorageCoordinator,
-            taskClientFactory,
-            OBJECT_MAPPER,
-            new NoopServiceEmitter(),
-            new DruidMonitorSchedulerConfig(),
-            rowIngestionMetersFactory,
-            new SupervisorStateManagerConfig()
+        null,
+        ingestionSchema,
+        dataSchema,
+        tuningConfigOri,
+        kafkaSupervisorIOConfig,
+        null,
+        false,
+        taskStorage,
+        taskMaster,
+        indexerMetadataStorageCoordinator,
+        taskClientFactory,
+        OBJECT_MAPPER,
+        new NoopServiceEmitter(),
+        new DruidMonitorSchedulerConfig(),
+        rowIngestionMetersFactory,
+        new SupervisorStateManagerConfig()
     );
 
     supervisor = new TestableKafkaSupervisor(
@@ -1186,6 +1189,11 @@ public class KafkaSupervisorTest extends EasyMockSupport
     Assert.assertEquals(
         "org.apache.druid.java.util.common.ISE",
         supervisor.getStateManager().getExceptionEvents().get(0).getExceptionClass()
+    );
+    AlertEvent alert = serviceEmitter.getAlerts().get(0);
+    Assert.assertEquals(
+        "Exception in supervisor run loop for supervisor[testDS] for dataSource[testDS]",
+        alert.getDescription()
     );
   }
 
@@ -3241,6 +3249,12 @@ public class KafkaSupervisorTest extends EasyMockSupport
     supervisor.start();
     supervisor.runInternal();
     verifyAll();
+
+    AlertEvent alert = serviceEmitter.getAlerts().get(0);
+    Assert.assertEquals(
+        "Exception in supervisor run loop for supervisor[testDS] for dataSource[testDS]",
+        alert.getDescription()
+    );
   }
 
   @Test
@@ -3659,7 +3673,7 @@ public class KafkaSupervisorTest extends EasyMockSupport
 
     AlertEvent alert = serviceEmitter.getAlerts().get(0);
     Assert.assertEquals(
-        "SeekableStreamSupervisor[testDS] failed to handle notice",
+        "SeekableStreamSupervisor[testDS] for datasource=[testDS] failed to handle notice",
         alert.getDescription()
     );
     Assert.assertEquals(
@@ -4667,6 +4681,28 @@ public class KafkaSupervisorTest extends EasyMockSupport
     verifyAll();
   }
 
+  @Test
+  public void test_doesTaskMatchSupervisor()
+  {
+    supervisor = getTestableSupervisor("supervisorId", 1, 1, true, true, null, new Period("PT1H"), new Period("PT1H"), false, kafkaHost, null);
+
+    KafkaIndexTask kafkaTaskMatch = createMock(KafkaIndexTask.class);
+    EasyMock.expect(kafkaTaskMatch.getSupervisorId()).andReturn("supervisorId");
+    EasyMock.replay(kafkaTaskMatch);
+
+    Assert.assertTrue(supervisor.doesTaskMatchSupervisor(kafkaTaskMatch));
+
+    KafkaIndexTask kafkaTaskNoMatch = createMock(KafkaIndexTask.class);
+    EasyMock.expect(kafkaTaskNoMatch.getSupervisorId()).andReturn(dataSchema.getDataSource());
+    EasyMock.replay(kafkaTaskNoMatch);
+
+    Assert.assertFalse(supervisor.doesTaskMatchSupervisor(kafkaTaskNoMatch));
+
+    SeekableStreamIndexTask differentTaskType = createMock(SeekableStreamIndexTask.class);
+    EasyMock.expect(differentTaskType.getSupervisorId()).andReturn("supervisorId");
+    EasyMock.replay(differentTaskType);
+  }
+
   private void addSomeEvents(int numEventsPerPartition) throws Exception
   {
     // create topic manually
@@ -4752,6 +4788,7 @@ public class KafkaSupervisorTest extends EasyMockSupport
   )
   {
     return getTestableSupervisor(
+        null,
         replicas,
         taskCount,
         useEarliestOffset,
@@ -4777,6 +4814,7 @@ public class KafkaSupervisorTest extends EasyMockSupport
   )
   {
     return getTestableSupervisor(
+        null,
         replicas,
         taskCount,
         useEarliestOffset,
@@ -4802,6 +4840,7 @@ public class KafkaSupervisorTest extends EasyMockSupport
   )
   {
     return getTestableSupervisor(
+        null,
         replicas,
         taskCount,
         useEarliestOffset,
@@ -4816,6 +4855,7 @@ public class KafkaSupervisorTest extends EasyMockSupport
   }
 
   private TestableKafkaSupervisor getTestableSupervisor(
+      @Nullable String id,
       int replicas,
       int taskCount,
       boolean useEarliestOffset,
@@ -4908,6 +4948,7 @@ public class KafkaSupervisorTest extends EasyMockSupport
         taskClientFactory,
         OBJECT_MAPPER,
         new KafkaSupervisorSpec(
+            id,
             null,
             dataSchema,
             tuningConfig,
@@ -5024,6 +5065,7 @@ public class KafkaSupervisorTest extends EasyMockSupport
         OBJECT_MAPPER,
         new KafkaSupervisorSpec(
             null,
+            null,
             dataSchema,
             tuningConfig,
             kafkaSupervisorIOConfig,
@@ -5114,6 +5156,7 @@ public class KafkaSupervisorTest extends EasyMockSupport
         taskClientFactory,
         OBJECT_MAPPER,
         new KafkaSupervisorSpec(
+            null,
             null,
             dataSchema,
             tuningConfig,
@@ -5213,6 +5256,7 @@ public class KafkaSupervisorTest extends EasyMockSupport
   {
     return new KafkaIndexTask(
         id,
+        null,
         null,
         schema,
         tuningConfig,

--- a/extensions-core/kafka-indexing-service/src/test/java/org/apache/druid/indexing/kafka/supervisor/KafkaSupervisorTest.java
+++ b/extensions-core/kafka-indexing-service/src/test/java/org/apache/druid/indexing/kafka/supervisor/KafkaSupervisorTest.java
@@ -3673,7 +3673,7 @@ public class KafkaSupervisorTest extends EasyMockSupport
 
     AlertEvent alert = serviceEmitter.getAlerts().get(0);
     Assert.assertEquals(
-        "SeekableStreamSupervisor[testDS] for datasource=[testDS] failed to handle notice",
+        "Supervisor[testDS] for datasource[testDS] failed to handle notice",
         alert.getDescription()
     );
     Assert.assertEquals(

--- a/extensions-core/kinesis-indexing-service/src/main/java/org/apache/druid/indexing/kinesis/KinesisIndexTask.java
+++ b/extensions-core/kinesis-indexing-service/src/main/java/org/apache/druid/indexing/kinesis/KinesisIndexTask.java
@@ -27,6 +27,7 @@ import com.google.common.annotations.VisibleForTesting;
 import com.google.common.base.Preconditions;
 import com.google.inject.name.Named;
 import org.apache.druid.common.aws.AWSCredentialsConfig;
+import org.apache.druid.common.config.Configs;
 import org.apache.druid.data.input.impl.ByteEntity;
 import org.apache.druid.indexer.TaskStatus;
 import org.apache.druid.indexing.common.TaskToolbox;
@@ -42,6 +43,8 @@ import org.apache.druid.server.security.ResourceType;
 import org.apache.druid.utils.RuntimeInfo;
 
 import javax.annotation.Nonnull;
+import javax.annotation.Nullable;
+
 import java.util.Collections;
 import java.util.Map;
 import java.util.Set;
@@ -62,6 +65,7 @@ public class KinesisIndexTask extends SeekableStreamIndexTask<String, String, By
   @JsonCreator
   public KinesisIndexTask(
       @JsonProperty("id") String id,
+      @JsonProperty("supervisorId") @Nullable String supervisorId,
       @JsonProperty("resource") TaskResource taskResource,
       @JsonProperty("dataSchema") DataSchema dataSchema,
       @JsonProperty("tuningConfig") KinesisIndexTaskTuningConfig tuningConfig,
@@ -73,12 +77,13 @@ public class KinesisIndexTask extends SeekableStreamIndexTask<String, String, By
   {
     super(
         getOrMakeId(id, dataSchema.getDataSource(), TYPE),
+        supervisorId,
         taskResource,
         dataSchema,
         tuningConfig,
         ioConfig,
         context,
-        getFormattedGroupId(dataSchema.getDataSource(), TYPE)
+        getFormattedGroupId(Configs.valueOrDefault(supervisorId, dataSchema.getDataSource()), TYPE)
     );
     this.useListShards = useListShards;
     this.awsCredentialsConfig = awsCredentialsConfig;

--- a/extensions-core/kinesis-indexing-service/src/main/java/org/apache/druid/indexing/kinesis/supervisor/KinesisSupervisor.java
+++ b/extensions-core/kinesis-indexing-service/src/main/java/org/apache/druid/indexing/kinesis/supervisor/KinesisSupervisor.java
@@ -22,6 +22,7 @@ package org.apache.druid.indexing.kinesis.supervisor;
 import com.fasterxml.jackson.core.JsonProcessingException;
 import com.fasterxml.jackson.core.type.TypeReference;
 import com.fasterxml.jackson.databind.ObjectMapper;
+import com.google.common.base.Objects;
 import com.google.common.collect.ImmutableMap;
 import org.apache.druid.common.aws.AWSCredentialsConfig;
 import org.apache.druid.common.utils.IdUtils;
@@ -100,7 +101,7 @@ public class KinesisSupervisor extends SeekableStreamSupervisor<String, String, 
   )
   {
     super(
-        StringUtils.format("KinesisSupervisor-%s", spec.getDataSchema().getDataSource()),
+        StringUtils.format("KinesisSupervisor-%s", spec.getId()),
         taskStorage,
         taskMaster,
         indexerMetadataStorageCoordinator,
@@ -169,6 +170,7 @@ public class KinesisSupervisor extends SeekableStreamSupervisor<String, String, 
       String taskId = IdUtils.getRandomIdWithPrefix(baseSequenceName);
       taskList.add(new KinesisIndexTask(
           taskId,
+          spec.getId(),
           new TaskResource(baseSequenceName, 1),
           spec.getDataSchema(),
           (KinesisIndexTaskTuningConfig) taskTuningConfig,
@@ -250,9 +252,14 @@ public class KinesisSupervisor extends SeekableStreamSupervisor<String, String, 
   }
 
   @Override
-  protected boolean doesTaskTypeMatchSupervisor(Task task)
+  protected boolean doesTaskMatchSupervisor(Task task)
   {
-    return task instanceof KinesisIndexTask;
+    if (task instanceof KinesisIndexTask) {
+      final String supervisorId = ((KinesisIndexTask) task).getSupervisorId();
+      return Objects.equal(supervisorId, spec.getId());
+    } else {
+      return false;
+    }
   }
 
   @Override
@@ -264,6 +271,7 @@ public class KinesisSupervisor extends SeekableStreamSupervisor<String, String, 
     KinesisSupervisorIOConfig ioConfig = spec.getIoConfig();
     Map<String, Long> partitionLag = getTimeLagPerPartition(getHighestCurrentOffsets());
     return new KinesisSupervisorReportPayload(
+        spec.getId(),
         spec.getDataSchema().getDataSource(),
         ioConfig.getStream(),
         numPartitions,

--- a/extensions-core/kinesis-indexing-service/src/main/java/org/apache/druid/indexing/kinesis/supervisor/KinesisSupervisorReportPayload.java
+++ b/extensions-core/kinesis-indexing-service/src/main/java/org/apache/druid/indexing/kinesis/supervisor/KinesisSupervisorReportPayload.java
@@ -29,6 +29,7 @@ import java.util.Map;
 public class KinesisSupervisorReportPayload extends SeekableStreamSupervisorReportPayload<String, String>
 {
   public KinesisSupervisorReportPayload(
+      String id,
       String dataSource,
       String stream,
       Integer partitions,
@@ -44,6 +45,7 @@ public class KinesisSupervisorReportPayload extends SeekableStreamSupervisorRepo
   )
   {
     super(
+        id,
         dataSource,
         stream,
         partitions,
@@ -67,7 +69,8 @@ public class KinesisSupervisorReportPayload extends SeekableStreamSupervisorRepo
   public String toString()
   {
     return "KinesisSupervisorReportPayload{" +
-           "dataSource='" + getDataSource() + '\'' +
+           "id='" + getId() + '\'' +
+           ", dataSource='" + getDataSource() + '\'' +
            ", stream='" + getStream() + '\'' +
            ", partitions=" + getPartitions() +
            ", replicas=" + getReplicas() +

--- a/extensions-core/kinesis-indexing-service/src/main/java/org/apache/druid/indexing/kinesis/supervisor/KinesisSupervisorSpec.java
+++ b/extensions-core/kinesis-indexing-service/src/main/java/org/apache/druid/indexing/kinesis/supervisor/KinesisSupervisorSpec.java
@@ -57,6 +57,7 @@ public class KinesisSupervisorSpec extends SeekableStreamSupervisorSpec
 
   @JsonCreator
   public KinesisSupervisorSpec(
+      @JsonProperty("id") @Nullable String id,
       @JsonProperty("spec") @Nullable KinesisSupervisorIngestionSpec ingestionSchema,
       @JsonProperty("dataSchema") @Nullable DataSchema dataSchema,
       @JsonProperty("tuningConfig") @Nullable KinesisSupervisorTuningConfig tuningConfig,
@@ -76,6 +77,7 @@ public class KinesisSupervisorSpec extends SeekableStreamSupervisorSpec
   )
   {
     super(
+        id,
         ingestionSchema != null
         ? ingestionSchema
         : new KinesisSupervisorIngestionSpec(
@@ -178,6 +180,7 @@ public class KinesisSupervisorSpec extends SeekableStreamSupervisorSpec
   protected KinesisSupervisorSpec toggleSuspend(boolean suspend)
   {
     return new KinesisSupervisorSpec(
+        getId(),
         getSpec(),
         getDataSchema(),
         getTuningConfig(),

--- a/extensions-core/kinesis-indexing-service/src/test/java/org/apache/druid/indexing/kinesis/KinesisIndexTaskSerdeTest.java
+++ b/extensions-core/kinesis-indexing-service/src/test/java/org/apache/druid/indexing/kinesis/KinesisIndexTaskSerdeTest.java
@@ -116,6 +116,7 @@ public class KinesisIndexTaskSerdeTest
     KinesisIndexTask target = new KinesisIndexTask(
         "id",
         null,
+        null,
         DATA_SCHEMA,
         TUNING_CONFIG,
         IO_CONFIG,

--- a/extensions-core/kinesis-indexing-service/src/test/java/org/apache/druid/indexing/kinesis/KinesisIndexTaskTest.java
+++ b/extensions-core/kinesis-indexing-service/src/test/java/org/apache/druid/indexing/kinesis/KinesisIndexTaskTest.java
@@ -2392,6 +2392,7 @@ public class KinesisIndexTaskTest extends SeekableStreamIndexTaskTestBase
     return new TestableKinesisIndexTask(
         taskId,
         null,
+        null,
         cloneDataSchema(dataSchema),
         tuningConfig,
         ioConfig,
@@ -2464,6 +2465,7 @@ public class KinesisIndexTaskTest extends SeekableStreamIndexTaskTestBase
     @JsonCreator
     private TestableKinesisIndexTask(
         @JsonProperty("id") String id,
+        @JsonProperty("supervisorId") @Nullable String supervisorId,
         @JsonProperty("resource") TaskResource taskResource,
         @JsonProperty("dataSchema") DataSchema dataSchema,
         @JsonProperty("tuningConfig") KinesisIndexTaskTuningConfig tuningConfig,
@@ -2474,6 +2476,7 @@ public class KinesisIndexTaskTest extends SeekableStreamIndexTaskTestBase
     {
       super(
           id,
+          supervisorId,
           taskResource,
           dataSchema,
           tuningConfig,

--- a/extensions-core/kinesis-indexing-service/src/test/java/org/apache/druid/indexing/kinesis/KinesisSamplerSpecTest.java
+++ b/extensions-core/kinesis-indexing-service/src/test/java/org/apache/druid/indexing/kinesis/KinesisSamplerSpecTest.java
@@ -126,6 +126,7 @@ public class KinesisSamplerSpecTest extends EasyMockSupport
   {
     KinesisSupervisorSpec supervisorSpec = new KinesisSupervisorSpec(
         null,
+        null,
         DATA_SCHEMA,
         null,
         new KinesisSupervisorIOConfig(
@@ -204,6 +205,7 @@ public class KinesisSamplerSpecTest extends EasyMockSupport
 
     KinesisSupervisorSpec supervisorSpec = new KinesisSupervisorSpec(
         null,
+        null,
         dataSchema,
         null,
         new KinesisSupervisorIOConfig(
@@ -256,6 +258,7 @@ public class KinesisSamplerSpecTest extends EasyMockSupport
   public void testGetInputSourceResources()
   {
     KinesisSupervisorSpec supervisorSpec = new KinesisSupervisorSpec(
+        null,
         null,
         DATA_SCHEMA,
         null,

--- a/extensions-core/kinesis-indexing-service/src/test/java/org/apache/druid/indexing/kinesis/supervisor/KinesisSupervisorTest.java
+++ b/extensions-core/kinesis-indexing-service/src/test/java/org/apache/druid/indexing/kinesis/supervisor/KinesisSupervisorTest.java
@@ -3472,7 +3472,7 @@ public class KinesisSupervisorTest extends EasyMockSupport
 
     final AlertEvent alert = serviceEmitter.getAlerts().get(0);
     Assert.assertEquals(
-        "SeekableStreamSupervisor[testDS] for datasource=[testDS] failed to handle notice",
+        "Supervisor[testDS] for datasource[testDS] failed to handle notice",
         alert.getDescription()
     );
     Assert.assertEquals(

--- a/extensions-core/kinesis-indexing-service/src/test/java/org/apache/druid/indexing/kinesis/supervisor/KinesisSupervisorTest.java
+++ b/extensions-core/kinesis-indexing-service/src/test/java/org/apache/druid/indexing/kinesis/supervisor/KinesisSupervisorTest.java
@@ -59,6 +59,7 @@ import org.apache.druid.indexing.overlord.supervisor.SupervisorStateManager;
 import org.apache.druid.indexing.overlord.supervisor.SupervisorStateManagerConfig;
 import org.apache.druid.indexing.overlord.supervisor.autoscaler.SupervisorTaskAutoScaler;
 import org.apache.druid.indexing.seekablestream.SeekableStreamEndSequenceNumbers;
+import org.apache.druid.indexing.seekablestream.SeekableStreamIndexTask;
 import org.apache.druid.indexing.seekablestream.SeekableStreamIndexTaskClient;
 import org.apache.druid.indexing.seekablestream.SeekableStreamIndexTaskRunner;
 import org.apache.druid.indexing.seekablestream.SeekableStreamIndexTaskTuningConfig;
@@ -105,6 +106,7 @@ import org.junit.Before;
 import org.junit.BeforeClass;
 import org.junit.Test;
 
+import javax.annotation.Nullable;
 import java.util.ArrayList;
 import java.util.Collection;
 import java.util.Collections;
@@ -473,6 +475,7 @@ public class KinesisSupervisorTest extends EasyMockSupport
         clientFactory,
         OBJECT_MAPPER,
         new KinesisSupervisorSpec(
+            null,
             null,
             dataSchema,
             tuningConfig,
@@ -916,6 +919,12 @@ public class KinesisSupervisorTest extends EasyMockSupport
     Assert.assertEquals(
         "org.apache.druid.java.util.common.ISE",
         supervisor.getStateManager().getExceptionEvents().get(0).getExceptionClass()
+    );
+
+    AlertEvent alert = serviceEmitter.getAlerts().get(0);
+    Assert.assertEquals(
+        "Exception in supervisor run loop for supervisor[testDS] for dataSource[testDS]",
+        alert.getDescription()
     );
   }
 
@@ -2763,7 +2772,7 @@ public class KinesisSupervisorTest extends EasyMockSupport
   @Test
   public void testGetOffsetFromStorageForPartitionWithResetOffsetAutomatically() throws Exception
   {
-    supervisor = getTestableSupervisor(1, 1, true, true, "PT1H", null, null, false);
+    supervisor = getTestableSupervisor(null, 1, 1, true, true, "PT1H", null, null, false);
 
     supervisorRecordSupplier.assign(EasyMock.anyObject());
     EasyMock.expectLastCall().anyTimes();
@@ -2857,6 +2866,12 @@ public class KinesisSupervisorTest extends EasyMockSupport
     supervisor.start();
     supervisor.runInternal();
     verifyAll();
+
+    AlertEvent alert = serviceEmitter.getAlerts().get(0);
+    Assert.assertEquals(
+        "Exception in supervisor run loop for supervisor[testDS] for dataSource[testDS]",
+        alert.getDescription()
+    );
   }
 
   @Test
@@ -3457,7 +3472,7 @@ public class KinesisSupervisorTest extends EasyMockSupport
 
     final AlertEvent alert = serviceEmitter.getAlerts().get(0);
     Assert.assertEquals(
-        "SeekableStreamSupervisor[testDS] failed to handle notice",
+        "SeekableStreamSupervisor[testDS] for datasource=[testDS] failed to handle notice",
         alert.getDescription()
     );
     Assert.assertEquals(
@@ -4160,6 +4175,7 @@ public class KinesisSupervisorTest extends EasyMockSupport
   {
     KinesisSupervisorSpec supervisorSpec = new KinesisSupervisorSpec(
         null,
+        null,
         dataSchema,
         null,
         new KinesisSupervisorIOConfig(
@@ -4660,6 +4676,29 @@ public class KinesisSupervisorTest extends EasyMockSupport
     testShardMergePhaseThree(phaseTwoTasks);
   }
 
+  @Test
+  public void test_doesTaskMatchSupervisor()
+  {
+    supervisor = getTestableSupervisor("supervisorId", 1, 1, true, true, "PT1H", null, null, false);
+    KinesisIndexTask kinesisTaskMatch = createMock(KinesisIndexTask.class);
+    EasyMock.expect(kinesisTaskMatch.getSupervisorId()).andReturn("supervisorId");
+    EasyMock.replay(kinesisTaskMatch);
+
+    Assert.assertTrue(supervisor.doesTaskMatchSupervisor(kinesisTaskMatch));
+
+    KinesisIndexTask kinesisTaskNoMatch = createMock(KinesisIndexTask.class);
+    EasyMock.expect(kinesisTaskNoMatch.getSupervisorId()).andReturn(dataSchema.getDataSource());
+    EasyMock.replay(kinesisTaskNoMatch);
+
+    Assert.assertFalse(supervisor.doesTaskMatchSupervisor(kinesisTaskNoMatch));
+
+    SeekableStreamIndexTask differentTaskType = createMock(SeekableStreamIndexTask.class);
+    EasyMock.expect(differentTaskType.getSupervisorId()).andReturn("supervisorId");
+    EasyMock.replay(differentTaskType);
+
+    Assert.assertFalse(supervisor.doesTaskMatchSupervisor(differentTaskType));
+  }
+
   private List<Task> testShardMergePhaseOne() throws Exception
   {
     supervisorRecordSupplier.assign(EasyMock.anyObject());
@@ -5065,6 +5104,7 @@ public class KinesisSupervisorTest extends EasyMockSupport
   )
   {
     return getTestableSupervisor(
+        null,
         replicas,
         taskCount,
         useEarliestOffset,
@@ -5077,6 +5117,7 @@ public class KinesisSupervisorTest extends EasyMockSupport
   }
 
   private TestableKinesisSupervisor getTestableSupervisor(
+      @Nullable String id,
       int replicas,
       int taskCount,
       boolean useEarliestOffset,
@@ -5173,6 +5214,7 @@ public class KinesisSupervisorTest extends EasyMockSupport
         taskClientFactory,
         OBJECT_MAPPER,
         new KinesisSupervisorSpec(
+            id,
             null,
             dataSchema,
             tuningConfig,
@@ -5282,6 +5324,7 @@ public class KinesisSupervisorTest extends EasyMockSupport
         OBJECT_MAPPER,
         new KinesisSupervisorSpec(
             null,
+            null,
             dataSchema,
             tuningConfig,
             kinesisSupervisorIOConfig,
@@ -5367,6 +5410,7 @@ public class KinesisSupervisorTest extends EasyMockSupport
         taskClientFactory,
         OBJECT_MAPPER,
         new KinesisSupervisorSpec(
+            null,
             null,
             dataSchema,
             tuningConfig,
@@ -5455,6 +5499,7 @@ public class KinesisSupervisorTest extends EasyMockSupport
         taskClientFactory,
         OBJECT_MAPPER,
         new KinesisSupervisorSpec(
+            null,
             null,
             dataSchema,
             tuningConfig,
@@ -5554,6 +5599,7 @@ public class KinesisSupervisorTest extends EasyMockSupport
   {
     return new KinesisIndexTask(
         id,
+        null,
         null,
         dataSchema,
         tuningConfig,

--- a/extensions-core/multi-stage-query/src/main/java/org/apache/druid/msq/exec/ControllerImpl.java
+++ b/extensions-core/multi-stage-query/src/main/java/org/apache/druid/msq/exec/ControllerImpl.java
@@ -1587,7 +1587,7 @@ public class ControllerImpl implements Controller
     if (taskLockType.equals(TaskLockType.APPEND)) {
       return SegmentTransactionalAppendAction.forSegments(segments, null);
     } else if (taskLockType.equals(TaskLockType.SHARED)) {
-      return SegmentTransactionalInsertAction.appendAction(segments, null, null, null);
+      return SegmentTransactionalInsertAction.appendAction(segments, null, null, null, null, null);
     } else {
       throw DruidException.defensive("Invalid lock type [%s] received for append action", taskLockType);
     }

--- a/extensions-core/multi-stage-query/src/test/java/org/apache/druid/msq/exec/ControllerImplTest.java
+++ b/extensions-core/multi-stage-query/src/test/java/org/apache/druid/msq/exec/ControllerImplTest.java
@@ -64,7 +64,7 @@ public class ControllerImplTest
   public void test_performSegmentPublish_ok() throws IOException
   {
     final SegmentTransactionalInsertAction action =
-        SegmentTransactionalInsertAction.appendAction(Collections.emptySet(), null, null, null);
+        SegmentTransactionalInsertAction.appendAction(Collections.emptySet(), null, null, null, null, null);
 
     final TaskActionClient taskActionClient = EasyMock.mock(TaskActionClient.class);
     EasyMock.expect(taskActionClient.submit(action)).andReturn(SegmentPublishResult.ok(Collections.emptySet()));
@@ -78,7 +78,7 @@ public class ControllerImplTest
   public void test_performSegmentPublish_publishFail() throws IOException
   {
     final SegmentTransactionalInsertAction action =
-        SegmentTransactionalInsertAction.appendAction(Collections.emptySet(), null, null, null);
+        SegmentTransactionalInsertAction.appendAction(Collections.emptySet(), null, null, null, null, null);
 
     final TaskActionClient taskActionClient = EasyMock.mock(TaskActionClient.class);
     EasyMock.expect(taskActionClient.submit(action)).andReturn(SegmentPublishResult.fail("oops"));
@@ -96,7 +96,7 @@ public class ControllerImplTest
   public void test_performSegmentPublish_publishException() throws IOException
   {
     final SegmentTransactionalInsertAction action =
-        SegmentTransactionalInsertAction.appendAction(Collections.emptySet(), null, null, null);
+        SegmentTransactionalInsertAction.appendAction(Collections.emptySet(), null, null, null, null, null);
 
     final TaskActionClient taskActionClient = EasyMock.mock(TaskActionClient.class);
     EasyMock.expect(taskActionClient.submit(action)).andThrow(new ISE("oops"));
@@ -114,7 +114,7 @@ public class ControllerImplTest
   public void test_performSegmentPublish_publishLockPreemptedException() throws IOException
   {
     final SegmentTransactionalInsertAction action =
-        SegmentTransactionalInsertAction.appendAction(Collections.emptySet(), null, null, null);
+        SegmentTransactionalInsertAction.appendAction(Collections.emptySet(), null, null, null, null, null);
 
     final TaskActionClient taskActionClient = EasyMock.mock(TaskActionClient.class);
     EasyMock.expect(taskActionClient.submit(action)).andThrow(new ISE("are not covered by locks"));

--- a/indexing-service/src/main/java/org/apache/druid/indexing/common/TaskToolbox.java
+++ b/indexing-service/src/main/java/org/apache/druid/indexing/common/TaskToolbox.java
@@ -349,7 +349,12 @@ public class TaskToolbox
     for (final Collection<DataSegment> segmentCollection : segmentMultimap.asMap().values()) {
       getTaskActionClient().submit(
           SegmentTransactionalInsertAction.appendAction(
-              ImmutableSet.copyOf(segmentCollection), null, null, null
+              ImmutableSet.copyOf(segmentCollection),
+              null,
+              null,
+              null,
+              null,
+              null
           )
       );
     }

--- a/indexing-service/src/main/java/org/apache/druid/indexing/common/actions/ResetDataSourceMetadataAction.java
+++ b/indexing-service/src/main/java/org/apache/druid/indexing/common/actions/ResetDataSourceMetadataAction.java
@@ -21,20 +21,30 @@ package org.apache.druid.indexing.common.actions;
 
 import com.fasterxml.jackson.annotation.JsonProperty;
 import com.fasterxml.jackson.core.type.TypeReference;
+import com.google.common.base.Preconditions;
+import org.apache.druid.common.config.Configs;
 import org.apache.druid.indexing.common.task.Task;
 import org.apache.druid.indexing.overlord.DataSourceMetadata;
 
+import javax.annotation.Nullable;
+
 public class ResetDataSourceMetadataAction implements TaskAction<Boolean>
 {
+  private final String supervisorId;
   private final String dataSource;
   private final DataSourceMetadata resetMetadata;
 
   public ResetDataSourceMetadataAction(
+      @JsonProperty("supervisorId") @Nullable String supervisorId,
       @JsonProperty("dataSource") String dataSource,
       @JsonProperty("resetMetadata") DataSourceMetadata resetMetadata
   )
   {
-    this.dataSource = dataSource;
+    this.dataSource = Preconditions.checkNotNull(dataSource, "dataSource cannot be null");
+    this.supervisorId = Preconditions.checkNotNull(
+        Configs.valueOrDefault(supervisorId, dataSource),
+        "supervisorId cannot be null"
+    );
     this.resetMetadata = resetMetadata;
   }
 
@@ -42,6 +52,12 @@ public class ResetDataSourceMetadataAction implements TaskAction<Boolean>
   public String getDataSource()
   {
     return dataSource;
+  }
+
+  @JsonProperty
+  public String getSupervisorId()
+  {
+    return supervisorId;
   }
 
   @JsonProperty
@@ -61,7 +77,7 @@ public class ResetDataSourceMetadataAction implements TaskAction<Boolean>
   @Override
   public Boolean perform(Task task, TaskActionToolbox toolbox)
   {
-    return toolbox.getSupervisorManager().resetSupervisor(dataSource, resetMetadata);
+    return toolbox.getSupervisorManager().resetSupervisor(supervisorId, resetMetadata);
   }
 
   @Override
@@ -75,6 +91,7 @@ public class ResetDataSourceMetadataAction implements TaskAction<Boolean>
   {
     return "ResetDataSourceMetadataAction{" +
            "dataSource='" + dataSource + '\'' +
+           ", supervisorId='" + supervisorId + '\'' +
            ", resetMetadata=" + resetMetadata +
            '}';
   }

--- a/indexing-service/src/main/java/org/apache/druid/indexing/common/actions/SegmentInsertAction.java
+++ b/indexing-service/src/main/java/org/apache/druid/indexing/common/actions/SegmentInsertAction.java
@@ -82,7 +82,7 @@ public class SegmentInsertAction implements TaskAction<Set<DataSegment>>
   @Override
   public Set<DataSegment> perform(Task task, TaskActionToolbox toolbox)
   {
-    return SegmentTransactionalInsertAction.appendAction(segments, null, null, segmentSchemaMapping).perform(task, toolbox).getSegments();
+    return SegmentTransactionalInsertAction.appendAction(segments, null, null, null, null, segmentSchemaMapping).perform(task, toolbox).getSegments();
   }
 
   @Override

--- a/indexing-service/src/main/java/org/apache/druid/indexing/common/actions/SegmentTransactionalAppendAction.java
+++ b/indexing-service/src/main/java/org/apache/druid/indexing/common/actions/SegmentTransactionalAppendAction.java
@@ -31,6 +31,7 @@ import org.apache.druid.indexing.common.task.PendingSegmentAllocatingTask;
 import org.apache.druid.indexing.common.task.Task;
 import org.apache.druid.indexing.overlord.CriticalAction;
 import org.apache.druid.indexing.overlord.DataSourceMetadata;
+import org.apache.druid.indexing.overlord.IndexerMetadataStorageCoordinator;
 import org.apache.druid.indexing.overlord.SegmentPublishResult;
 import org.apache.druid.metadata.ReplaceTaskLock;
 import org.apache.druid.segment.SegmentSchemaMapping;
@@ -105,14 +106,9 @@ public class SegmentTransactionalAppendAction implements TaskAction<SegmentPubli
     } else {
       this.supervisorId = supervisorId;
     }
-
-    if ((startMetadata == null && endMetadata != null)
-        || (startMetadata != null && endMetadata == null)) {
-      throw InvalidInput.exception("startMetadata and endMetadata must either be both null or both non-null.");
-    } else if (startMetadata != null && supervisorId == null) {
-      throw InvalidInput.exception("supervisorId cannot be null if startMetadata and endMetadata are both non-null.");
-    }
     this.segmentSchemaMapping = segmentSchemaMapping;
+
+    IndexerMetadataStorageCoordinator.validateDataSourceMetadata(supervisorId, startMetadata, endMetadata);
   }
 
   @Nullable

--- a/indexing-service/src/main/java/org/apache/druid/indexing/common/actions/SegmentTransactionalAppendAction.java
+++ b/indexing-service/src/main/java/org/apache/druid/indexing/common/actions/SegmentTransactionalAppendAction.java
@@ -67,26 +67,30 @@ public class SegmentTransactionalAppendAction implements TaskAction<SegmentPubli
   @Nullable
   private final DataSourceMetadata endMetadata;
   @Nullable
+  private final String supervisorId;
+  @Nullable
   private final SegmentSchemaMapping segmentSchemaMapping;
 
   public static SegmentTransactionalAppendAction forSegments(Set<DataSegment> segments, SegmentSchemaMapping segmentSchemaMapping)
   {
-    return new SegmentTransactionalAppendAction(segments, null, null, segmentSchemaMapping);
+    return new SegmentTransactionalAppendAction(segments, null, null, null, segmentSchemaMapping);
   }
 
   public static SegmentTransactionalAppendAction forSegmentsAndMetadata(
       Set<DataSegment> segments,
+      String supervisorId,
       DataSourceMetadata startMetadata,
       DataSourceMetadata endMetadata,
       SegmentSchemaMapping segmentSchemaMapping
   )
   {
-    return new SegmentTransactionalAppendAction(segments, startMetadata, endMetadata, segmentSchemaMapping);
+    return new SegmentTransactionalAppendAction(segments, supervisorId, startMetadata, endMetadata, segmentSchemaMapping);
   }
 
   @JsonCreator
   private SegmentTransactionalAppendAction(
       @JsonProperty("segments") Set<DataSegment> segments,
+      @JsonProperty("supervisorId") @Nullable String supervisorId,
       @JsonProperty("startMetadata") @Nullable DataSourceMetadata startMetadata,
       @JsonProperty("endMetadata") @Nullable DataSourceMetadata endMetadata,
       @JsonProperty("segmentSchemaMapping") @Nullable SegmentSchemaMapping segmentSchemaMapping
@@ -96,11 +100,26 @@ public class SegmentTransactionalAppendAction implements TaskAction<SegmentPubli
     this.startMetadata = startMetadata;
     this.endMetadata = endMetadata;
 
+    if (supervisorId == null && !segments.isEmpty()) {
+      this.supervisorId = segments.stream().findFirst().get().getDataSource();
+    } else {
+      this.supervisorId = supervisorId;
+    }
+
     if ((startMetadata == null && endMetadata != null)
         || (startMetadata != null && endMetadata == null)) {
       throw InvalidInput.exception("startMetadata and endMetadata must either be both null or both non-null.");
+    } else if (startMetadata != null && supervisorId == null) {
+      throw InvalidInput.exception("supervisorId cannot be null if startMetadata and endMetadata are both non-null.");
     }
     this.segmentSchemaMapping = segmentSchemaMapping;
+  }
+
+  @Nullable
+  @JsonProperty
+  public String getSupervisorId()
+  {
+    return supervisorId;
   }
 
   @JsonProperty
@@ -178,6 +197,7 @@ public class SegmentTransactionalAppendAction implements TaskAction<SegmentPubli
       publishAction = () -> toolbox.getIndexerMetadataStorageCoordinator().commitAppendSegmentsAndMetadata(
           segments,
           segmentToReplaceLock,
+          supervisorId,
           startMetadata,
           endMetadata,
           taskAllocatorId,
@@ -219,6 +239,7 @@ public class SegmentTransactionalAppendAction implements TaskAction<SegmentPubli
   public String toString()
   {
     return "SegmentTransactionalAppendAction{" +
+           "supervisorId='" + supervisorId + '\'' +
            "segments=" + SegmentUtils.commaSeparatedIdentifiers(segments) +
            '}';
   }

--- a/indexing-service/src/main/java/org/apache/druid/indexing/common/actions/SegmentTransactionalInsertAction.java
+++ b/indexing-service/src/main/java/org/apache/druid/indexing/common/actions/SegmentTransactionalInsertAction.java
@@ -25,7 +25,6 @@ import com.fasterxml.jackson.core.type.TypeReference;
 import com.google.common.base.Preconditions;
 import com.google.common.collect.ImmutableSet;
 import org.apache.druid.common.config.Configs;
-import org.apache.druid.error.InvalidInput;
 import org.apache.druid.indexing.common.LockGranularity;
 import org.apache.druid.indexing.common.TaskLock;
 import org.apache.druid.indexing.common.task.IndexTaskUtils;
@@ -33,6 +32,7 @@ import org.apache.druid.indexing.common.task.Task;
 import org.apache.druid.indexing.common.task.TaskLockHelper;
 import org.apache.druid.indexing.overlord.CriticalAction;
 import org.apache.druid.indexing.overlord.DataSourceMetadata;
+import org.apache.druid.indexing.overlord.IndexerMetadataStorageCoordinator;
 import org.apache.druid.indexing.overlord.SegmentPublishResult;
 import org.apache.druid.java.util.common.ISE;
 import org.apache.druid.segment.SegmentSchemaMapping;
@@ -135,12 +135,7 @@ public class SegmentTransactionalInsertAction implements TaskAction<SegmentPubli
     this.supervisorId = Configs.valueOrDefault(supervisorId, dataSource);
     this.segmentSchemaMapping = segmentSchemaMapping;
 
-    if ((startMetadata == null && endMetadata != null)
-        || (startMetadata != null && endMetadata == null)) {
-      throw InvalidInput.exception("startMetadata and endMetadata must either be both null or both non-null.");
-    } else if (startMetadata != null && supervisorId == null) {
-      throw InvalidInput.exception("supervisorId cannot be null if startMetadata and endMetadata are both non-null.");
-    }
+    IndexerMetadataStorageCoordinator.validateDataSourceMetadata(supervisorId, startMetadata, endMetadata);
   }
 
   @JsonProperty

--- a/indexing-service/src/main/java/org/apache/druid/indexing/common/actions/SegmentTransactionalInsertAction.java
+++ b/indexing-service/src/main/java/org/apache/druid/indexing/common/actions/SegmentTransactionalInsertAction.java
@@ -24,6 +24,8 @@ import com.fasterxml.jackson.annotation.JsonProperty;
 import com.fasterxml.jackson.core.type.TypeReference;
 import com.google.common.base.Preconditions;
 import com.google.common.collect.ImmutableSet;
+import org.apache.druid.common.config.Configs;
+import org.apache.druid.error.InvalidInput;
 import org.apache.druid.indexing.common.LockGranularity;
 import org.apache.druid.indexing.common.TaskLock;
 import org.apache.druid.indexing.common.task.IndexTaskUtils;
@@ -71,6 +73,8 @@ public class SegmentTransactionalInsertAction implements TaskAction<SegmentPubli
   @Nullable
   private final String dataSource;
   @Nullable
+  private final String supervisorId;
+  @Nullable
   private final SegmentSchemaMapping segmentSchemaMapping;
 
   public static SegmentTransactionalInsertAction overwriteAction(
@@ -85,27 +89,31 @@ public class SegmentTransactionalInsertAction implements TaskAction<SegmentPubli
         null,
         null,
         null,
+        null,
         segmentSchemaMapping
     );
   }
 
   public static SegmentTransactionalInsertAction appendAction(
       Set<DataSegment> segments,
+      @Nullable String supervisorId,
+      @Nullable String dataSource,
       @Nullable DataSourceMetadata startMetadata,
       @Nullable DataSourceMetadata endMetadata,
       @Nullable SegmentSchemaMapping segmentSchemaMapping
   )
   {
-    return new SegmentTransactionalInsertAction(null, segments, startMetadata, endMetadata, null, segmentSchemaMapping);
+    return new SegmentTransactionalInsertAction(null, segments, startMetadata, endMetadata, supervisorId, dataSource, segmentSchemaMapping);
   }
 
   public static SegmentTransactionalInsertAction commitMetadataOnlyAction(
+      String supervisorId,
       String dataSource,
       DataSourceMetadata startMetadata,
       DataSourceMetadata endMetadata
   )
   {
-    return new SegmentTransactionalInsertAction(null, null, startMetadata, endMetadata, dataSource, null);
+    return new SegmentTransactionalInsertAction(null, null, startMetadata, endMetadata, supervisorId, dataSource, null);
   }
 
   @JsonCreator
@@ -114,6 +122,7 @@ public class SegmentTransactionalInsertAction implements TaskAction<SegmentPubli
       @JsonProperty("segments") @Nullable Set<DataSegment> segments,
       @JsonProperty("startMetadata") @Nullable DataSourceMetadata startMetadata,
       @JsonProperty("endMetadata") @Nullable DataSourceMetadata endMetadata,
+      @JsonProperty("supervisorId") @Nullable String supervisorId,
       @JsonProperty("dataSource") @Nullable String dataSource,
       @JsonProperty("segmentSchemaMapping") @Nullable SegmentSchemaMapping segmentSchemaMapping
   )
@@ -123,7 +132,15 @@ public class SegmentTransactionalInsertAction implements TaskAction<SegmentPubli
     this.startMetadata = startMetadata;
     this.endMetadata = endMetadata;
     this.dataSource = dataSource;
+    this.supervisorId = Configs.valueOrDefault(supervisorId, dataSource);
     this.segmentSchemaMapping = segmentSchemaMapping;
+
+    if ((startMetadata == null && endMetadata != null)
+        || (startMetadata != null && endMetadata == null)) {
+      throw InvalidInput.exception("startMetadata and endMetadata must either be both null or both non-null.");
+    } else if (startMetadata != null && supervisorId == null) {
+      throw InvalidInput.exception("supervisorId cannot be null if startMetadata and endMetadata are both non-null.");
+    }
   }
 
   @JsonProperty
@@ -162,6 +179,13 @@ public class SegmentTransactionalInsertAction implements TaskAction<SegmentPubli
 
   @JsonProperty
   @Nullable
+  public String getSupervisorId()
+  {
+    return supervisorId;
+  }
+
+  @JsonProperty
+  @Nullable
   public SegmentSchemaMapping getSegmentSchemaMapping()
   {
     return segmentSchemaMapping;
@@ -188,6 +212,7 @@ public class SegmentTransactionalInsertAction implements TaskAction<SegmentPubli
       // but still needs to update metadata with the progress that the task made.
       try {
         retVal = toolbox.getIndexerMetadataStorageCoordinator().commitMetadataOnly(
+            supervisorId,
             dataSource,
             startMetadata,
             endMetadata
@@ -222,6 +247,7 @@ public class SegmentTransactionalInsertAction implements TaskAction<SegmentPubli
               .onValidLocks(
                   () -> toolbox.getIndexerMetadataStorageCoordinator().commitSegmentsAndMetadata(
                       segments,
+                      supervisorId,
                       startMetadata,
                       endMetadata,
                       segmentSchemaMapping
@@ -317,6 +343,8 @@ public class SegmentTransactionalInsertAction implements TaskAction<SegmentPubli
     return "SegmentTransactionalInsertAction{" +
            "segmentsToBeOverwritten=" + SegmentUtils.commaSeparatedIdentifiers(segmentsToBeOverwritten) +
            ", segments=" + SegmentUtils.commaSeparatedIdentifiers(segments) +
+           ", dataSource=" + dataSource +
+           ", supervisorId=" + supervisorId +
            ", startMetadata=" + startMetadata +
            ", endMetadata=" + endMetadata +
            ", dataSource='" + dataSource + '\'' +

--- a/indexing-service/src/main/java/org/apache/druid/indexing/common/task/AppenderatorDriverRealtimeIndexTask.java
+++ b/indexing-service/src/main/java/org/apache/druid/indexing/common/task/AppenderatorDriverRealtimeIndexTask.java
@@ -370,6 +370,8 @@ public class AppenderatorDriverRealtimeIndexTask extends AbstractTask
             segments,
             null,
             null,
+            null,
+            null,
             null
         );
         return toolbox.getTaskActionClient().submit(action);

--- a/indexing-service/src/main/java/org/apache/druid/indexing/overlord/setup/WorkerCategorySpec.java
+++ b/indexing-service/src/main/java/org/apache/druid/indexing/overlord/setup/WorkerCategorySpec.java
@@ -21,7 +21,9 @@ package org.apache.druid.indexing.overlord.setup;
 
 import com.fasterxml.jackson.annotation.JsonCreator;
 import com.fasterxml.jackson.annotation.JsonProperty;
+import org.apache.druid.common.config.Configs;
 
+import javax.annotation.Nullable;
 import java.util.Collections;
 import java.util.Map;
 import java.util.Objects;
@@ -86,17 +88,19 @@ public class WorkerCategorySpec
   public static class CategoryConfig
   {
     private final String defaultCategory;
-    // key: datasource, value: category
     private final Map<String, String> categoryAffinity;
+    private final Map<String, String> supervisorIdCategoryAffinity;
 
     @JsonCreator
     public CategoryConfig(
         @JsonProperty("defaultCategory") String defaultCategory,
-        @JsonProperty("categoryAffinity") Map<String, String> categoryAffinity
+        @JsonProperty("categoryAffinity") Map<String, String> categoryAffinity,
+        @JsonProperty("supervisorIdCategoryAffinity") @Nullable Map<String, String> supervisorIdCategoryAffinity
     )
     {
       this.defaultCategory = defaultCategory;
       this.categoryAffinity = categoryAffinity == null ? Collections.emptyMap() : categoryAffinity;
+      this.supervisorIdCategoryAffinity = Configs.valueOrDefault(supervisorIdCategoryAffinity, Collections.emptyMap());
     }
 
     @JsonProperty
@@ -105,10 +109,23 @@ public class WorkerCategorySpec
       return defaultCategory;
     }
 
+    /**
+     * Returns a map from datasource name to the worker category name to be used for tasks of that datasource.
+     */
     @JsonProperty
     public Map<String, String> getCategoryAffinity()
     {
       return categoryAffinity;
+    }
+
+    /**
+     * Returns a map from supervisor ID to worker category name to be used for tasks of that supervisor.
+     * This takes precedence over {@link #getCategoryAffinity()} when both are configured.
+     */
+    @JsonProperty
+    public Map<String, String> getSupervisorIdCategoryAffinity()
+    {
+      return supervisorIdCategoryAffinity;
     }
 
     @Override
@@ -122,13 +139,14 @@ public class WorkerCategorySpec
       }
       final CategoryConfig that = (CategoryConfig) o;
       return Objects.equals(defaultCategory, that.defaultCategory) &&
-             Objects.equals(categoryAffinity, that.categoryAffinity);
+             Objects.equals(categoryAffinity, that.categoryAffinity) &&
+             Objects.equals(supervisorIdCategoryAffinity, that.supervisorIdCategoryAffinity);
     }
 
     @Override
     public int hashCode()
     {
-      return Objects.hash(defaultCategory, categoryAffinity);
+      return Objects.hash(defaultCategory, categoryAffinity, supervisorIdCategoryAffinity);
     }
 
     @Override
@@ -137,6 +155,7 @@ public class WorkerCategorySpec
       return "CategoryConfig{" +
              "defaultCategory=" + defaultCategory +
              ", categoryAffinity=" + categoryAffinity +
+             ", supervisorIdCategoryAffinity=" + supervisorIdCategoryAffinity +
              '}';
     }
   }

--- a/indexing-service/src/main/java/org/apache/druid/indexing/overlord/setup/WorkerSelectUtils.java
+++ b/indexing-service/src/main/java/org/apache/druid/indexing/overlord/setup/WorkerSelectUtils.java
@@ -24,6 +24,7 @@ import com.google.common.collect.Maps;
 import org.apache.druid.indexing.common.task.Task;
 import org.apache.druid.indexing.overlord.ImmutableWorkerInfo;
 import org.apache.druid.indexing.overlord.config.WorkerTaskRunnerConfig;
+import org.apache.druid.indexing.seekablestream.SeekableStreamIndexTask;
 
 import javax.annotation.Nullable;
 import java.util.Map;
@@ -117,10 +118,25 @@ public class WorkerSelectUtils
       if (categoryConfig != null) {
         final String defaultCategory = categoryConfig.getDefaultCategory();
         final Map<String, String> categoryAffinity = categoryConfig.getCategoryAffinity();
+        final Map<String, String> supervisorIdCategoryAffinity = categoryConfig.getSupervisorIdCategoryAffinity();
 
-        String preferredCategory = categoryAffinity.get(task.getDataSource());
-        // If there is no preferred category for the datasource, then using the defaultCategory. However, the defaultCategory
-        // may be null too, so we need to do one more null check (see below).
+        String preferredCategory = null;
+        
+        // First, check if this task has a supervisorId and if there's a category affinity for it
+        if (task instanceof SeekableStreamIndexTask) {
+          final String supervisorId = ((SeekableStreamIndexTask<?, ?, ?>) task).getSupervisorId();
+          if (supervisorId != null) {
+            preferredCategory = supervisorIdCategoryAffinity.get(supervisorId);
+          }
+        }
+        
+        // If no supervisor-based category is found, fall back to datasource-based category affinity
+        if (preferredCategory == null) {
+          preferredCategory = categoryAffinity.get(task.getDataSource());
+        }
+        
+        // If there is no preferred category for the supervisorId or datasource, then use the defaultCategory.
+        // However, the defaultCategory may be null too, so we need to do one more null check (see below).
         preferredCategory = preferredCategory == null ? defaultCategory : preferredCategory;
 
         if (preferredCategory != null) {

--- a/indexing-service/src/main/java/org/apache/druid/indexing/overlord/supervisor/SupervisorResource.java
+++ b/indexing-service/src/main/java/org/apache/druid/indexing/overlord/supervisor/SupervisorResource.java
@@ -214,7 +214,8 @@ public class SupervisorResource
                   if (includeFull) {
                     Optional<SupervisorSpec> theSpec = manager.getSupervisorSpec(x);
                     if (theSpec.isPresent()) {
-                      theBuilder.withSpec(manager.getSupervisorSpec(x).get());
+                      theBuilder.withSpec(theSpec.get())
+                          .withDataSource(theSpec.get().getDataSources().stream().findFirst().orElse(null));
                     }
                   }
                   if (includeSystem) {

--- a/indexing-service/src/main/java/org/apache/druid/indexing/overlord/supervisor/SupervisorResource.java
+++ b/indexing-service/src/main/java/org/apache/druid/indexing/overlord/supervisor/SupervisorResource.java
@@ -211,30 +211,28 @@ public class SupervisorResource
                               .withDetailedState(theState.get().toString())
                               .withHealthy(theState.get().isHealthy());
                   }
-                  if (includeFull) {
-                    Optional<SupervisorSpec> theSpec = manager.getSupervisorSpec(x);
-                    if (theSpec.isPresent()) {
-                      theBuilder.withSpec(theSpec.get())
-                          .withDataSource(theSpec.get().getDataSources().stream().findFirst().orElse(null));
+                  Optional<SupervisorSpec> theSpec = manager.getSupervisorSpec(x);
+                  if (theSpec.isPresent()) {
+                    final SupervisorSpec spec = theSpec.get();
+                    theBuilder.withDataSource(spec.getDataSources().stream().findFirst().orElse(null));
+                    if (includeFull) {
+                      theBuilder.withSpec(spec);
                     }
-                  }
-                  if (includeSystem) {
-                    Optional<SupervisorSpec> theSpec = manager.getSupervisorSpec(x);
-                    if (theSpec.isPresent()) {
+                    if (includeSystem) {
                       try {
                         // serializing SupervisorSpec here, so that callers of `druid/indexer/v1/supervisor?system`
                         // which are outside the overlord process can deserialize the response and get a json
                         // payload of SupervisorSpec object when they don't have guice bindings for all the fields
                         // for example, broker does not have bindings for all fields of `KafkaSupervisorSpec` or
                         // `KinesisSupervisorSpec`
-                        theBuilder.withSpecString(objectMapper.writeValueAsString(manager.getSupervisorSpec(x).get()));
+                        theBuilder.withSpecString(objectMapper.writeValueAsString(spec));
                       }
                       catch (JsonProcessingException e) {
                         throw new RuntimeException(e);
                       }
-                      theBuilder.withType(manager.getSupervisorSpec(x).get().getType())
-                                .withSource(manager.getSupervisorSpec(x).get().getSource())
-                                .withSuspended(manager.getSupervisorSpec(x).get().isSuspended());
+                      theBuilder.withType(spec.getType())
+                                .withSource(spec.getSource())
+                                .withSuspended(spec.isSuspended());
                     }
                   }
                   return theBuilder.build();

--- a/indexing-service/src/main/java/org/apache/druid/indexing/seekablestream/SeekableStreamIndexTask.java
+++ b/indexing-service/src/main/java/org/apache/druid/indexing/seekablestream/SeekableStreamIndexTask.java
@@ -138,6 +138,10 @@ public abstract class SeekableStreamIndexTask<PartitionIdType, SequenceOffsetTyp
     return dataSchema;
   }
 
+  /**
+   * Returns the supervisor ID of the supervisor this task belongs to.
+   * If null/unspecified, this defaults to the datasource name.
+   */
   @JsonProperty
   public String getSupervisorId()
   {

--- a/indexing-service/src/main/java/org/apache/druid/indexing/seekablestream/SeekableStreamIndexTask.java
+++ b/indexing-service/src/main/java/org/apache/druid/indexing/seekablestream/SeekableStreamIndexTask.java
@@ -24,6 +24,7 @@ import com.google.common.annotations.VisibleForTesting;
 import com.google.common.base.Preconditions;
 import com.google.common.base.Supplier;
 import com.google.common.base.Suppliers;
+import org.apache.druid.common.config.Configs;
 import org.apache.druid.data.input.InputRow;
 import org.apache.druid.data.input.impl.ByteEntity;
 import org.apache.druid.indexer.TaskStatus;
@@ -73,6 +74,7 @@ public abstract class SeekableStreamIndexTask<PartitionIdType, SequenceOffsetTyp
   protected final Map<String, Object> context;
   protected final LockGranularity lockGranularityToUse;
   protected final TaskLockType lockTypeToUse;
+  protected final String supervisorId;
 
   // Lazily initialized, to avoid calling it on the overlord when tasks are instantiated.
   // See https://github.com/apache/druid/issues/7724 for issues that can cause.
@@ -84,6 +86,7 @@ public abstract class SeekableStreamIndexTask<PartitionIdType, SequenceOffsetTyp
 
   public SeekableStreamIndexTask(
       final String id,
+      final @Nullable String supervisorId,
       @Nullable final TaskResource taskResource,
       final DataSchema dataSchema,
       final SeekableStreamIndexTaskTuningConfig tuningConfig,
@@ -109,11 +112,12 @@ public abstract class SeekableStreamIndexTask<PartitionIdType, SequenceOffsetTyp
                                 ? LockGranularity.TIME_CHUNK
                                 : LockGranularity.SEGMENT;
     this.lockTypeToUse = TaskLocks.determineLockTypeForAppend(getContext());
+    this.supervisorId = Preconditions.checkNotNull(Configs.valueOrDefault(supervisorId, dataSchema.getDataSource()), "supervisorId");
   }
 
-  protected static String getFormattedGroupId(String dataSource, String type)
+  protected static String getFormattedGroupId(String supervisorId, String type)
   {
-    return StringUtils.format("%s_%s", type, dataSource);
+    return StringUtils.format("%s_%s", type, supervisorId);
   }
 
   @Override
@@ -132,6 +136,12 @@ public abstract class SeekableStreamIndexTask<PartitionIdType, SequenceOffsetTyp
   public DataSchema getDataSchema()
   {
     return dataSchema;
+  }
+
+  @JsonProperty
+  public String getSupervisorId()
+  {
+    return supervisorId;
   }
 
   @JsonProperty

--- a/indexing-service/src/main/java/org/apache/druid/indexing/seekablestream/SeekableStreamIndexTaskRunner.java
+++ b/indexing-service/src/main/java/org/apache/druid/indexing/seekablestream/SeekableStreamIndexTaskRunner.java
@@ -298,6 +298,20 @@ public abstract class SeekableStreamIndexTaskRunner<PartitionIdType, SequenceOff
     }
   }
 
+  /**
+   * Returns the supervisorId for the task this runner is executing.
+   * Backwards compatibility: if task spec from metadata has a null supervisorId field, falls back to dataSource
+  */
+  public String getSupervisorId()
+  {
+    @Nullable
+    final String supervisorId = task.getSupervisorId();
+    if (supervisorId != null) {
+      return supervisorId;
+    }
+    return task.getDataSource();
+  }
+
   @VisibleForTesting
   public void setToolbox(TaskToolbox toolbox)
   {
@@ -765,7 +779,7 @@ public abstract class SeekableStreamIndexTaskRunner<PartitionIdType, SequenceOff
             );
             requestPause();
             final CheckPointDataSourceMetadataAction checkpointAction = new CheckPointDataSourceMetadataAction(
-                task.getDataSource(),
+                getSupervisorId(),
                 ioConfig.getTaskGroupId(),
                 null,
                 createDataSourceMetadata(
@@ -1401,6 +1415,7 @@ public abstract class SeekableStreamIndexTaskRunner<PartitionIdType, SequenceOff
         .getTaskActionClient()
         .submit(
             new ResetDataSourceMetadataAction(
+                getSupervisorId(),
                 task.getDataSource(),
                 createDataSourceMetadata(
                     new SeekableStreamEndSequenceNumbers<>(

--- a/indexing-service/src/main/java/org/apache/druid/indexing/seekablestream/SeekableStreamIndexTaskRunner.java
+++ b/indexing-service/src/main/java/org/apache/druid/indexing/seekablestream/SeekableStreamIndexTaskRunner.java
@@ -304,12 +304,7 @@ public abstract class SeekableStreamIndexTaskRunner<PartitionIdType, SequenceOff
   */
   public String getSupervisorId()
   {
-    @Nullable
-    final String supervisorId = task.getSupervisorId();
-    if (supervisorId != null) {
-      return supervisorId;
-    }
-    return task.getDataSource();
+    return task.getSupervisorId();
   }
 
   @VisibleForTesting

--- a/indexing-service/src/main/java/org/apache/druid/indexing/seekablestream/SequenceMetadata.java
+++ b/indexing-service/src/main/java/org/apache/druid/indexing/seekablestream/SequenceMetadata.java
@@ -404,6 +404,7 @@ public class SequenceMetadata<PartitionIdType, SequenceOffsetType>
               finalPartitions
           );
           action = SegmentTransactionalInsertAction.commitMetadataOnlyAction(
+              runner.getSupervisorId(),
               runner.getAppenderator().getDataSource(),
               runner.createDataSourceMetadata(startPartitions),
               runner.createDataSourceMetadata(finalPartitions)
@@ -419,16 +420,14 @@ public class SequenceMetadata<PartitionIdType, SequenceOffsetType>
         );
         final DataSourceMetadata endMetadata = runner.createDataSourceMetadata(finalPartitions);
         action = taskLockType == TaskLockType.APPEND
-                 ? SegmentTransactionalAppendAction.forSegmentsAndMetadata(segmentsToPush, startMetadata, endMetadata,
-                                                                           segmentSchemaMapping
-        )
-                 : SegmentTransactionalInsertAction.appendAction(segmentsToPush, startMetadata, endMetadata,
-                                                                 segmentSchemaMapping
-                 );
+                 ? SegmentTransactionalAppendAction
+                     .forSegmentsAndMetadata(segmentsToPush, runner.getSupervisorId(), startMetadata, endMetadata, segmentSchemaMapping)
+                 : SegmentTransactionalInsertAction
+                     .appendAction(segmentsToPush, runner.getSupervisorId(), runner.getAppenderator().getDataSource(), startMetadata, endMetadata, segmentSchemaMapping);
       } else {
         action = taskLockType == TaskLockType.APPEND
                  ? SegmentTransactionalAppendAction.forSegments(segmentsToPush, segmentSchemaMapping)
-                 : SegmentTransactionalInsertAction.appendAction(segmentsToPush, null, null, segmentSchemaMapping);
+                 : SegmentTransactionalInsertAction.appendAction(segmentsToPush, runner.getSupervisorId(), runner.getAppenderator().getDataSource(), null, null, segmentSchemaMapping);
       }
 
       return toolbox.getTaskActionClient().submit(action);

--- a/indexing-service/src/main/java/org/apache/druid/indexing/seekablestream/supervisor/SeekableStreamSupervisor.java
+++ b/indexing-service/src/main/java/org/apache/druid/indexing/seekablestream/supervisor/SeekableStreamSupervisor.java
@@ -434,24 +434,26 @@ public abstract class SeekableStreamSupervisor<PartitionIdType, SequenceOffsetTy
           if (spec.isSuspended()) {
             log.info(
                 "Skipping DynamicAllocationTasksNotice execution because [%s] supervisor is suspended",
-                dataSource
+                supervisorId
             );
             return;
           }
           if (SupervisorStateManager.BasicState.IDLE == getState()) {
             log.info(
                 "Skipping DynamicAllocationTasksNotice execution because [%s] supervisor is idle",
-                dataSource
+                supervisorId
             );
             return;
           }
-          log.debug("PendingCompletionTaskGroups is [%s] for dataSource [%s]", pendingCompletionTaskGroups,
+          log.debug("PendingCompletionTaskGroups is [%s] for supervisor[%s] for dataSource[%s]", pendingCompletionTaskGroups,
+                    supervisorId,
                     dataSource
           );
           for (CopyOnWriteArrayList<TaskGroup> list : pendingCompletionTaskGroups.values()) {
             if (!list.isEmpty()) {
               log.info(
-                  "Skipping DynamicAllocationTasksNotice execution for datasource [%s] because following tasks are pending [%s]",
+                  "Skipping DynamicAllocationTasksNotice execution for supervisor[%s] for datasource[%s] because following tasks are pending [%s]",
+                  supervisorId,
                   dataSource,
                   pendingCompletionTaskGroups
               );
@@ -460,13 +462,15 @@ public abstract class SeekableStreamSupervisor<PartitionIdType, SequenceOffsetTy
           }
           final Integer desiredTaskCount = scaleAction.call();
           ServiceMetricEvent.Builder event = ServiceMetricEvent.builder()
-              .setDimension(DruidMetrics.DATASOURCE, dataSource)
+                                                               .setDimension(DruidMetrics.SUPERVISOR_ID, supervisorId)
+                                                               .setDimension(DruidMetrics.DATASOURCE, dataSource)
               .setDimension(DruidMetrics.STREAM, getIoConfig().getStream());
           if (nowTime - dynamicTriggerLastRunTime < autoScalerConfig.getMinTriggerScaleActionFrequencyMillis()) {
             log.info(
-                "DynamicAllocationTasksNotice submitted again in [%d] millis, minTriggerDynamicFrequency is [%s] for dataSource [%s], skipping it! desired task count is [%s], active task count is [%s]",
+                "DynamicAllocationTasksNotice submitted again in [%d] millis, minTriggerDynamicFrequency is [%s] for supervisor[%s] for dataSource[%s], skipping it! desired task count is [%s], active task count is [%s]",
                 nowTime - dynamicTriggerLastRunTime,
                 autoScalerConfig.getMinTriggerScaleActionFrequencyMillis(),
+                supervisorId,
                 dataSource,
                 desiredTaskCount,
                 getActiveTaskGroupsCount()
@@ -529,15 +533,16 @@ public abstract class SeekableStreamSupervisor<PartitionIdType, SequenceOffsetTy
       return false;
     } else {
       log.info(
-          "Starting scale action, current active task count is [%d] and desired task count is [%d] for dataSource [%s].",
+          "Starting scale action, current active task count is [%d] and desired task count is [%d] for supervisor[%s] for dataSource[%s].",
           currentActiveTaskCount,
           desiredActiveTaskCount,
+          supervisorId,
           dataSource
       );
       gracefulShutdownInternal();
       changeTaskCountInIOConfig(desiredActiveTaskCount);
       clearAllocationInfo();
-      log.info("Changed taskCount to [%s] for dataSource [%s].", desiredActiveTaskCount, dataSource);
+      log.info("Changed taskCount to [%s] for supervisor[%s] for dataSource[%s].", desiredActiveTaskCount, supervisorId, dataSource);
       return true;
     }
   }
@@ -549,13 +554,13 @@ public abstract class SeekableStreamSupervisor<PartitionIdType, SequenceOffsetTy
       Optional<SupervisorManager> supervisorManager = taskMaster.getSupervisorManager();
       if (supervisorManager.isPresent()) {
         MetadataSupervisorManager metadataSupervisorManager = supervisorManager.get().getMetadataSupervisorManager();
-        metadataSupervisorManager.insert(dataSource, spec);
+        metadataSupervisorManager.insert(supervisorId, spec);
       } else {
-        log.error("supervisorManager is null in taskMaster, skipping scale action for dataSource [%s].", dataSource);
+        log.error("supervisorManager is null in taskMaster, skipping scale action for supervisor[%s] for dataSource[%s].", supervisorId, dataSource);
       }
     }
     catch (Exception e) {
-      log.error(e, "Failed to sync taskCount to MetaStorage for dataSource [%s].", dataSource);
+      log.error(e, "Failed to sync taskCount to MetaStorage for supervisor[%s] for dataSource[%s].", supervisorId, dataSource);
     }
   }
 
@@ -784,6 +789,11 @@ public abstract class SeekableStreamSupervisor<PartitionIdType, SequenceOffsetTy
   private final SeekableStreamSupervisorTuningConfig tuningConfig;
   private final SeekableStreamIndexTaskTuningConfig taskTuningConfig;
   private final String supervisorId;
+
+  /**
+   * Type-verbose id for identifying this supervisor in thread-names, listeners, etc.
+  */
+  private final String supervisorTag;
   private final TaskInfoProvider taskInfoProvider;
   private final long futureTimeoutInSeconds; // how long to wait for async operations to complete
   private final RowIngestionMetersFactory rowIngestionMetersFactory;
@@ -816,7 +826,7 @@ public abstract class SeekableStreamSupervisor<PartitionIdType, SequenceOffsetTy
   private final IdleConfig idleConfig;
 
   public SeekableStreamSupervisor(
-      final String supervisorId,
+      final String supervisorTag,
       final TaskStorage taskStorage,
       final TaskMaster taskMaster,
       final IndexerMetadataStorageCoordinator indexerMetadataStorageCoordinator,
@@ -827,6 +837,7 @@ public abstract class SeekableStreamSupervisor<PartitionIdType, SequenceOffsetTy
       final boolean useExclusiveStartingSequence
   )
   {
+    this.supervisorTag = Preconditions.checkNotNull(supervisorTag, "supervisorTag");
     this.taskStorage = taskStorage;
     this.taskMaster = taskMaster;
     this.indexerMetadataStorageCoordinator = indexerMetadataStorageCoordinator;
@@ -840,10 +851,10 @@ public abstract class SeekableStreamSupervisor<PartitionIdType, SequenceOffsetTy
     this.autoScalerConfig = ioConfig.getAutoScalerConfig();
     this.tuningConfig = spec.getTuningConfig();
     this.taskTuningConfig = this.tuningConfig.convertToTaskTuningConfig();
-    this.supervisorId = supervisorId;
-    this.exec = Execs.singleThreaded(StringUtils.encodeForFormat(supervisorId));
-    this.scheduledExec = Execs.scheduledSingleThreaded(StringUtils.encodeForFormat(supervisorId) + "-Scheduler-%d");
-    this.reportingExec = Execs.scheduledSingleThreaded(StringUtils.encodeForFormat(supervisorId) + "-Reporting-%d");
+    this.supervisorId = spec.getId();
+    this.exec = Execs.singleThreaded(StringUtils.encodeForFormat(supervisorTag));
+    this.scheduledExec = Execs.scheduledSingleThreaded(StringUtils.encodeForFormat(supervisorTag) + "-Scheduler-%d");
+    this.reportingExec = Execs.scheduledSingleThreaded(StringUtils.encodeForFormat(supervisorTag) + "-Reporting-%d");
 
     this.stateManager = new SeekableStreamSupervisorStateManager(
         spec.getSupervisorStateManagerConfig(),
@@ -853,7 +864,7 @@ public abstract class SeekableStreamSupervisor<PartitionIdType, SequenceOffsetTy
     int workerThreads;
     int maxNumTasks;
     if (autoScalerConfig != null && autoScalerConfig.getEnableTaskAutoScaler()) {
-      log.info("Running Task autoscaler for datasource [%s]", dataSource);
+      log.info("Running Task autoscaler for supervisor[%s] for datasource[%s]", supervisorId, dataSource);
 
       workerThreads = (this.tuningConfig.getWorkerThreads() != null
                        ? this.tuningConfig.getWorkerThreads()
@@ -888,10 +899,10 @@ public abstract class SeekableStreamSupervisor<PartitionIdType, SequenceOffsetTy
     this.workerExec = MoreExecutors.listeningDecorator(
         Execs.multiThreaded(
             workerThreads,
-            StringUtils.encodeForFormat(supervisorId) + "-Worker-%d"
+            StringUtils.encodeForFormat(supervisorTag) + "-Worker-%d"
         )
     );
-    log.info("Created worker pool with [%d] threads for dataSource [%s]", workerThreads, this.dataSource);
+    log.info("Created worker pool with [%d] threads for supervisor[%s] for dataSource[%s]", workerThreads, this.supervisorId, this.dataSource);
 
     this.taskInfoProvider = new TaskInfoProvider()
     {
@@ -933,7 +944,7 @@ public abstract class SeekableStreamSupervisor<PartitionIdType, SequenceOffsetTy
   @Override
   public int getActiveTaskGroupsCount()
   {
-    return activelyReadingTaskGroups.values().size();
+    return activelyReadingTaskGroups.size();
   }
 
   @Override
@@ -951,7 +962,7 @@ public abstract class SeekableStreamSupervisor<PartitionIdType, SequenceOffsetTy
         if (!started) {
           log.warn(
               "First initialization attempt failed for SeekableStreamSupervisor[%s], starting retries...",
-              dataSource
+              supervisorId
           );
 
           exec.submit(
@@ -1002,7 +1013,7 @@ public abstract class SeekableStreamSupervisor<PartitionIdType, SequenceOffsetTy
         if (started) {
           Optional<TaskRunner> taskRunner = taskMaster.getTaskRunner();
           if (taskRunner.isPresent()) {
-            taskRunner.get().unregisterListener(supervisorId);
+            taskRunner.get().unregisterListener(supervisorTag);
           }
 
           // Stopping gracefully will synchronize the end sequences of the tasks and signal them to publish, and will block
@@ -1166,15 +1177,15 @@ public abstract class SeekableStreamSupervisor<PartitionIdType, SequenceOffsetTy
                     if (log.isDebugEnabled()) {
                       log.debug(
                           "Handled notice [%s] from notices queue in [%d] ms, "
-                              + "current notices queue size [%d] for datasource [%s]",
-                          noticeType, timeElapsed.toMillis(), getNoticesQueueSize(), dataSource
+                              + "current notices queue size [%d] for supervisor[%s] for datasource[%s]",
+                          noticeType, timeElapsed.toMillis(), getNoticesQueueSize(), supervisorId, dataSource
                       );
                     }
                     emitNoticeProcessTime(noticeType, timeElapsed.toMillis());
                   }
                   catch (Throwable e) {
                     stateManager.recordThrowableEvent(e);
-                    log.makeAlert(e, "SeekableStreamSupervisor[%s] failed to handle notice", dataSource)
+                    log.makeAlert(e, "SeekableStreamSupervisor[%s] for datasource=[%s] failed to handle notice", supervisorId, dataSource)
                        .addData("noticeClass", notice.getClass().getSimpleName())
                        .emit();
                   }
@@ -1182,7 +1193,7 @@ public abstract class SeekableStreamSupervisor<PartitionIdType, SequenceOffsetTy
               }
               catch (InterruptedException e) {
                 stateManager.recordThrowableEvent(e);
-                log.info("SeekableStreamSupervisor[%s] interrupted, exiting", dataSource);
+                log.info("SeekableStreamSupervisor[%s] interrupted, exiting", supervisorId);
               }
             }
         );
@@ -1198,7 +1209,7 @@ public abstract class SeekableStreamSupervisor<PartitionIdType, SequenceOffsetTy
         started = true;
         log.info(
             "Started SeekableStreamSupervisor[%s], first run in [%s], with spec: [%s]",
-            dataSource,
+            supervisorId,
             ioConfig.getStartDelay(),
             spec.toString()
         );
@@ -1209,7 +1220,7 @@ public abstract class SeekableStreamSupervisor<PartitionIdType, SequenceOffsetTy
           recordSupplier.close();
         }
         initRetryCounter++;
-        log.makeAlert(e, "Exception starting SeekableStreamSupervisor[%s]", dataSource)
+        log.makeAlert(e, "Exception starting SeekableStreamSupervisor[%s]", supervisorId)
            .emit();
 
         throw new RuntimeException(e);
@@ -1258,7 +1269,7 @@ public abstract class SeekableStreamSupervisor<PartitionIdType, SequenceOffsetTy
     );
 
     SupervisorReport<SeekableStreamSupervisorReportPayload<PartitionIdType, SequenceOffsetType>> report = new SupervisorReport<>(
-        dataSource,
+        supervisorId,
         DateTimes.nowUtc(),
         payload
     );
@@ -1621,16 +1632,15 @@ public abstract class SeekableStreamSupervisor<PartitionIdType, SequenceOffsetTy
         // if suspended, ensure tasks have been requested to gracefully stop
         if (stateManager.getSupervisorState().getBasicState().equals(SupervisorStateManager.BasicState.STOPPING)) {
           // if we're already terminating, don't do anything here, the terminate already handles shutdown
-          log.info("[%s] supervisor is already stopping.", dataSource);
+          log.debug("Supervisor[%s] for datasource[%s] is already stopping.", supervisorId, dataSource);
         } else if (stateManager.isIdle()) {
-          log.info("[%s] supervisor is idle.", dataSource);
+          log.debug("Supervisor[%s] for datasource[%s] is idle.", supervisorId, dataSource);
         } else if (!spec.isSuspended()) {
-          log.info("[%s] supervisor is running.", dataSource);
-
+          log.debug("Supervisor[%s] for datasource[%s] is running.", supervisorId, dataSource);
           stateManager.maybeSetState(SeekableStreamSupervisorStateManager.SeekableStreamState.CREATING_TASKS);
           createNewTasks();
         } else {
-          log.info("[%s] supervisor is suspended.", dataSource);
+          log.debug("Supervisor[%s] for datasource[%s] is suspended.", supervisorId, dataSource);
           gracefulShutdownInternal();
         }
       }
@@ -1639,7 +1649,7 @@ public abstract class SeekableStreamSupervisor<PartitionIdType, SequenceOffsetTy
     }
     catch (Exception e) {
       stateManager.recordThrowableEvent(e);
-      log.warn(e, "Exception in supervisor run loop for dataSource [%s]", dataSource);
+      log.makeAlert(e, "Exception in supervisor run loop for supervisor[%s] for dataSource[%s]", supervisorId, dataSource).emit();
     }
     finally {
       stateManager.markRunFinished();
@@ -1667,7 +1677,7 @@ public abstract class SeekableStreamSupervisor<PartitionIdType, SequenceOffsetTy
             @Override
             public String getListenerId()
             {
-              return supervisorId;
+              return supervisorTag;
             }
 
             @Override
@@ -1709,8 +1719,8 @@ public abstract class SeekableStreamSupervisor<PartitionIdType, SequenceOffsetTy
   {
     if (dataSourceMetadata == null) {
       // Reset everything
-      boolean result = indexerMetadataStorageCoordinator.deleteDataSourceMetadata(dataSource);
-      log.info("Reset dataSource[%s] - dataSource metadata entry deleted? [%s]", dataSource, result);
+      boolean result = indexerMetadataStorageCoordinator.deleteDataSourceMetadata(supervisorId);
+      log.info("Reset supervisor[%s] for dataSource[%s] - dataSource metadata entry deleted? [%s]", supervisorId, dataSource, result);
       activelyReadingTaskGroups.values()
                                .forEach(group -> killTasksInGroup(
                                    group,
@@ -1726,7 +1736,7 @@ public abstract class SeekableStreamSupervisor<PartitionIdType, SequenceOffsetTy
             dataSourceMetadata.getClass()
         );
       }
-      log.info("Reset dataSource[%s] with metadata[%s]", dataSource, dataSourceMetadata);
+      log.info("Reset supervisor[%s] for dataSource[%s] with metadata[%s]", supervisorId, dataSource, dataSourceMetadata);
       // Reset only the partitions in dataSourceMetadata if it has not been reset yet
       @SuppressWarnings("unchecked")
       final SeekableStreamDataSourceMetadata<PartitionIdType, SequenceOffsetType> resetMetadata =
@@ -1734,7 +1744,7 @@ public abstract class SeekableStreamSupervisor<PartitionIdType, SequenceOffsetTy
 
       if (resetMetadata.getSeekableStreamSequenceNumbers().getStream().equals(ioConfig.getStream())) {
         // metadata can be null
-        final DataSourceMetadata metadata = indexerMetadataStorageCoordinator.retrieveDataSourceMetadata(dataSource);
+        final DataSourceMetadata metadata = indexerMetadataStorageCoordinator.retrieveDataSourceMetadata(supervisorId);
         if (metadata != null && !checkSourceMetadataMatch(metadata)) {
           throw new IAE(
               "Datasource metadata instance does not match required, found instance of [%s]",
@@ -1782,7 +1792,7 @@ public abstract class SeekableStreamSupervisor<PartitionIdType, SequenceOffsetTy
         } else {
           final DataSourceMetadata newMetadata = currentMetadata.minus(resetMetadata);
           try {
-            metadataUpdateSuccess = indexerMetadataStorageCoordinator.resetDataSourceMetadata(dataSource, newMetadata);
+            metadataUpdateSuccess = indexerMetadataStorageCoordinator.resetDataSourceMetadata(supervisorId, newMetadata);
           }
           catch (IOException e) {
             log.error("Resetting DataSourceMetadata failed [%s]", e.getMessage());
@@ -1827,17 +1837,17 @@ public abstract class SeekableStreamSupervisor<PartitionIdType, SequenceOffsetTy
    */
   public void resetOffsetsInternal(@Nonnull final DataSourceMetadata dataSourceMetadata)
   {
-    log.info("Reset offsets for dataSource[%s] with metadata[%s]", dataSource, dataSourceMetadata);
+    log.info("Reset offsets for supervisor[%s] for dataSource[%s] with metadata[%s]", supervisorId, dataSource, dataSourceMetadata);
 
     @SuppressWarnings("unchecked")
     final SeekableStreamDataSourceMetadata<PartitionIdType, SequenceOffsetType> resetMetadata =
         (SeekableStreamDataSourceMetadata<PartitionIdType, SequenceOffsetType>) dataSourceMetadata;
 
     final boolean metadataUpdateSuccess;
-    final DataSourceMetadata metadata = indexerMetadataStorageCoordinator.retrieveDataSourceMetadata(dataSource);
+    final DataSourceMetadata metadata = indexerMetadataStorageCoordinator.retrieveDataSourceMetadata(supervisorId);
     if (metadata == null) {
-      log.info("Checkpointed metadata in null for dataSource[%s] - inserting metadata[%s]", dataSource, resetMetadata);
-      metadataUpdateSuccess = indexerMetadataStorageCoordinator.insertDataSourceMetadata(dataSource, resetMetadata);
+      log.info("Checkpointed metadata in null for supervisor[%s] for dataSource[%s] - inserting metadata[%s]", supervisorId, dataSource, resetMetadata);
+      metadataUpdateSuccess = indexerMetadataStorageCoordinator.insertDataSourceMetadata(supervisorId, resetMetadata);
     } else {
       if (!checkSourceMetadataMatch(metadata)) {
         throw InvalidInput.exception(
@@ -1849,18 +1859,18 @@ public abstract class SeekableStreamSupervisor<PartitionIdType, SequenceOffsetTy
       final SeekableStreamDataSourceMetadata<PartitionIdType, SequenceOffsetType> currentMetadata =
           (SeekableStreamDataSourceMetadata<PartitionIdType, SequenceOffsetType>) metadata;
       final DataSourceMetadata newMetadata = currentMetadata.plus(resetMetadata);
-      log.info("Current checkpointed metadata[%s], new metadata[%s] for dataSource[%s]", currentMetadata, newMetadata, dataSource);
+      log.info("Current checkpointed metadata[%s], new metadata[%s] for supervisor[%s] for dataSource[%s]", currentMetadata, newMetadata, supervisorId, dataSource);
       try {
-        metadataUpdateSuccess = indexerMetadataStorageCoordinator.resetDataSourceMetadata(dataSource, newMetadata);
+        metadataUpdateSuccess = indexerMetadataStorageCoordinator.resetDataSourceMetadata(supervisorId, newMetadata);
       }
       catch (IOException e) {
-        log.error("Reset offsets for dataSource[%s] with metadata[%s] failed [%s]", dataSource, newMetadata, e.getMessage());
+        log.error("Reset offsets for supervisor[%s] for dataSource[%s] with metadata[%s] failed [%s]", supervisorId, dataSource, newMetadata, e.getMessage());
         throw new RuntimeException(e);
       }
     }
 
     if (!metadataUpdateSuccess) {
-      throw new ISE("Unable to reset metadata[%s] for datasource[%s]", dataSource, dataSourceMetadata);
+      throw new ISE("Unable to reset metadata[%s] for supervisor[%s] for dataSource[%s]", supervisorId, dataSource, dataSourceMetadata);
     }
 
     resetMetadata.getSeekableStreamSequenceNumbers()
@@ -1943,7 +1953,7 @@ public abstract class SeekableStreamSupervisor<PartitionIdType, SequenceOffsetTy
     final Map<String, Task> activeTaskMap = getActiveTaskMap();
 
     for (Task task : activeTaskMap.values()) {
-      if (!doesTaskTypeMatchSupervisor(task)) {
+      if (!doesTaskMatchSupervisor(task)) {
         continue;
       }
 
@@ -2146,7 +2156,7 @@ public abstract class SeekableStreamSupervisor<PartitionIdType, SequenceOffsetTy
         stopFutures.add(stopTask(taskId, false));
       }
     }
-    log.debug("Found [%d] seekablestream indexing tasks for datasource[%s]", taskCount, dataSource);
+    log.debug("Found [%d] seekablestream indexing tasks for supervisor[%s] for datasource[%s]", taskCount, supervisorId, dataSource);
 
     if (!stopFutures.isEmpty()) {
       coalesceAndAwait(stopFutures);
@@ -2316,7 +2326,7 @@ public abstract class SeekableStreamSupervisor<PartitionIdType, SequenceOffsetTy
     }
 
     final DataSourceMetadata rawDataSourceMetadata = indexerMetadataStorageCoordinator.retrieveDataSourceMetadata(
-        dataSource);
+        supervisorId);
 
     if (rawDataSourceMetadata != null && !checkSourceMetadataMatch(rawDataSourceMetadata)) {
       throw new IAE(
@@ -2509,7 +2519,7 @@ public abstract class SeekableStreamSupervisor<PartitionIdType, SequenceOffsetTy
             .stream()
             .map(x -> {
               Optional<Task> taskOptional = taskStorage.getTask(x);
-              if (!taskOptional.isPresent() || !doesTaskTypeMatchSupervisor(taskOptional.get())) {
+              if (!taskOptional.isPresent() || !doesTaskMatchSupervisor(taskOptional.get())) {
                 return false;
               }
               @SuppressWarnings("unchecked")
@@ -2567,7 +2577,7 @@ public abstract class SeekableStreamSupervisor<PartitionIdType, SequenceOffsetTy
       genericTask = taskStorage.getTask(taskId).orNull();
     }
 
-    if (genericTask == null || !doesTaskTypeMatchSupervisor(genericTask)) {
+    if (genericTask == null || !doesTaskMatchSupervisor(genericTask)) {
       return false;
     }
 
@@ -2644,7 +2654,7 @@ public abstract class SeekableStreamSupervisor<PartitionIdType, SequenceOffsetTy
                                           + maxMsgTimeStr)
                                  .substring(0, 15);
 
-    return Joiner.on("_").join(baseTaskName(), dataSource, hashCode);
+    return Joiner.on("_").join(baseTaskName(), supervisorId, hashCode);
   }
 
   protected abstract String baseTaskName();
@@ -2893,7 +2903,7 @@ public abstract class SeekableStreamSupervisor<PartitionIdType, SequenceOffsetTy
       @SuppressWarnings("unchecked")
       SeekableStreamDataSourceMetadata<PartitionIdType, SequenceOffsetType> currentMetadata =
           (SeekableStreamDataSourceMetadata<PartitionIdType, SequenceOffsetType>)
-              indexerMetadataStorageCoordinator.retrieveDataSourceMetadata(dataSource);
+              indexerMetadataStorageCoordinator.retrieveDataSourceMetadata(supervisorId);
 
       SeekableStreamDataSourceMetadata<PartitionIdType, SequenceOffsetType> cleanedMetadata =
           createDataSourceMetadataWithExpiredPartitions(currentMetadata, newlyExpiredPartitions);
@@ -2903,7 +2913,7 @@ public abstract class SeekableStreamSupervisor<PartitionIdType, SequenceOffsetTy
       validateMetadataPartitionExpiration(newlyExpiredPartitions, currentMetadata, cleanedMetadata);
 
       try {
-        boolean success = indexerMetadataStorageCoordinator.resetDataSourceMetadata(dataSource, cleanedMetadata);
+        boolean success = indexerMetadataStorageCoordinator.resetDataSourceMetadata(supervisorId, cleanedMetadata);
         if (!success) {
           log.error("Failed to update datasource metadata[%s] with expired partitions removed", cleanedMetadata);
         }
@@ -3903,7 +3913,7 @@ public abstract class SeekableStreamSupervisor<PartitionIdType, SequenceOffsetTy
 
   protected DataSourceMetadata retrieveDataSourceMetadata()
   {
-    return indexerMetadataStorageCoordinator.retrieveDataSourceMetadata(dataSource);
+    return indexerMetadataStorageCoordinator.retrieveDataSourceMetadata(supervisorId);
   }
 
   /**
@@ -4255,7 +4265,7 @@ public abstract class SeekableStreamSupervisor<PartitionIdType, SequenceOffsetTy
    * @param task task
    * @return true if isInstance else false
    */
-  protected abstract boolean doesTaskTypeMatchSupervisor(Task task);
+  protected abstract boolean doesTaskMatchSupervisor(Task task);
 
   /**
    * creates a specific instance of kafka/kinesis datasource metadata. Only used for reset.
@@ -4384,7 +4394,8 @@ public abstract class SeekableStreamSupervisor<PartitionIdType, SequenceOffsetTy
       emitter.emit(
           ServiceMetricEvent.builder()
                             .setDimension("noticeType", noticeType)
-                            .setDimension("dataSource", dataSource)
+                            .setDimension(DruidMetrics.SUPERVISOR_ID, supervisorId)
+                            .setDimension(DruidMetrics.DATASOURCE, dataSource)
                             .setDimensionIfNotNull(DruidMetrics.TAGS, spec.getContextValue(DruidMetrics.TAGS))
                             .setMetric("ingest/notices/time", timeInMillis)
       );
@@ -4403,7 +4414,8 @@ public abstract class SeekableStreamSupervisor<PartitionIdType, SequenceOffsetTy
     try {
       emitter.emit(
           ServiceMetricEvent.builder()
-                            .setDimension("dataSource", dataSource)
+                            .setDimension(DruidMetrics.SUPERVISOR_ID, supervisorId)
+                            .setDimension(DruidMetrics.DATASOURCE, dataSource)
                             .setDimensionIfNotNull(DruidMetrics.TAGS, spec.getContextValue(DruidMetrics.TAGS))
                             .setMetric("ingest/notices/queueSize", getNoticesQueueSize())
       );
@@ -4459,6 +4471,7 @@ public abstract class SeekableStreamSupervisor<PartitionIdType, SequenceOffsetTy
         for (Map.Entry<PartitionIdType, Long> entry : partitionLags.entrySet()) {
           emitter.emit(
               ServiceMetricEvent.builder()
+                                .setDimension(DruidMetrics.SUPERVISOR_ID, supervisorId)
                                 .setDimension(DruidMetrics.DATASOURCE, dataSource)
                                 .setDimension(DruidMetrics.STREAM, getIoConfig().getStream())
                                 .setDimension(DruidMetrics.PARTITION, entry.getKey())
@@ -4471,6 +4484,7 @@ public abstract class SeekableStreamSupervisor<PartitionIdType, SequenceOffsetTy
         }
         emitter.emit(
             ServiceMetricEvent.builder()
+                              .setDimension(DruidMetrics.SUPERVISOR_ID, supervisorId)
                               .setDimension(DruidMetrics.DATASOURCE, dataSource)
                               .setDimension(DruidMetrics.STREAM, getIoConfig().getStream())
                               .setDimensionIfNotNull(DruidMetrics.TAGS, metricTags)
@@ -4478,6 +4492,7 @@ public abstract class SeekableStreamSupervisor<PartitionIdType, SequenceOffsetTy
         );
         emitter.emit(
             ServiceMetricEvent.builder()
+                              .setDimension(DruidMetrics.SUPERVISOR_ID, supervisorId)
                               .setDimension(DruidMetrics.DATASOURCE, dataSource)
                               .setDimension(DruidMetrics.STREAM, getIoConfig().getStream())
                               .setDimensionIfNotNull(DruidMetrics.TAGS, metricTags)
@@ -4485,6 +4500,7 @@ public abstract class SeekableStreamSupervisor<PartitionIdType, SequenceOffsetTy
         );
         emitter.emit(
             ServiceMetricEvent.builder()
+                              .setDimension(DruidMetrics.SUPERVISOR_ID, supervisorId)
                               .setDimension(DruidMetrics.DATASOURCE, dataSource)
                               .setDimension(DruidMetrics.STREAM, getIoConfig().getStream())
                               .setDimensionIfNotNull(DruidMetrics.TAGS, metricTags)

--- a/indexing-service/src/main/java/org/apache/druid/indexing/seekablestream/supervisor/SeekableStreamSupervisor.java
+++ b/indexing-service/src/main/java/org/apache/druid/indexing/seekablestream/supervisor/SeekableStreamSupervisor.java
@@ -791,7 +791,7 @@ public abstract class SeekableStreamSupervisor<PartitionIdType, SequenceOffsetTy
   private final String supervisorId;
 
   /**
-   * Type-verbose id for identifying this supervisor in thread-names, listeners, etc.
+   * Tag for identifying this supervisor in thread-names, listeners, etc. tag = (type + supervisorId).
   */
   private final String supervisorTag;
   private final TaskInfoProvider taskInfoProvider;
@@ -961,8 +961,9 @@ public abstract class SeekableStreamSupervisor<PartitionIdType, SequenceOffsetTy
       catch (Exception e) {
         if (!started) {
           log.warn(
-              "First initialization attempt failed for SeekableStreamSupervisor[%s], starting retries...",
-              supervisorId
+              "First initialization attempt failed for supervisor[%s], dataSource[%s], starting retries...",
+              supervisorId,
+              dataSource
           );
 
           exec.submit(
@@ -1185,7 +1186,7 @@ public abstract class SeekableStreamSupervisor<PartitionIdType, SequenceOffsetTy
                   }
                   catch (Throwable e) {
                     stateManager.recordThrowableEvent(e);
-                    log.makeAlert(e, "SeekableStreamSupervisor[%s] for datasource=[%s] failed to handle notice", supervisorId, dataSource)
+                    log.makeAlert(e, "Supervisor[%s] for datasource[%s] failed to handle notice", supervisorId, dataSource)
                        .addData("noticeClass", notice.getClass().getSimpleName())
                        .emit();
                   }

--- a/indexing-service/src/main/java/org/apache/druid/indexing/seekablestream/supervisor/SeekableStreamSupervisorReportPayload.java
+++ b/indexing-service/src/main/java/org/apache/druid/indexing/seekablestream/supervisor/SeekableStreamSupervisorReportPayload.java
@@ -33,6 +33,7 @@ import java.util.Map;
 @JsonInclude(JsonInclude.Include.NON_NULL)
 public abstract class SeekableStreamSupervisorReportPayload<PartitionIdType, SequenceOffsetType>
 {
+  private final String id;
   private final String dataSource;
   private final String stream;
   private final int partitions;
@@ -53,6 +54,7 @@ public abstract class SeekableStreamSupervisorReportPayload<PartitionIdType, Seq
   private final List<SupervisorStateManager.ExceptionEvent> recentErrors;
 
   public SeekableStreamSupervisorReportPayload(
+      String id,
       String dataSource,
       String stream,
       int partitions,
@@ -71,6 +73,7 @@ public abstract class SeekableStreamSupervisorReportPayload<PartitionIdType, Seq
       List<SupervisorStateManager.ExceptionEvent> recentErrors
   )
   {
+    this.id = id;
     this.dataSource = dataSource;
     this.stream = stream;
     this.partitions = partitions;
@@ -100,6 +103,12 @@ public abstract class SeekableStreamSupervisorReportPayload<PartitionIdType, Seq
     } else {
       throw new IAE("Unknown task type [%s]", data.getType().name());
     }
+  }
+
+  @JsonProperty
+  public String getId()
+  {
+    return id;
   }
 
   @JsonProperty

--- a/indexing-service/src/main/java/org/apache/druid/indexing/seekablestream/supervisor/SeekableStreamSupervisorSpec.java
+++ b/indexing-service/src/main/java/org/apache/druid/indexing/seekablestream/supervisor/SeekableStreamSupervisorSpec.java
@@ -157,6 +157,10 @@ public abstract class SeekableStreamSupervisorSpec implements SupervisorSpec
     return emitter;
   }
 
+  /**
+   * Returns the identifier for this supervisor.
+   * If unspecified, defaults to the dataSource being written to.
+   */
   @Override
   @JsonProperty
   public String getId()

--- a/indexing-service/src/main/java/org/apache/druid/indexing/seekablestream/supervisor/SeekableStreamSupervisorSpec.java
+++ b/indexing-service/src/main/java/org/apache/druid/indexing/seekablestream/supervisor/SeekableStreamSupervisorSpec.java
@@ -23,6 +23,9 @@ import com.fasterxml.jackson.annotation.JsonProperty;
 import com.fasterxml.jackson.databind.ObjectMapper;
 import com.google.common.base.Preconditions;
 import com.google.common.collect.ImmutableList;
+import org.apache.druid.common.config.Configs;
+import org.apache.druid.error.DruidException;
+import org.apache.druid.error.InvalidInput;
 import org.apache.druid.guice.annotations.Json;
 import org.apache.druid.indexing.overlord.IndexerMetadataStorageCoordinator;
 import org.apache.druid.indexing.overlord.TaskMaster;
@@ -56,6 +59,7 @@ public abstract class SeekableStreamSupervisorSpec implements SupervisorSpec
     return ingestionSchema;
   }
 
+  protected final String id;
   protected final TaskStorage taskStorage;
   protected final TaskMaster taskMaster;
   protected final IndexerMetadataStorageCoordinator indexerMetadataStorageCoordinator;
@@ -70,7 +74,13 @@ public abstract class SeekableStreamSupervisorSpec implements SupervisorSpec
   private final boolean suspended;
   protected final SupervisorStateManagerConfig supervisorStateManagerConfig;
 
+  /**
+   * Base constructor for SeekableStreamSupervisors.
+   * The unique identifier for the supervisor. A null {@code id} implies the constructor will use the
+   * non-null `dataSource` in `ingestionSchema` for backwards compatibility.
+   */
   public SeekableStreamSupervisorSpec(
+      @Nullable final String id,
       final SeekableStreamSupervisorIngestionSpec ingestionSchema,
       @Nullable Map<String, Object> context,
       Boolean suspended,
@@ -86,6 +96,10 @@ public abstract class SeekableStreamSupervisorSpec implements SupervisorSpec
   )
   {
     this.ingestionSchema = checkIngestionSchema(ingestionSchema);
+    this.id = Preconditions.checkNotNull(
+        Configs.valueOrDefault(id, ingestionSchema.getDataSchema().getDataSource()),
+        "spec id cannot be null!"
+    );
     this.context = context;
 
     this.taskStorage = taskStorage;
@@ -144,9 +158,10 @@ public abstract class SeekableStreamSupervisorSpec implements SupervisorSpec
   }
 
   @Override
+  @JsonProperty
   public String getId()
   {
-    return ingestionSchema.getDataSchema().getDataSource();
+    return id;
   }
 
   public DruidMonitorSchedulerConfig getMonitorSchedulerConfig()

--- a/indexing-service/src/test/java/org/apache/druid/indexing/common/actions/LocalTaskActionClientTest.java
+++ b/indexing-service/src/test/java/org/apache/druid/indexing/common/actions/LocalTaskActionClientTest.java
@@ -33,7 +33,7 @@ public class LocalTaskActionClientTest
   @Test
   public void testGetActionType()
   {
-    final TaskAction<?> action = SegmentTransactionalInsertAction.appendAction(Collections.emptySet(), null, null, null);
+    final TaskAction<?> action = SegmentTransactionalInsertAction.appendAction(Collections.emptySet(), null, null, null, null, null);
     Assert.assertEquals("segmentTransactionalInsert", LocalTaskActionClient.getActionType(objectMapper, action));
   }
 }

--- a/indexing-service/src/test/java/org/apache/druid/indexing/common/actions/SegmentTransactionalInsertActionTest.java
+++ b/indexing-service/src/test/java/org/apache/druid/indexing/common/actions/SegmentTransactionalInsertActionTest.java
@@ -51,6 +51,7 @@ public class SegmentTransactionalInsertActionTest
   public TaskActionTestKit actionTestKit = new TaskActionTestKit();
 
   private static final String DATA_SOURCE = "none";
+  private static final String SUPERVISOR_ID = "supervisorId";
   private static final Interval INTERVAL = Intervals.of("2020/2020T01");
   private static final String PARTY_YEAR = "1999";
   private static final String THE_DISTANT_FUTURE = "3000";
@@ -98,7 +99,7 @@ public class SegmentTransactionalInsertActionTest
   }
 
   @Test
-  public void testTransactionalUpdateDataSourceMetadata() throws Exception
+  public void test_transactionalUpdateDataSourceMetadata_withDefaultSupervisorId() throws Exception
   {
     final Task task = NoopTask.create();
     actionTestKit.getTaskLockbox().add(task);
@@ -106,6 +107,8 @@ public class SegmentTransactionalInsertActionTest
 
     SegmentPublishResult result1 = SegmentTransactionalInsertAction.appendAction(
         ImmutableSet.of(SEGMENT1),
+        SUPERVISOR_ID,
+        DATA_SOURCE,
         new ObjectMetadata(null),
         new ObjectMetadata(ImmutableList.of(1)),
         null
@@ -117,6 +120,8 @@ public class SegmentTransactionalInsertActionTest
 
     SegmentPublishResult result2 = SegmentTransactionalInsertAction.appendAction(
         ImmutableSet.of(SEGMENT2),
+        SUPERVISOR_ID,
+        DATA_SOURCE,
         new ObjectMetadata(ImmutableList.of(1)),
         new ObjectMetadata(ImmutableList.of(2)),
         null
@@ -133,12 +138,56 @@ public class SegmentTransactionalInsertActionTest
 
     Assert.assertEquals(
         new ObjectMetadata(ImmutableList.of(2)),
-        actionTestKit.getMetadataStorageCoordinator().retrieveDataSourceMetadata(DATA_SOURCE)
+        actionTestKit.getMetadataStorageCoordinator().retrieveDataSourceMetadata(SUPERVISOR_ID)
     );
   }
 
   @Test
-  public void testFailTransactionalUpdateDataSourceMetadata() throws Exception
+  public void test_transactionalUpdateDataSourceMetadata_withCustomSupervisorId() throws Exception
+  {
+    final Task task = NoopTask.create();
+    actionTestKit.getTaskLockbox().add(task);
+    acquireTimeChunkLock(TaskLockType.EXCLUSIVE, task, INTERVAL, 5000);
+
+    SegmentPublishResult result1 = SegmentTransactionalInsertAction.appendAction(
+        ImmutableSet.of(SEGMENT1),
+        SUPERVISOR_ID,
+        DATA_SOURCE,
+        new ObjectMetadata(null),
+        new ObjectMetadata(ImmutableList.of(1)),
+        null
+    ).perform(
+        task,
+        actionTestKit.getTaskActionToolbox()
+    );
+    Assert.assertEquals(SegmentPublishResult.ok(ImmutableSet.of(SEGMENT1)), result1);
+
+    SegmentPublishResult result2 = SegmentTransactionalInsertAction.appendAction(
+        ImmutableSet.of(SEGMENT2),
+        SUPERVISOR_ID,
+        DATA_SOURCE,
+        new ObjectMetadata(ImmutableList.of(1)),
+        new ObjectMetadata(ImmutableList.of(2)),
+        null
+    ).perform(
+        task,
+        actionTestKit.getTaskActionToolbox()
+    );
+    Assert.assertEquals(SegmentPublishResult.ok(ImmutableSet.of(SEGMENT2)), result2);
+
+    Assertions.assertThat(
+        actionTestKit.getMetadataStorageCoordinator()
+                     .retrieveUsedSegmentsForInterval(DATA_SOURCE, INTERVAL, Segments.ONLY_VISIBLE)
+    ).containsExactlyInAnyOrder(SEGMENT1, SEGMENT2);
+
+    Assert.assertEquals(
+        new ObjectMetadata(ImmutableList.of(2)),
+        actionTestKit.getMetadataStorageCoordinator().retrieveDataSourceMetadata(SUPERVISOR_ID)
+    );
+  }
+
+  @Test
+  public void test_fail_transactionalUpdateDataSourceMetadata() throws Exception
   {
     final Task task = NoopTask.create();
     actionTestKit.getTaskLockbox().add(task);
@@ -146,6 +195,8 @@ public class SegmentTransactionalInsertActionTest
 
     SegmentPublishResult result = SegmentTransactionalInsertAction.appendAction(
         ImmutableSet.of(SEGMENT1),
+        SUPERVISOR_ID,
+        DATA_SOURCE,
         new ObjectMetadata(ImmutableList.of(1)),
         new ObjectMetadata(ImmutableList.of(2)),
         null
@@ -166,7 +217,7 @@ public class SegmentTransactionalInsertActionTest
   }
 
   @Test
-  public void testFailBadVersion() throws Exception
+  public void test_fail_badVersion() throws Exception
   {
     final Task task = NoopTask.create();
     final SegmentTransactionalInsertAction action = SegmentTransactionalInsertAction.overwriteAction(

--- a/indexing-service/src/test/java/org/apache/druid/indexing/common/task/AppenderatorDriverRealtimeIndexTaskTest.java
+++ b/indexing-service/src/test/java/org/apache/druid/indexing/common/task/AppenderatorDriverRealtimeIndexTaskTest.java
@@ -1541,12 +1541,13 @@ public class AppenderatorDriverRealtimeIndexTaskTest extends InitializedNullHand
       @Override
       public SegmentPublishResult commitSegmentsAndMetadata(
           Set<DataSegment> segments,
+          String supervisorId,
           DataSourceMetadata startMetadata,
           DataSourceMetadata endMetadata,
           SegmentSchemaMapping segmentSchemaMapping
       ) throws IOException
       {
-        SegmentPublishResult result = super.commitSegmentsAndMetadata(segments, startMetadata, endMetadata, segmentSchemaMapping);
+        SegmentPublishResult result = super.commitSegmentsAndMetadata(segments, supervisorId, startMetadata, endMetadata, segmentSchemaMapping);
 
         Assert.assertNotNull(
             "Segment latch not initialized, did you forget to call expectPublishSegments?",

--- a/indexing-service/src/test/java/org/apache/druid/indexing/overlord/setup/EqualDistributionWithCategorySpecWorkerSelectStrategyTest.java
+++ b/indexing-service/src/test/java/org/apache/druid/indexing/overlord/setup/EqualDistributionWithCategorySpecWorkerSelectStrategyTest.java
@@ -20,14 +20,26 @@
 package org.apache.druid.indexing.overlord.setup;
 
 import com.google.common.collect.ImmutableMap;
+import org.apache.druid.data.input.impl.DimensionsSpec;
+import org.apache.druid.data.input.impl.TimestampSpec;
+import org.apache.druid.segment.indexing.granularity.ArbitraryGranularitySpec;
 import org.apache.druid.indexing.common.task.NoopTask;
+import org.apache.druid.indexing.common.task.Task;
 import org.apache.druid.indexing.overlord.ImmutableWorkerInfo;
 import org.apache.druid.indexing.overlord.config.RemoteTaskRunnerConfig;
+import org.apache.druid.indexing.seekablestream.SeekableStreamIndexTaskIOConfig;
+import org.apache.druid.indexing.seekablestream.SeekableStreamIndexTaskTuningConfig;
+import org.apache.druid.indexing.seekablestream.TestSeekableStreamIndexTask;
 import org.apache.druid.indexing.worker.Worker;
 import org.apache.druid.java.util.common.DateTimes;
+import org.apache.druid.java.util.common.granularity.AllGranularity;
+import org.apache.druid.segment.indexing.DataSchema;
 import org.junit.Assert;
 import org.junit.Test;
+import org.mockito.Mockito;
 
+import javax.annotation.Nullable;
+import java.util.Collections;
 import java.util.HashSet;
 
 public class EqualDistributionWithCategorySpecWorkerSelectStrategyTest
@@ -80,7 +92,8 @@ public class EqualDistributionWithCategorySpecWorkerSelectStrategyTest
             "noop",
             new WorkerCategorySpec.CategoryConfig(
                 "c2",
-                ImmutableMap.of("ds1", "c2")
+                ImmutableMap.of("ds1", "c2"),
+                null
             )
         ),
         false
@@ -95,7 +108,8 @@ public class EqualDistributionWithCategorySpecWorkerSelectStrategyTest
             "noop",
             new WorkerCategorySpec.CategoryConfig(
                 null,
-                ImmutableMap.of("ds1", "c2")
+                ImmutableMap.of("ds1", "c2"),
+                null
             )
         ),
         false
@@ -110,6 +124,7 @@ public class EqualDistributionWithCategorySpecWorkerSelectStrategyTest
             "noop",
             new WorkerCategorySpec.CategoryConfig(
                 "c2",
+                null,
                 null
             )
         ),
@@ -127,6 +142,7 @@ public class EqualDistributionWithCategorySpecWorkerSelectStrategyTest
         ImmutableMap.of(
             "noop",
             new WorkerCategorySpec.CategoryConfig(
+                null,
                 null,
                 null
             )
@@ -146,7 +162,8 @@ public class EqualDistributionWithCategorySpecWorkerSelectStrategyTest
             "noop",
             new WorkerCategorySpec.CategoryConfig(
                 "c1",
-                ImmutableMap.of("ds1", "c3")
+                ImmutableMap.of("ds1", "c3"),
+                null
             )
         ),
         false
@@ -164,7 +181,8 @@ public class EqualDistributionWithCategorySpecWorkerSelectStrategyTest
             "noop",
             new WorkerCategorySpec.CategoryConfig(
                 "c1",
-                ImmutableMap.of("ds1", "c3")
+                ImmutableMap.of("ds1", "c3"),
+                null
             )
         ),
         true
@@ -172,6 +190,94 @@ public class EqualDistributionWithCategorySpecWorkerSelectStrategyTest
 
     ImmutableWorkerInfo worker = selectWorker(workerCategorySpec);
     Assert.assertNull(worker);
+  }
+
+  @Test
+  public void testSupervisorIdCategoryAffinity()
+  {
+    final WorkerCategorySpec workerCategorySpec = new WorkerCategorySpec(
+        ImmutableMap.of(
+            "test_seekable_stream",
+            new WorkerCategorySpec.CategoryConfig(
+                "c1",
+                ImmutableMap.of("ds1", "c1"),
+                ImmutableMap.of("supervisor1", "c2")
+            )
+        ),
+        false
+    );
+    final Task taskWithSupervisor = createTestTask("task1", "supervisor1", "ds1");
+    
+    final EqualDistributionWithCategorySpecWorkerSelectStrategy strategy =
+        new EqualDistributionWithCategorySpecWorkerSelectStrategy(workerCategorySpec);
+
+    ImmutableWorkerInfo worker = strategy.findWorkerForTask(
+        new RemoteTaskRunnerConfig(),
+        WORKERS_FOR_TIER_TESTS,
+        taskWithSupervisor
+    );
+    Assert.assertNotNull(worker);
+    Assert.assertEquals("c2", worker.getWorker().getCategory());
+    Assert.assertEquals("localhost3", worker.getWorker().getHost());
+  }
+
+  @Test
+  public void testSupervisorIdCategoryAffinityFallbackToDatasource()
+  {
+    final WorkerCategorySpec workerCategorySpec = new WorkerCategorySpec(
+        ImmutableMap.of(
+            "test_seekable_stream",
+            new WorkerCategorySpec.CategoryConfig(
+                "c2",
+                ImmutableMap.of("ds1", "c1"),
+                ImmutableMap.of("supervisor2", "c2")
+            )
+        ),
+        false
+    );
+    final Task taskWithSupervisor = createTestTask("task1", "supervisor1", "ds1");
+    
+    final EqualDistributionWithCategorySpecWorkerSelectStrategy strategy =
+        new EqualDistributionWithCategorySpecWorkerSelectStrategy(workerCategorySpec);
+
+    ImmutableWorkerInfo worker = strategy.findWorkerForTask(
+        new RemoteTaskRunnerConfig(),
+        WORKERS_FOR_TIER_TESTS,
+        taskWithSupervisor
+    );
+    Assert.assertNotNull(worker);
+    Assert.assertEquals("c1", worker.getWorker().getCategory());
+    Assert.assertEquals("localhost1", worker.getWorker().getHost());
+  }
+
+  @Test
+  public void testSupervisorIdCategoryAffinityFallbackToDefault()
+  {
+    final WorkerCategorySpec workerCategorySpec = new WorkerCategorySpec(
+        ImmutableMap.of(
+            "test_seekable_stream",
+            new WorkerCategorySpec.CategoryConfig(
+                "c2",
+                ImmutableMap.of("ds2", "c1"),
+                ImmutableMap.of("supervisor2", "c1")
+            )
+        ),
+        false
+    );
+
+    final Task taskWithSupervisor = createTestTask("task1", "supervisor1", "ds1");
+    
+    final EqualDistributionWithCategorySpecWorkerSelectStrategy strategy =
+        new EqualDistributionWithCategorySpecWorkerSelectStrategy(workerCategorySpec);
+
+    ImmutableWorkerInfo worker = strategy.findWorkerForTask(
+        new RemoteTaskRunnerConfig(),
+        WORKERS_FOR_TIER_TESTS,
+        taskWithSupervisor
+    );
+    Assert.assertNotNull(worker);
+    Assert.assertEquals("c2", worker.getWorker().getCategory());
+    Assert.assertEquals("localhost3", worker.getWorker().getHost());
   }
 
   private ImmutableWorkerInfo selectWorker(WorkerCategorySpec workerCategorySpec)
@@ -186,5 +292,30 @@ public class EqualDistributionWithCategorySpecWorkerSelectStrategyTest
     );
 
     return worker;
+  }
+
+  /**
+   * Helper method to create a test task with supervisor ID for testing
+   */
+  @SuppressWarnings("unchecked")
+  private static Task createTestTask(String id, @Nullable String supervisorId, String datasource)
+  {
+    return new TestSeekableStreamIndexTask(
+        id,
+        supervisorId,
+        null,
+        new DataSchema(
+            datasource,
+            new TimestampSpec(null, null, null),
+            new DimensionsSpec(Collections.emptyList()),
+            null,
+            new ArbitraryGranularitySpec(new AllGranularity(), Collections.emptyList()),
+            null
+        ),
+        Mockito.mock(SeekableStreamIndexTaskTuningConfig.class),
+        Mockito.mock(SeekableStreamIndexTaskIOConfig.class),
+        null,
+        null
+    );
   }
 }

--- a/indexing-service/src/test/java/org/apache/druid/indexing/overlord/setup/FillCapacityWithCategorySpecWorkerSelectStrategyTest.java
+++ b/indexing-service/src/test/java/org/apache/druid/indexing/overlord/setup/FillCapacityWithCategorySpecWorkerSelectStrategyTest.java
@@ -20,14 +20,26 @@
 package org.apache.druid.indexing.overlord.setup;
 
 import com.google.common.collect.ImmutableMap;
+import org.apache.druid.data.input.impl.DimensionsSpec;
+import org.apache.druid.data.input.impl.TimestampSpec;
+import org.apache.druid.segment.indexing.granularity.ArbitraryGranularitySpec;
 import org.apache.druid.indexing.common.task.NoopTask;
+import org.apache.druid.indexing.common.task.Task;
 import org.apache.druid.indexing.overlord.ImmutableWorkerInfo;
 import org.apache.druid.indexing.overlord.config.RemoteTaskRunnerConfig;
+import org.apache.druid.indexing.seekablestream.SeekableStreamIndexTaskIOConfig;
+import org.apache.druid.indexing.seekablestream.SeekableStreamIndexTaskTuningConfig;
+import org.apache.druid.indexing.seekablestream.TestSeekableStreamIndexTask;
 import org.apache.druid.indexing.worker.Worker;
 import org.apache.druid.java.util.common.DateTimes;
+import org.apache.druid.java.util.common.granularity.AllGranularity;
+import org.apache.druid.segment.indexing.DataSchema;
 import org.junit.Assert;
 import org.junit.Test;
+import org.mockito.Mockito;
 
+import javax.annotation.Nullable;
+import java.util.Collections;
 import java.util.HashSet;
 
 public class FillCapacityWithCategorySpecWorkerSelectStrategyTest
@@ -80,7 +92,8 @@ public class FillCapacityWithCategorySpecWorkerSelectStrategyTest
             "noop",
             new WorkerCategorySpec.CategoryConfig(
                 "c1",
-                ImmutableMap.of("ds1", "c1")
+                ImmutableMap.of("ds1", "c1"),
+                null
             )
         ),
         false
@@ -95,7 +108,8 @@ public class FillCapacityWithCategorySpecWorkerSelectStrategyTest
             "noop",
             new WorkerCategorySpec.CategoryConfig(
                 null,
-                ImmutableMap.of("ds1", "c1")
+                ImmutableMap.of("ds1", "c1"),
+                null
             )
         ),
         false
@@ -110,6 +124,7 @@ public class FillCapacityWithCategorySpecWorkerSelectStrategyTest
             "noop",
             new WorkerCategorySpec.CategoryConfig(
                 "c1",
+                null,
                 null
             )
         ),
@@ -127,6 +142,7 @@ public class FillCapacityWithCategorySpecWorkerSelectStrategyTest
         ImmutableMap.of(
             "noop",
             new WorkerCategorySpec.CategoryConfig(
+                null,
                 null,
                 null
             )
@@ -146,7 +162,8 @@ public class FillCapacityWithCategorySpecWorkerSelectStrategyTest
             "noop",
             new WorkerCategorySpec.CategoryConfig(
                 "c1",
-                ImmutableMap.of("ds1", "c3")
+                ImmutableMap.of("ds1", "c3"),
+                null
             )
         ),
         false
@@ -164,7 +181,8 @@ public class FillCapacityWithCategorySpecWorkerSelectStrategyTest
             "noop",
             new WorkerCategorySpec.CategoryConfig(
                 "c1",
-                ImmutableMap.of("ds1", "c3")
+                ImmutableMap.of("ds1", "c3"),
+                null
             )
         ),
         true
@@ -172,6 +190,99 @@ public class FillCapacityWithCategorySpecWorkerSelectStrategyTest
 
     ImmutableWorkerInfo worker = selectWorker(workerCategorySpec);
     Assert.assertNull(worker);
+  }
+
+  @Test
+  public void testSupervisorIdCategoryAffinity()
+  {
+    final WorkerCategorySpec workerCategorySpec = new WorkerCategorySpec(
+        ImmutableMap.of(
+            "test_seekable_stream",
+            new WorkerCategorySpec.CategoryConfig(
+                "c1",
+                ImmutableMap.of("ds1", "c1"),
+                ImmutableMap.of("supervisor1", "c2")
+            )
+        ),
+        false
+    );
+
+    // Create a test task with supervisor ID "supervisor1"
+    final Task taskWithSupervisor = createTestTask("task1", "supervisor1", "ds1");
+    
+    final FillCapacityWithCategorySpecWorkerSelectStrategy strategy =
+        new FillCapacityWithCategorySpecWorkerSelectStrategy(workerCategorySpec);
+
+    ImmutableWorkerInfo worker = strategy.findWorkerForTask(
+        new RemoteTaskRunnerConfig(),
+        WORKERS_FOR_TIER_TESTS,
+        taskWithSupervisor
+    );
+    Assert.assertNotNull(worker);
+    Assert.assertEquals("c2", worker.getWorker().getCategory());
+    Assert.assertEquals("localhost3", worker.getWorker().getHost());
+  }
+
+  @Test
+  public void testSupervisorIdCategoryAffinityFallbackToDatasource()
+  {
+    final WorkerCategorySpec workerCategorySpec = new WorkerCategorySpec(
+        ImmutableMap.of(
+            "test_seekable_stream",
+            new WorkerCategorySpec.CategoryConfig(
+                "c2",
+                ImmutableMap.of("ds1", "c1"),
+                ImmutableMap.of("supervisor2", "c2")
+            )
+        ),
+        false
+    );
+
+    // Create a test task with supervisor ID "supervisor1" (not in supervisorIdCategoryAffinity map)
+    final Task taskWithSupervisor = createTestTask("task1", "supervisor1", "ds1");
+    
+    final FillCapacityWithCategorySpecWorkerSelectStrategy strategy =
+        new FillCapacityWithCategorySpecWorkerSelectStrategy(workerCategorySpec);
+
+    ImmutableWorkerInfo worker = strategy.findWorkerForTask(
+        new RemoteTaskRunnerConfig(),
+        WORKERS_FOR_TIER_TESTS,
+        taskWithSupervisor
+    );
+    Assert.assertNotNull(worker);
+    Assert.assertEquals("c1", worker.getWorker().getCategory());
+    Assert.assertEquals("localhost1", worker.getWorker().getHost());
+  }
+
+  @Test
+  public void testSupervisorIdCategoryAffinityFallbackToDefault()
+  {
+    final WorkerCategorySpec workerCategorySpec = new WorkerCategorySpec(
+        ImmutableMap.of(
+            "test_seekable_stream",
+            new WorkerCategorySpec.CategoryConfig(
+                "c2",
+                ImmutableMap.of("ds2", "c1"),
+                ImmutableMap.of("supervisor2", "c1")
+            )
+        ),
+        false
+    );
+
+    // Create a test task with supervisor ID "supervisor1" and datasource "ds1"
+    final Task taskWithSupervisor = createTestTask("task1", "supervisor1", "ds1");
+    
+    final FillCapacityWithCategorySpecWorkerSelectStrategy strategy =
+        new FillCapacityWithCategorySpecWorkerSelectStrategy(workerCategorySpec);
+
+    ImmutableWorkerInfo worker = strategy.findWorkerForTask(
+        new RemoteTaskRunnerConfig(),
+        WORKERS_FOR_TIER_TESTS,
+        taskWithSupervisor
+    );
+    Assert.assertNotNull(worker);
+    Assert.assertEquals("c2", worker.getWorker().getCategory());
+    Assert.assertEquals("localhost3", worker.getWorker().getHost());
   }
 
   private ImmutableWorkerInfo selectWorker(WorkerCategorySpec workerCategorySpec)
@@ -186,5 +297,30 @@ public class FillCapacityWithCategorySpecWorkerSelectStrategyTest
     );
 
     return worker;
+  }
+
+  /**
+   * Helper method to create a test task with supervisor ID for testing
+   */
+  @SuppressWarnings("unchecked")
+  private static Task createTestTask(String id, @Nullable String supervisorId, String datasource)
+  {
+    return new TestSeekableStreamIndexTask(
+        id,
+        supervisorId,
+        null,
+        new DataSchema(
+            datasource,
+            new TimestampSpec(null, null, null),
+            new DimensionsSpec(Collections.emptyList()),
+            null,
+            new ArbitraryGranularitySpec(new AllGranularity(), Collections.emptyList()),
+            null
+        ),
+        Mockito.mock(SeekableStreamIndexTaskTuningConfig.class),
+        Mockito.mock(SeekableStreamIndexTaskIOConfig.class),
+        null,
+        null
+    );
   }
 }

--- a/indexing-service/src/test/java/org/apache/druid/indexing/overlord/setup/WorkerCategorySpecTest.java
+++ b/indexing-service/src/test/java/org/apache/druid/indexing/overlord/setup/WorkerCategorySpecTest.java
@@ -58,7 +58,7 @@ public class WorkerCategorySpecTest
     Assert.assertTrue(workerCategorySpec.isStrong());
     Assert.assertEquals(ImmutableMap.of(
         "index_kafka",
-        new WorkerCategorySpec.CategoryConfig("c1", ImmutableMap.of("ds1", "c2"))
+        new WorkerCategorySpec.CategoryConfig("c1", ImmutableMap.of("ds1", "c2"), null)
     ), workerCategorySpec.getCategoryMap());
   }
 }

--- a/indexing-service/src/test/java/org/apache/druid/indexing/overlord/supervisor/SupervisorResourceTest.java
+++ b/indexing-service/src/test/java/org/apache/druid/indexing/overlord/supervisor/SupervisorResourceTest.java
@@ -294,8 +294,8 @@ public class SupervisorResourceTest extends EasyMockSupport
     Assert.assertTrue(
         specs.stream()
              .allMatch(spec ->
-                           ("id1".equals(spec.getId()) && SPEC1.equals(spec.getSpec())) ||
-                           ("id2".equals(spec.getId()) && SPEC2.equals(spec.getSpec()))
+                           ("id1".equals(spec.getId()) && spec.getDataSource().equals("datasource1") && SPEC1.equals(spec.getSpec())) ||
+                           ("id2".equals(spec.getId()) && spec.getDataSource().equals("datasource2") && SPEC2.equals(spec.getSpec()))
              )
     );
   }
@@ -341,8 +341,8 @@ public class SupervisorResourceTest extends EasyMockSupport
 
     EasyMock.expect(taskMaster.getSupervisorManager()).andReturn(Optional.of(supervisorManager));
     EasyMock.expect(supervisorManager.getSupervisorIds()).andReturn(SUPERVISOR_IDS).atLeastOnce();
-    EasyMock.expect(supervisorManager.getSupervisorSpec("id1")).andReturn(Optional.of(SPEC1)).times(1);
-    EasyMock.expect(supervisorManager.getSupervisorSpec("id2")).andReturn(Optional.of(SPEC2)).times(1);
+    EasyMock.expect(supervisorManager.getSupervisorSpec("id1")).andReturn(Optional.of(SPEC1)).times(2);
+    EasyMock.expect(supervisorManager.getSupervisorSpec("id2")).andReturn(Optional.of(SPEC2)).times(2);
     EasyMock.expect(supervisorManager.getSupervisorState("id1")).andReturn(Optional.of(state1)).times(1);
     EasyMock.expect(supervisorManager.getSupervisorState("id2")).andReturn(Optional.of(state2)).times(1);
     setupMockRequest();
@@ -360,11 +360,13 @@ public class SupervisorResourceTest extends EasyMockSupport
                 if ("id1".equals(id)) {
                   return state1.toString().equals(state.getState())
                          && state1.toString().equals(state.getDetailedState())
-                         && (Boolean) state.isHealthy() == state1.isHealthy();
+                         && (Boolean) state.isHealthy() == state1.isHealthy()
+                         && state.getDataSource().equals("datasource1");
                 } else if ("id2".equals(id)) {
                   return state2.toString().equals(state.getState())
                          && state2.toString().equals(state.getDetailedState())
-                         && (Boolean) state.isHealthy() == state2.isHealthy();
+                         && (Boolean) state.isHealthy() == state2.isHealthy()
+                         && state.getDataSource().equals("datasource2");
                 }
                 return false;
               })

--- a/indexing-service/src/test/java/org/apache/druid/indexing/seekablestream/SeekableStreamIndexTaskRunnerAuthTest.java
+++ b/indexing-service/src/test/java/org/apache/druid/indexing/seekablestream/SeekableStreamIndexTaskRunnerAuthTest.java
@@ -351,7 +351,7 @@ public class SeekableStreamIndexTaskRunnerAuthTest
         SeekableStreamIndexTaskIOConfig<String, String> ioConfig
     )
     {
-      super(id, null, dataSchema, tuningConfig, ioConfig, null, null);
+      super(id, null, null, dataSchema, tuningConfig, ioConfig, null, null);
     }
 
     @Override

--- a/indexing-service/src/test/java/org/apache/druid/indexing/seekablestream/SeekableStreamSupervisorSpecTest.java
+++ b/indexing-service/src/test/java/org/apache/druid/indexing/seekablestream/SeekableStreamSupervisorSpecTest.java
@@ -101,6 +101,7 @@ public class SeekableStreamSupervisorSpecTest extends EasyMockSupport
   private SeekableStreamIndexTaskClientFactory taskClientFactory;
   private static final String STREAM = "stream";
   private static final String DATASOURCE = "testDS";
+  private static final String SUPERVISOR = "supervisor";
   private SeekableStreamSupervisorSpec spec;
   private SupervisorStateManagerConfig supervisorConfig;
 
@@ -231,7 +232,7 @@ public class SeekableStreamSupervisorSpecTest extends EasyMockSupport
     }
 
     @Override
-    protected boolean doesTaskTypeMatchSupervisor(Task task)
+    protected boolean doesTaskMatchSupervisor(Task task)
     {
       return true;
     }
@@ -283,6 +284,7 @@ public class SeekableStreamSupervisorSpecTest extends EasyMockSupport
     )
     {
       return new SeekableStreamSupervisorReportPayload<String, String>(
+          SUPERVISOR,
           DATASOURCE,
           STREAM,
           1,
@@ -383,7 +385,6 @@ public class SeekableStreamSupervisorSpecTest extends EasyMockSupport
   private static class TestSeekableStreamSupervisorSpec extends SeekableStreamSupervisorSpec
   {
     private SeekableStreamSupervisor supervisor;
-    private String id;
 
     public TestSeekableStreamSupervisorSpec(
         SeekableStreamSupervisorIngestionSpec ingestionSchema,
@@ -403,6 +404,7 @@ public class SeekableStreamSupervisorSpecTest extends EasyMockSupport
     )
     {
       super(
+          id,
           ingestionSchema,
           context,
           suspended,
@@ -418,19 +420,6 @@ public class SeekableStreamSupervisorSpecTest extends EasyMockSupport
       );
 
       this.supervisor = supervisor;
-      this.id = id;
-    }
-
-    @Override
-    public List<String> getDataSources()
-    {
-      return new ArrayList<>();
-    }
-
-    @Override
-    public String getId()
-    {
-      return id;
     }
 
     @Override
@@ -740,6 +729,7 @@ public class SeekableStreamSupervisorSpecTest extends EasyMockSupport
   @Test
   public void testSeekableStreamSupervisorSpecWithScaleOut() throws InterruptedException
   {
+    EasyMock.expect(spec.getId()).andReturn(SUPERVISOR).anyTimes();
     EasyMock.expect(spec.getSupervisorStateManagerConfig()).andReturn(supervisorConfig).anyTimes();
 
     EasyMock.expect(spec.getDataSchema()).andReturn(getDataSchema()).anyTimes();
@@ -795,6 +785,7 @@ public class SeekableStreamSupervisorSpecTest extends EasyMockSupport
   @Test
   public void testSeekableStreamSupervisorSpecWithScaleOutAlreadyAtMax() throws InterruptedException
   {
+    EasyMock.expect(spec.getId()).andReturn(SUPERVISOR).anyTimes();
     EasyMock.expect(spec.getSupervisorStateManagerConfig()).andReturn(supervisorConfig).anyTimes();
 
     EasyMock.expect(spec.getDataSchema()).andReturn(getDataSchema()).anyTimes();
@@ -854,6 +845,7 @@ public class SeekableStreamSupervisorSpecTest extends EasyMockSupport
   @Test
   public void testSeekableStreamSupervisorSpecWithNoScalingOnIdleSupervisor() throws InterruptedException
   {
+    EasyMock.expect(spec.getId()).andReturn(SUPERVISOR).anyTimes();
     EasyMock.expect(spec.getSupervisorStateManagerConfig()).andReturn(supervisorConfig).anyTimes();
 
     EasyMock.expect(spec.getDataSchema()).andReturn(getDataSchema()).anyTimes();
@@ -903,6 +895,7 @@ public class SeekableStreamSupervisorSpecTest extends EasyMockSupport
   @Test
   public void testSeekableStreamSupervisorSpecWithScaleOutSmallPartitionNumber() throws InterruptedException
   {
+    EasyMock.expect(spec.getId()).andReturn(SUPERVISOR).anyTimes();
     EasyMock.expect(spec.getSupervisorStateManagerConfig()).andReturn(supervisorConfig).anyTimes();
 
     EasyMock.expect(spec.getDataSchema()).andReturn(getDataSchema()).anyTimes();
@@ -948,6 +941,7 @@ public class SeekableStreamSupervisorSpecTest extends EasyMockSupport
   @Test
   public void testSeekableStreamSupervisorSpecWithScaleIn() throws InterruptedException
   {
+    EasyMock.expect(spec.getId()).andReturn(SUPERVISOR).anyTimes();
     EasyMock.expect(spec.getSupervisorStateManagerConfig()).andReturn(supervisorConfig).anyTimes();
     EasyMock.expect(spec.getDataSchema()).andReturn(getDataSchema()).anyTimes();
     EasyMock.expect(spec.getIoConfig()).andReturn(getIOConfig(2, false)).anyTimes();
@@ -996,6 +990,7 @@ public class SeekableStreamSupervisorSpecTest extends EasyMockSupport
   @Test
   public void testSeekableStreamSupervisorSpecWithScaleInAlreadyAtMin() throws InterruptedException
   {
+    EasyMock.expect(spec.getId()).andReturn(SUPERVISOR).anyTimes();
     EasyMock.expect(spec.getSupervisorStateManagerConfig()).andReturn(supervisorConfig).anyTimes();
 
     EasyMock.expect(spec.getDataSchema()).andReturn(getDataSchema()).anyTimes();
@@ -1074,6 +1069,7 @@ public class SeekableStreamSupervisorSpecTest extends EasyMockSupport
     )
     {
     };
+    EasyMock.expect(spec.getId()).andReturn(SUPERVISOR).anyTimes();
     EasyMock.expect(spec.getSupervisorStateManagerConfig()).andReturn(supervisorConfig).anyTimes();
 
     EasyMock.expect(spec.getDataSchema()).andReturn(getDataSchema()).anyTimes();
@@ -1133,8 +1129,11 @@ public class SeekableStreamSupervisorSpecTest extends EasyMockSupport
     EasyMock.expect(ingestionSchema.getIOConfig()).andReturn(seekableStreamSupervisorIOConfig).anyTimes();
     EasyMock.expect(ingestionSchema.getDataSchema()).andReturn(dataSchema).anyTimes();
     EasyMock.replay(ingestionSchema);
+    EasyMock.expect(dataSchema.getDataSource()).andReturn(DATASOURCE);
+    EasyMock.replay(dataSchema);
 
     spec = new SeekableStreamSupervisorSpec(
+        SUPERVISOR,
         ingestionSchema,
         null,
         null,
@@ -1224,6 +1223,52 @@ public class SeekableStreamSupervisorSpecTest extends EasyMockSupport
   }
 
   @Test
+  public void testSupervisorIdEqualsDataSourceIfNull()
+  {
+    mockIngestionSchema();
+    TestSeekableStreamSupervisorSpec spec = new TestSeekableStreamSupervisorSpec(
+        ingestionSchema,
+        ImmutableMap.of("key", "value"),
+        false,
+        taskStorage,
+        taskMaster,
+        indexerMetadataStorageCoordinator,
+        indexTaskClientFactory,
+        mapper,
+        emitter,
+        monitorSchedulerConfig,
+        rowIngestionMetersFactory,
+        supervisorStateManagerConfig,
+        supervisor4,
+        SUPERVISOR
+    );
+    Assert.assertEquals(SUPERVISOR, spec.getId());
+  }
+
+  @Test
+  public void testSupervisorIdDifferentFromDataSource()
+  {
+    mockIngestionSchema();
+    TestSeekableStreamSupervisorSpec spec = new TestSeekableStreamSupervisorSpec(
+        ingestionSchema,
+        ImmutableMap.of("key", "value"),
+        false,
+        taskStorage,
+        taskMaster,
+        indexerMetadataStorageCoordinator,
+        indexTaskClientFactory,
+        mapper,
+        emitter,
+        monitorSchedulerConfig,
+        rowIngestionMetersFactory,
+        supervisorStateManagerConfig,
+        supervisor4,
+        SUPERVISOR
+    );
+    Assert.assertEquals(SUPERVISOR, spec.getId());
+  }
+
+  @Test
   public void testGetContextVauleForKeyShouldReturnValue()
   {
     mockIngestionSchema();
@@ -1249,9 +1294,11 @@ public class SeekableStreamSupervisorSpecTest extends EasyMockSupport
   private void mockIngestionSchema()
   {
     EasyMock.expect(ingestionSchema.getIOConfig()).andReturn(seekableStreamSupervisorIOConfig).anyTimes();
+    EasyMock.expect(dataSchema.getDataSource()).andReturn(DATASOURCE).anyTimes();
     EasyMock.expect(ingestionSchema.getDataSchema()).andReturn(dataSchema).anyTimes();
     EasyMock.expect(ingestionSchema.getTuningConfig()).andReturn(seekableStreamSupervisorTuningConfig).anyTimes();
     EasyMock.replay(ingestionSchema);
+    EasyMock.replay(dataSchema);
   }
 
   private static DataSchema getDataSchema()

--- a/indexing-service/src/test/java/org/apache/druid/indexing/seekablestream/SequenceMetadataTest.java
+++ b/indexing-service/src/test/java/org/apache/druid/indexing/seekablestream/SequenceMetadataTest.java
@@ -30,6 +30,7 @@ import org.apache.druid.java.util.common.ISE;
 import org.apache.druid.java.util.common.Intervals;
 import org.apache.druid.java.util.common.StringUtils;
 import org.apache.druid.segment.SegmentUtils;
+import org.apache.druid.segment.realtime.appenderator.Appenderator;
 import org.apache.druid.segment.realtime.appenderator.TransactionalSegmentPublisher;
 import org.apache.druid.timeline.DataSegment;
 import org.apache.druid.timeline.partition.LinearShardSpec;
@@ -53,6 +54,9 @@ public class SequenceMetadataTest
 
   @Mock
   private SeekableStreamEndSequenceNumbers mockSeekableStreamEndSequenceNumbers;
+
+  @Mock
+  private Appenderator mockAppenderator;
 
   @Mock
   private TaskActionClient mockTaskActionClient;
@@ -104,6 +108,12 @@ public class SequenceMetadataTest
                    ArgumentMatchers.any()
                ))
            .thenReturn(mockSeekableStreamEndSequenceNumbers);
+    Mockito.when(
+        mockSeekableStreamIndexTaskRunner.getAppenderator()
+    ).thenReturn(mockAppenderator);
+    Mockito.when(
+        mockAppenderator.getDataSource()
+    ).thenReturn("foo");
     Mockito.when(mockSeekableStreamEndSequenceNumbers.getPartitionSequenceNumberMap()).thenReturn(ImmutableMap.of());
     Mockito.when(mockSeekableStreamEndSequenceNumbers.getStream()).thenReturn("stream");
     Mockito.when(mockTaskToolbox.getTaskActionClient()).thenReturn(mockTaskActionClient);

--- a/indexing-service/src/test/java/org/apache/druid/indexing/seekablestream/TestSeekableStreamIndexTask.java
+++ b/indexing-service/src/test/java/org/apache/druid/indexing/seekablestream/TestSeekableStreamIndexTask.java
@@ -1,0 +1,90 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+package org.apache.druid.indexing.seekablestream;
+
+import org.apache.druid.data.input.impl.ByteEntity;
+import org.apache.druid.indexing.common.TaskToolbox;
+import org.apache.druid.indexing.common.task.TaskResource;
+import org.apache.druid.indexing.seekablestream.common.RecordSupplier;
+import org.apache.druid.segment.indexing.DataSchema;
+
+import javax.annotation.Nullable;
+import java.util.Map;
+
+/**
+ * Test implementation of SeekableStreamIndexTask for use in unit tests.
+ */
+public class TestSeekableStreamIndexTask extends SeekableStreamIndexTask<String, String, ByteEntity>
+{
+  private final SeekableStreamIndexTaskRunner<String, String, ByteEntity> streamingTaskRunner;
+  private final RecordSupplier<String, String, ByteEntity> recordSupplier;
+
+  public TestSeekableStreamIndexTask(
+      String id,
+      @Nullable String supervisorId,
+      @Nullable TaskResource taskResource,
+      DataSchema dataSchema,
+      SeekableStreamIndexTaskTuningConfig tuningConfig,
+      SeekableStreamIndexTaskIOConfig<String, String> ioConfig,
+      @Nullable Map<String, Object> context,
+      @Nullable String groupId
+  )
+  {
+    this(id, supervisorId, taskResource, dataSchema, tuningConfig, ioConfig, context, groupId, null, null);
+  }
+
+  public TestSeekableStreamIndexTask(
+      String id,
+      @Nullable String supervisorId,
+      @Nullable TaskResource taskResource,
+      DataSchema dataSchema,
+      SeekableStreamIndexTaskTuningConfig tuningConfig,
+      SeekableStreamIndexTaskIOConfig<String, String> ioConfig,
+      @Nullable Map<String, Object> context,
+      @Nullable String groupId,
+      @Nullable SeekableStreamIndexTaskRunner<String, String, ByteEntity> streamingTaskRunner,
+      @Nullable RecordSupplier<String, String, ByteEntity> recordSupplier
+  )
+  {
+    super(id, supervisorId, taskResource, dataSchema, tuningConfig, ioConfig, context, groupId);
+    this.streamingTaskRunner = streamingTaskRunner;
+    this.recordSupplier = recordSupplier;
+  }
+
+  @Nullable
+  @Override
+  protected SeekableStreamIndexTaskRunner<String, String, ByteEntity> createTaskRunner()
+  {
+    return streamingTaskRunner;
+  }
+
+  @Override
+  protected RecordSupplier<String, String, ByteEntity> newTaskRecordSupplier(final TaskToolbox toolbox)
+  {
+    return recordSupplier;
+  }
+
+  @Override
+  public String getType()
+  {
+    return "test_seekable_stream";
+  }
+}
+

--- a/indexing-service/src/test/java/org/apache/druid/indexing/seekablestream/supervisor/SeekableStreamSupervisorStateTest.java
+++ b/indexing-service/src/test/java/org/apache/druid/indexing/seekablestream/supervisor/SeekableStreamSupervisorStateTest.java
@@ -79,6 +79,7 @@ import org.apache.druid.java.util.common.StringUtils;
 import org.apache.druid.java.util.common.concurrent.Execs;
 import org.apache.druid.java.util.common.granularity.Granularities;
 import org.apache.druid.java.util.common.parsers.JSONPathSpec;
+import org.apache.druid.java.util.emitter.EmittingLogger;
 import org.apache.druid.java.util.metrics.DruidMonitorSchedulerConfig;
 import org.apache.druid.java.util.metrics.StubServiceEmitter;
 import org.apache.druid.metadata.PendingSegmentRecord;
@@ -130,6 +131,7 @@ public class SeekableStreamSupervisorStateTest extends EasyMockSupport
 {
   private static final ObjectMapper OBJECT_MAPPER = TestHelper.makeJsonMapper();
   private static final String DATASOURCE = "testDS";
+  private static final String SUPERVISOR_ID = "testSupervisorId";
   private static final String STREAM = "stream";
   private static final String SHARD_ID = "0";
   private static final StreamPartition<String> SHARD0_PARTITION = StreamPartition.of(STREAM, SHARD_ID);
@@ -169,7 +171,9 @@ public class SeekableStreamSupervisorStateTest extends EasyMockSupport
     supervisorConfig = new SupervisorStateManagerConfig();
 
     emitter = new StubServiceEmitter("test-supervisor-state", "localhost");
+    EmittingLogger.registerEmitter(emitter);
 
+    EasyMock.expect(spec.getId()).andReturn(SUPERVISOR_ID).anyTimes();
     EasyMock.expect(spec.getSupervisorStateManagerConfig()).andReturn(supervisorConfig).anyTimes();
 
     EasyMock.expect(spec.getDataSchema()).andReturn(getDataSchema()).anyTimes();
@@ -191,7 +195,7 @@ public class SeekableStreamSupervisorStateTest extends EasyMockSupport
     taskRunner.registerListener(EasyMock.anyObject(TaskRunnerListener.class), EasyMock.anyObject(Executor.class));
     EasyMock.expectLastCall().times(0, 1);
 
-    EasyMock.expect(indexerMetadataStorageCoordinator.retrieveDataSourceMetadata(DATASOURCE)).andReturn(null).anyTimes();
+    EasyMock.expect(indexerMetadataStorageCoordinator.retrieveDataSourceMetadata(SUPERVISOR_ID)).andReturn(null).anyTimes();
     EasyMock.expect(recordSupplier.getAssignment()).andReturn(ImmutableSet.of(SHARD0_PARTITION)).anyTimes();
     EasyMock.expect(recordSupplier.getLatestSequenceNumber(EasyMock.anyObject())).andReturn("10").anyTimes();
   }
@@ -692,6 +696,7 @@ public class SeekableStreamSupervisorStateTest extends EasyMockSupport
     )
     {
     }).anyTimes();
+    EasyMock.expect(spec.getId()).andReturn(SUPERVISOR_ID).anyTimes();
     EasyMock.expect(spec.getTuningConfig()).andReturn(getTuningConfig()).anyTimes();
     EasyMock.expect(spec.getEmitter()).andReturn(emitter).anyTimes();
     EasyMock.expect(spec.getMonitorSchedulerConfig()).andReturn(new DruidMonitorSchedulerConfig() {
@@ -984,6 +989,7 @@ public class SeekableStreamSupervisorStateTest extends EasyMockSupport
     ) {};
 
     EasyMock.reset(spec);
+    EasyMock.expect(spec.getId()).andReturn(SUPERVISOR_ID).anyTimes();
     EasyMock.expect(spec.isSuspended()).andReturn(false).anyTimes();
     EasyMock.expect(spec.getDataSchema()).andReturn(getDataSchema()).anyTimes();
     EasyMock.expect(spec.getIoConfig()).andReturn(ioConfig).anyTimes();
@@ -1024,6 +1030,7 @@ public class SeekableStreamSupervisorStateTest extends EasyMockSupport
     TestSeekableStreamIndexTask id1 = new TestSeekableStreamIndexTask(
             "id1",
             null,
+            null,
             getDataSchema(),
             taskTuningConfig,
             taskIoConfig,
@@ -1034,6 +1041,7 @@ public class SeekableStreamSupervisorStateTest extends EasyMockSupport
     TestSeekableStreamIndexTask id2 = new TestSeekableStreamIndexTask(
             "id2",
             null,
+            null,
             getDataSchema(),
             taskTuningConfig,
             taskIoConfig,
@@ -1043,6 +1051,7 @@ public class SeekableStreamSupervisorStateTest extends EasyMockSupport
 
     TestSeekableStreamIndexTask id3 = new TestSeekableStreamIndexTask(
         "id3",
+        null,
         null,
         getDataSchema(),
         taskTuningConfig,
@@ -1072,7 +1081,7 @@ public class SeekableStreamSupervisorStateTest extends EasyMockSupport
     EasyMock.expect(taskStorage.getTask("id3")).andReturn(Optional.of(id2)).anyTimes();
 
     EasyMock.reset(indexerMetadataStorageCoordinator);
-    EasyMock.expect(indexerMetadataStorageCoordinator.retrieveDataSourceMetadata(DATASOURCE))
+    EasyMock.expect(indexerMetadataStorageCoordinator.retrieveDataSourceMetadata(SUPERVISOR_ID))
             .andReturn(new TestSeekableStreamDataSourceMetadata(null)).anyTimes();
     EasyMock.expect(indexTaskClient.getStatusAsync("id1"))
             .andReturn(Futures.immediateFuture(SeekableStreamIndexTaskRunner.Status.READING))
@@ -1193,6 +1202,7 @@ public class SeekableStreamSupervisorStateTest extends EasyMockSupport
     };
 
     EasyMock.reset(spec);
+    EasyMock.expect(spec.getId()).andReturn(SUPERVISOR_ID).anyTimes();
     EasyMock.expect(spec.isSuspended()).andReturn(false).anyTimes();
     EasyMock.expect(spec.getDataSchema()).andReturn(getDataSchema()).anyTimes();
     EasyMock.expect(spec.getIoConfig()).andReturn(ioConfig).anyTimes();
@@ -1223,6 +1233,7 @@ public class SeekableStreamSupervisorStateTest extends EasyMockSupport
     TestSeekableStreamIndexTask id1 = new TestSeekableStreamIndexTask(
         "id1",
         null,
+        null,
         getDataSchema(),
         taskTuningConfig,
         createTaskIoConfigExt(
@@ -1242,6 +1253,7 @@ public class SeekableStreamSupervisorStateTest extends EasyMockSupport
     TestSeekableStreamIndexTask id2 = new TestSeekableStreamIndexTask(
         "id2",
         null,
+        null,
         getDataSchema(),
         taskTuningConfig,
         createTaskIoConfigExt(
@@ -1260,6 +1272,7 @@ public class SeekableStreamSupervisorStateTest extends EasyMockSupport
 
     TestSeekableStreamIndexTask id3 = new TestSeekableStreamIndexTask(
         "id3",
+        null,
         null,
         getDataSchema(),
         taskTuningConfig,
@@ -1301,7 +1314,7 @@ public class SeekableStreamSupervisorStateTest extends EasyMockSupport
     EasyMock.expect(taskStorage.getTask("id3")).andReturn(Optional.of(id2)).anyTimes();
 
     EasyMock.reset(indexerMetadataStorageCoordinator);
-    EasyMock.expect(indexerMetadataStorageCoordinator.retrieveDataSourceMetadata(DATASOURCE))
+    EasyMock.expect(indexerMetadataStorageCoordinator.retrieveDataSourceMetadata(SUPERVISOR_ID))
             .andReturn(new TestSeekableStreamDataSourceMetadata(null)).anyTimes();
     EasyMock.expect(indexTaskClient.getStatusAsync("id1"))
             .andReturn(Futures.immediateFuture(SeekableStreamIndexTaskRunner.Status.READING))
@@ -1639,7 +1652,7 @@ public class SeekableStreamSupervisorStateTest extends EasyMockSupport
   public void testSupervisorResetAllWithCheckpoints() throws InterruptedException
   {
     EasyMock.expect(spec.isSuspended()).andReturn(false);
-    EasyMock.expect(indexerMetadataStorageCoordinator.deleteDataSourceMetadata(DATASOURCE)).andReturn(
+    EasyMock.expect(indexerMetadataStorageCoordinator.deleteDataSourceMetadata(SUPERVISOR_ID)).andReturn(
         true
     );
     taskQueue.shutdown("task1", "DataSourceMetadata is not found while reset");
@@ -1684,7 +1697,7 @@ public class SeekableStreamSupervisorStateTest extends EasyMockSupport
 
     EasyMock.expect(spec.isSuspended()).andReturn(false);
     EasyMock.reset(indexerMetadataStorageCoordinator);
-    EasyMock.expect(indexerMetadataStorageCoordinator.retrieveDataSourceMetadata(DATASOURCE)).andReturn(
+    EasyMock.expect(indexerMetadataStorageCoordinator.retrieveDataSourceMetadata(SUPERVISOR_ID)).andReturn(
         new TestSeekableStreamDataSourceMetadata(
             new SeekableStreamEndSequenceNumbers<>(
                 STREAM,
@@ -1692,7 +1705,7 @@ public class SeekableStreamSupervisorStateTest extends EasyMockSupport
             )
         )
     );
-    EasyMock.expect(indexerMetadataStorageCoordinator.resetDataSourceMetadata(DATASOURCE, new TestSeekableStreamDataSourceMetadata(
+    EasyMock.expect(indexerMetadataStorageCoordinator.resetDataSourceMetadata(SUPERVISOR_ID, new TestSeekableStreamDataSourceMetadata(
         new SeekableStreamEndSequenceNumbers<>(
             STREAM,
             expectedOffsets
@@ -1823,7 +1836,7 @@ public class SeekableStreamSupervisorStateTest extends EasyMockSupport
 
     EasyMock.expect(spec.isSuspended()).andReturn(false);
     EasyMock.reset(indexerMetadataStorageCoordinator);
-    EasyMock.expect(indexerMetadataStorageCoordinator.retrieveDataSourceMetadata(DATASOURCE)).andReturn(
+    EasyMock.expect(indexerMetadataStorageCoordinator.retrieveDataSourceMetadata(SUPERVISOR_ID)).andReturn(
         new TestSeekableStreamDataSourceMetadata(
             new SeekableStreamEndSequenceNumbers<>(
                 STREAM,
@@ -1831,7 +1844,7 @@ public class SeekableStreamSupervisorStateTest extends EasyMockSupport
             )
         )
     );
-    EasyMock.expect(indexerMetadataStorageCoordinator.resetDataSourceMetadata(DATASOURCE, new TestSeekableStreamDataSourceMetadata(
+    EasyMock.expect(indexerMetadataStorageCoordinator.resetDataSourceMetadata(SUPERVISOR_ID, new TestSeekableStreamDataSourceMetadata(
         new SeekableStreamEndSequenceNumbers<>(
             "stream",
             expectedOffsets
@@ -1901,8 +1914,8 @@ public class SeekableStreamSupervisorStateTest extends EasyMockSupport
 
     EasyMock.expect(spec.isSuspended()).andReturn(false);
     EasyMock.reset(indexerMetadataStorageCoordinator);
-    EasyMock.expect(indexerMetadataStorageCoordinator.retrieveDataSourceMetadata(DATASOURCE)).andReturn(null);
-    EasyMock.expect(indexerMetadataStorageCoordinator.insertDataSourceMetadata(DATASOURCE, new TestSeekableStreamDataSourceMetadata(
+    EasyMock.expect(indexerMetadataStorageCoordinator.retrieveDataSourceMetadata(SUPERVISOR_ID)).andReturn(null);
+    EasyMock.expect(indexerMetadataStorageCoordinator.insertDataSourceMetadata(SUPERVISOR_ID, new TestSeekableStreamDataSourceMetadata(
         new SeekableStreamEndSequenceNumbers<>(
             "stream",
             expectedOffsets
@@ -1974,7 +1987,7 @@ public class SeekableStreamSupervisorStateTest extends EasyMockSupport
 
     EasyMock.expect(spec.isSuspended()).andReturn(false);
     EasyMock.reset(indexerMetadataStorageCoordinator);
-    EasyMock.expect(indexerMetadataStorageCoordinator.retrieveDataSourceMetadata(DATASOURCE)).andReturn(
+    EasyMock.expect(indexerMetadataStorageCoordinator.retrieveDataSourceMetadata(SUPERVISOR_ID)).andReturn(
         new TestSeekableStreamDataSourceMetadata(
             new SeekableStreamEndSequenceNumbers<>(
                 STREAM,
@@ -1982,7 +1995,7 @@ public class SeekableStreamSupervisorStateTest extends EasyMockSupport
             )
         )
     );
-    EasyMock.expect(indexerMetadataStorageCoordinator.resetDataSourceMetadata(DATASOURCE, new TestSeekableStreamDataSourceMetadata(
+    EasyMock.expect(indexerMetadataStorageCoordinator.resetDataSourceMetadata(SUPERVISOR_ID, new TestSeekableStreamDataSourceMetadata(
         new SeekableStreamEndSequenceNumbers<>(
             "stream",
             expectedOffsets
@@ -2039,7 +2052,7 @@ public class SeekableStreamSupervisorStateTest extends EasyMockSupport
 
     EasyMock.expect(spec.isSuspended()).andReturn(false);
     EasyMock.reset(indexerMetadataStorageCoordinator);
-    EasyMock.expect(indexerMetadataStorageCoordinator.retrieveDataSourceMetadata(DATASOURCE)).andReturn(
+    EasyMock.expect(indexerMetadataStorageCoordinator.retrieveDataSourceMetadata(SUPERVISOR_ID)).andReturn(
         new TestSeekableStreamDataSourceMetadata(
             new SeekableStreamEndSequenceNumbers<>(
                 STREAM,
@@ -2047,7 +2060,7 @@ public class SeekableStreamSupervisorStateTest extends EasyMockSupport
             )
         )
     );
-    EasyMock.expect(indexerMetadataStorageCoordinator.resetDataSourceMetadata(DATASOURCE, new TestSeekableStreamDataSourceMetadata(
+    EasyMock.expect(indexerMetadataStorageCoordinator.resetDataSourceMetadata(SUPERVISOR_ID, new TestSeekableStreamDataSourceMetadata(
         new SeekableStreamEndSequenceNumbers<>(
             "stream",
             expectedOffsets
@@ -2301,6 +2314,7 @@ public class SeekableStreamSupervisorStateTest extends EasyMockSupport
   private void expectEmitterSupervisor(boolean suspended)
   {
     spec = createMock(SeekableStreamSupervisorSpec.class);
+    EasyMock.expect(spec.getId()).andReturn(SUPERVISOR_ID).anyTimes();
     EasyMock.expect(spec.getSupervisorStateManagerConfig()).andReturn(supervisorConfig).anyTimes();
     EasyMock.expect(spec.getDataSchema()).andReturn(getDataSchema()).anyTimes();
     EasyMock.expect(spec.getIoConfig()).andReturn(new SeekableStreamSupervisorIOConfig(
@@ -2492,6 +2506,7 @@ public class SeekableStreamSupervisorStateTest extends EasyMockSupport
   {
     public TestSeekableStreamIndexTask(
         String id,
+        @Nullable String supervisorId,
         @Nullable TaskResource taskResource,
         DataSchema dataSchema,
         SeekableStreamIndexTaskTuningConfig tuningConfig,
@@ -2502,6 +2517,7 @@ public class SeekableStreamSupervisorStateTest extends EasyMockSupport
     {
       super(
           id,
+          supervisorId,
           taskResource,
           dataSchema,
           tuningConfig,
@@ -2613,6 +2629,7 @@ public class SeekableStreamSupervisorStateTest extends EasyMockSupport
       return ImmutableList.of(new TestSeekableStreamIndexTask(
           "id",
           null,
+          null,
           getDataSchema(),
           taskTuningConfig,
           taskIoConfig,
@@ -2639,7 +2656,7 @@ public class SeekableStreamSupervisorStateTest extends EasyMockSupport
     }
 
     @Override
-    protected boolean doesTaskTypeMatchSupervisor(Task task)
+    protected boolean doesTaskMatchSupervisor(Task task)
     {
       return true;
     }
@@ -2691,6 +2708,7 @@ public class SeekableStreamSupervisorStateTest extends EasyMockSupport
     )
     {
       return new SeekableStreamSupervisorReportPayload<String, String>(
+          SUPERVISOR_ID,
           DATASOURCE,
           STREAM,
           1,

--- a/indexing-service/src/test/java/org/apache/druid/indexing/test/TestIndexerMetadataStorageCoordinator.java
+++ b/indexing-service/src/test/java/org/apache/druid/indexing/test/TestIndexerMetadataStorageCoordinator.java
@@ -61,25 +61,25 @@ public class TestIndexerMetadataStorageCoordinator implements IndexerMetadataSto
   }
 
   @Override
-  public DataSourceMetadata retrieveDataSourceMetadata(String dataSource)
+  public DataSourceMetadata retrieveDataSourceMetadata(String supervisorId)
   {
     throw new UnsupportedOperationException();
   }
 
   @Override
-  public boolean deleteDataSourceMetadata(String dataSource)
+  public boolean deleteDataSourceMetadata(String supervisorId)
   {
     throw new UnsupportedOperationException();
   }
 
   @Override
-  public boolean resetDataSourceMetadata(String dataSource, DataSourceMetadata dataSourceMetadata)
+  public boolean resetDataSourceMetadata(String supervisorId, DataSourceMetadata dataSourceMetadata)
   {
     return false;
   }
 
   @Override
-  public boolean insertDataSourceMetadata(String dataSource, DataSourceMetadata dataSourceMetadata)
+  public boolean insertDataSourceMetadata(String supervisorId, DataSourceMetadata dataSourceMetadata)
   {
     return false;
   }
@@ -193,6 +193,7 @@ public class TestIndexerMetadataStorageCoordinator implements IndexerMetadataSto
   public SegmentPublishResult commitAppendSegmentsAndMetadata(
       Set<DataSegment> appendSegments,
       Map<DataSegment, ReplaceTaskLock> appendSegmentToReplaceLock,
+      String supervisorId,
       DataSourceMetadata startMetadata,
       DataSourceMetadata endMetadata,
       String taskGroup,
@@ -205,6 +206,7 @@ public class TestIndexerMetadataStorageCoordinator implements IndexerMetadataSto
   @Override
   public SegmentPublishResult commitSegmentsAndMetadata(
       Set<DataSegment> segments,
+      @Nullable final String supervisorId,
       @Nullable DataSourceMetadata startMetadata,
       @Nullable DataSourceMetadata endMetadata,
       SegmentSchemaMapping segmentSchemaMapping
@@ -216,6 +218,7 @@ public class TestIndexerMetadataStorageCoordinator implements IndexerMetadataSto
 
   @Override
   public SegmentPublishResult commitMetadataOnly(
+      String supervisorId,
       String dataSource,
       DataSourceMetadata startMetadata,
       DataSourceMetadata endMetadata

--- a/integration-tests/src/test/java/org/apache/druid/tests/indexer/AbstractKafkaIndexingServiceTest.java
+++ b/integration-tests/src/test/java/org/apache/druid/tests/indexer/AbstractKafkaIndexingServiceTest.java
@@ -50,6 +50,7 @@ public abstract class AbstractKafkaIndexingServiceTest extends AbstractStreamInd
 
   @Override
   Function<String, String> generateStreamIngestionPropsTransform(
+      String supervisorId,
       String streamName,
       String fullDatasourceName,
       String parserType,
@@ -65,6 +66,11 @@ public abstract class AbstractKafkaIndexingServiceTest extends AbstractStreamInd
     KafkaUtil.addPropertiesFromTestConfig(config, consumerProperties);
     return spec -> {
       try {
+        spec = StringUtils.replace(
+            spec,
+            "%%SUPERVISOR_ID%%",
+            supervisorId
+        );
         spec = StringUtils.replace(
             spec,
             "%%DATASOURCE%%",

--- a/integration-tests/src/test/java/org/apache/druid/tests/indexer/AbstractKinesisIndexingServiceTest.java
+++ b/integration-tests/src/test/java/org/apache/druid/tests/indexer/AbstractKinesisIndexingServiceTest.java
@@ -56,6 +56,7 @@ public abstract class AbstractKinesisIndexingServiceTest extends AbstractStreamI
 
   @Override
   Function<String, String> generateStreamIngestionPropsTransform(
+      String supervisorId,
       String streamName,
       String fullDatasourceName,
       String parserType,
@@ -66,6 +67,11 @@ public abstract class AbstractKinesisIndexingServiceTest extends AbstractStreamI
   {
     return spec -> {
       try {
+        spec = StringUtils.replace(
+            spec,
+            "%%SUPERVISOR_ID%%",
+            supervisorId
+        );
         spec = StringUtils.replace(
             spec,
             "%%DATASOURCE%%",

--- a/integration-tests/src/test/java/org/apache/druid/tests/parallelized/ITKafkaIndexingServiceNonTransactionalParallelizedTest.java
+++ b/integration-tests/src/test/java/org/apache/druid/tests/parallelized/ITKafkaIndexingServiceNonTransactionalParallelizedTest.java
@@ -87,4 +87,17 @@ public class ITKafkaIndexingServiceNonTransactionalParallelizedTest extends Abst
   {
     doTestTerminatedSupervisorAutoCleanup(false);
   }
+
+  /**
+   * This test can be run concurrently with other tests as it creates/modifies/teardowns a unique datasource
+   * with supervisor(s) maintained and scoped within this test only
+   */
+  @Test
+  public void testKafkaIndexMultiSupervisorWithNoTransaction() throws Exception
+  {
+    doTestMultiSupervisorIndexDataStableState(
+        false,
+        2
+    );
+  }
 }

--- a/integration-tests/src/test/java/org/apache/druid/tests/parallelized/ITKafkaIndexingServiceTransactionalParallelizedTest.java
+++ b/integration-tests/src/test/java/org/apache/druid/tests/parallelized/ITKafkaIndexingServiceTransactionalParallelizedTest.java
@@ -61,4 +61,17 @@ public class ITKafkaIndexingServiceTransactionalParallelizedTest extends Abstrac
   {
     doTestIndexDataWithStreamReshardSplit(true);
   }
+
+  /**
+   * This test can be run concurrently with other tests as it creates/modifies/teardowns a unique datasource
+   * with supervisor(s) maintained and scoped within this test only
+   */
+  @Test
+  public void testKafkaIndexMultiSupervisorWithTransaction() throws Exception
+  {
+    doTestMultiSupervisorIndexDataStableState(
+        true,
+        2
+    );
+  }
 }

--- a/integration-tests/src/test/java/org/apache/druid/tests/parallelized/ITKinesisIndexingServiceParallelizedTest.java
+++ b/integration-tests/src/test/java/org/apache/druid/tests/parallelized/ITKinesisIndexingServiceParallelizedTest.java
@@ -51,4 +51,17 @@ public class ITKinesisIndexingServiceParallelizedTest extends AbstractKinesisInd
   {
     doTestTerminatedSupervisorAutoCleanup(false);
   }
+
+  /**
+   * This test can be run concurrently with other tests as it creates/modifies/teardowns a unique datasource
+   * with supervisor(s) maintained and scoped within this test only
+   */
+  @Test
+  public void testKinesisIndexMultiSupervisor() throws Exception
+  {
+    doTestMultiSupervisorIndexDataStableState(
+        null,
+        2
+    );
+  }
 }

--- a/integration-tests/src/test/resources/stream/data/supervisor_with_autoscaler_spec_template.json
+++ b/integration-tests/src/test/resources/stream/data/supervisor_with_autoscaler_spec_template.json
@@ -1,5 +1,6 @@
 {
   "type": "%%STREAM_TYPE%%",
+  "id": "%%SUPERVISOR_ID%%",
   "dataSchema": {
     "dataSource": "%%DATASOURCE%%",
     "parser": %%PARSER%%,

--- a/integration-tests/src/test/resources/stream/data/supervisor_with_idle_behaviour_enabled_spec_template.json
+++ b/integration-tests/src/test/resources/stream/data/supervisor_with_idle_behaviour_enabled_spec_template.json
@@ -1,5 +1,6 @@
 {
   "type": "%%STREAM_TYPE%%",
+  "id": "%%SUPERVISOR_ID%%",
   "dataSchema": {
     "dataSource": "%%DATASOURCE%%",
     "parser": %%PARSER%%,

--- a/integration-tests/src/test/resources/stream/data/supervisor_with_long_duration.json
+++ b/integration-tests/src/test/resources/stream/data/supervisor_with_long_duration.json
@@ -49,9 +49,9 @@
   "ioConfig": {
     "%%TOPIC_KEY%%": "%%TOPIC_VALUE%%",
     "%%STREAM_PROPERTIES_KEY%%": %%STREAM_PROPERTIES_VALUE%%,
-    "taskCount": 2,
+    "taskCount": 1,
     "replicas": 1,
-    "taskDuration": "PT120S",
+    "taskDuration": "PT600S",
     "%%USE_EARLIEST_KEY%%": true,
     "inputFormat" : %%INPUT_FORMAT%%
   }

--- a/processing/src/main/java/org/apache/druid/query/DruidMetrics.java
+++ b/processing/src/main/java/org/apache/druid/query/DruidMetrics.java
@@ -46,6 +46,7 @@ public class DruidMetrics
   public static final String STREAM = "stream";
 
   public static final String PARTITION = "partition";
+  public static final String SUPERVISOR_ID = "supervisorId";
 
   public static final String TAGS = "tags";
 

--- a/server/src/main/java/org/apache/druid/indexing/overlord/IndexerMetadataStorageCoordinator.java
+++ b/server/src/main/java/org/apache/druid/indexing/overlord/IndexerMetadataStorageCoordinator.java
@@ -289,6 +289,8 @@ public interface IndexerMetadataStorageCoordinator
    * If segmentsToDrop is not null and not empty, this insertion will be atomic with a insert-and-drop on inserting
    * {@param segments} and dropping {@param segmentsToDrop}.
    *
+   * @param supervisorId   supervisorID which is committing the segments. Cannot be null if `startMetadata`
+   *                       and endMetadata` are both non-null.
    * @param segments       set of segments to add, must all be from the same dataSource
    * @param startMetadata  dataSource metadata pre-insert must match this startMetadata according to
    *                       {@link DataSourceMetadata#matches(DataSourceMetadata)}. If null, this insert will
@@ -307,6 +309,7 @@ public interface IndexerMetadataStorageCoordinator
    */
   SegmentPublishResult commitSegmentsAndMetadata(
       Set<DataSegment> segments,
+      @Nullable String supervisorId,
       @Nullable DataSourceMetadata startMetadata,
       @Nullable DataSourceMetadata endMetadata,
       @Nullable SegmentSchemaMapping segmentSchemaMapping
@@ -350,6 +353,7 @@ public interface IndexerMetadataStorageCoordinator
   SegmentPublishResult commitAppendSegmentsAndMetadata(
       Set<DataSegment> appendSegments,
       Map<DataSegment, ReplaceTaskLock> appendSegmentToReplaceLock,
+      @Nullable String supervisorId,
       DataSourceMetadata startMetadata,
       DataSourceMetadata endMetadata,
       String taskGroup,
@@ -396,47 +400,47 @@ public interface IndexerMetadataStorageCoordinator
   );
 
   /**
-   * Retrieves data source's metadata from the metadata store. Returns null if there is no metadata.
+   * Retrieves {@link DataSourceMetadata} entry for {@code supervisorId} from the metadata store. Returns null if there is no metadata.
    */
-  @Nullable DataSourceMetadata retrieveDataSourceMetadata(String dataSource);
+  @Nullable DataSourceMetadata retrieveDataSourceMetadata(String supervisorId);
 
   /**
-   * Removes entry for 'dataSource' from the dataSource metadata table.
+   * Removes entry for {@code supervisorId} from the dataSource metadata table.
    *
-   * @param dataSource identifier
+   * @param supervisorId identifier
    *
    * @return true if the entry was deleted, false otherwise
    */
-  boolean deleteDataSourceMetadata(String dataSource);
+  boolean deleteDataSourceMetadata(String supervisorId);
 
   /**
-   * Resets dataSourceMetadata entry for 'dataSource' to the one supplied.
+   * Resets {@link DataSourceMetadata} entry for {@code supervisorId} to the one supplied.
    *
-   * @param dataSource         identifier
+   * @param supervisorId         identifier
    * @param dataSourceMetadata value to set
    *
    * @return true if the entry was reset, false otherwise
    */
-  boolean resetDataSourceMetadata(String dataSource, DataSourceMetadata dataSourceMetadata) throws IOException;
+  boolean resetDataSourceMetadata(String supervisorId, DataSourceMetadata dataSourceMetadata) throws IOException;
 
   /**
-   * Insert dataSourceMetadata entry for 'dataSource'.
+   * Insert {@link DataSourceMetadata} entry for {@code supervisorId}.
    *
-   * @param dataSource         identifier
+   * @param supervisorId       identifier
    * @param dataSourceMetadata value to set
    *
    * @return true if the entry was inserted, false otherwise
    */
-  boolean insertDataSourceMetadata(String dataSource, DataSourceMetadata dataSourceMetadata);
+  boolean insertDataSourceMetadata(String supervisorId, DataSourceMetadata dataSourceMetadata);
 
   /**
-   * Remove datasource metadata created before the given timestamp and not in given excludeDatasources set.
+   * Remove supervisors' datasource metadata created before the given timestamp and not in given excludeSupervisorIds set.
    *
    * @param timestamp timestamp in milliseconds
-   * @param excludeDatasources set of datasource names to exclude from removal
+   * @param excludeSupervisorIds set of supervisor ids to exclude from removal
    * @return number of datasource metadata removed
    */
-  int removeDataSourceMetadataOlderThan(long timestamp, @NotNull Set<String> excludeDatasources);
+  int removeDataSourceMetadataOlderThan(long timestamp, @NotNull Set<String> excludeSupervisorIds);
 
   /**
    * Similar to {@link #commitSegments}, but meant for streaming ingestion tasks for handling
@@ -446,7 +450,8 @@ public interface IndexerMetadataStorageCoordinator
    * The metadata should undergo the same validation checks as performed by {@link #commitSegments}.
    *
    *
-   * @param dataSource the datasource
+   * @param supervisorId the supervisorId
+   * @param dataSource the dataSource
    * @param startMetadata dataSource metadata pre-insert must match this startMetadata according to
    *                      {@link DataSourceMetadata#matches(DataSourceMetadata)}.
    * @param endMetadata   dataSource metadata post-insert will have this endMetadata merged in with
@@ -460,6 +465,7 @@ public interface IndexerMetadataStorageCoordinator
    * @throws RuntimeException         if the state of metadata storage after this call is unknown
    */
   SegmentPublishResult commitMetadataOnly(
+      String supervisorId,
       String dataSource,
       DataSourceMetadata startMetadata,
       DataSourceMetadata endMetadata

--- a/server/src/main/java/org/apache/druid/indexing/overlord/IndexerMetadataStorageCoordinator.java
+++ b/server/src/main/java/org/apache/druid/indexing/overlord/IndexerMetadataStorageCoordinator.java
@@ -19,6 +19,7 @@
 
 package org.apache.druid.indexing.overlord;
 
+import org.apache.druid.error.InvalidInput;
 import org.apache.druid.java.util.common.Pair;
 import org.apache.druid.metadata.PendingSegmentRecord;
 import org.apache.druid.metadata.ReplaceTaskLock;
@@ -289,8 +290,8 @@ public interface IndexerMetadataStorageCoordinator
    * If segmentsToDrop is not null and not empty, this insertion will be atomic with a insert-and-drop on inserting
    * {@param segments} and dropping {@param segmentsToDrop}.
    *
-   * @param supervisorId   supervisorID which is committing the segments. Cannot be null if `startMetadata`
-   *                       and endMetadata` are both non-null.
+   * @param supervisorId   supervisorID which is committing the segments. Cannot be null if {@code startMetadata}
+   *                       and {@code endMetadata} are both non-null.
    * @param segments       set of segments to add, must all be from the same dataSource
    * @param startMetadata  dataSource metadata pre-insert must match this startMetadata according to
    *                       {@link DataSourceMetadata#matches(DataSourceMetadata)}. If null, this insert will
@@ -511,4 +512,21 @@ public interface IndexerMetadataStorageCoordinator
    * @return List of pending segment records
    */
   List<PendingSegmentRecord> getPendingSegments(String datasource, Interval interval);
+  /**
+   * Validates the given supervisorId and given metadata to ensure
+   * that start/end metadata non-null implies supervisor ID is non-null.
+   */
+  static void validateDataSourceMetadata(
+      @Nullable final String supervisorId,
+      @Nullable final DataSourceMetadata startMetadata,
+      @Nullable final DataSourceMetadata endMetadata
+  )
+  {
+    if ((startMetadata == null && endMetadata != null) || (startMetadata != null && endMetadata == null)) {
+      throw InvalidInput.exception("'startMetadata' and 'endMetadata' must either both be null or both non-null");
+    } else if (startMetadata != null && supervisorId == null) {
+      throw InvalidInput.exception(
+          "'supervisorId' cannot be null if 'startMetadata' and 'endMetadata' are both non-null.");
+    }
+  }
 }

--- a/server/src/main/java/org/apache/druid/indexing/overlord/supervisor/SupervisorStatus.java
+++ b/server/src/main/java/org/apache/druid/indexing/overlord/supervisor/SupervisorStatus.java
@@ -37,6 +37,7 @@ import java.util.Objects;
 public class SupervisorStatus
 {
   private final String id;
+  private final String dataSource;
   private final String state;
   private final String detailedState;
   private final boolean healthy;
@@ -56,6 +57,7 @@ public class SupervisorStatus
   )
   {
     this.id = Preconditions.checkNotNull(builder.id, "id");
+    this.dataSource = builder.dataSource;
     this.state = builder.state;
     this.detailedState = builder.detailedState;
     this.healthy = builder.healthy;
@@ -78,6 +80,7 @@ public class SupervisorStatus
     SupervisorStatus that = (SupervisorStatus) o;
     return healthy == that.healthy &&
            Objects.equals(id, that.id) &&
+           Objects.equals(dataSource, that.dataSource) &&
            Objects.equals(state, that.state) &&
            Objects.equals(detailedState, that.detailedState) &&
            Objects.equals(spec, that.spec) &&
@@ -90,13 +93,19 @@ public class SupervisorStatus
   @Override
   public int hashCode()
   {
-    return Objects.hash(id, state, detailedState, healthy, spec, specString, type, source, suspended);
+    return Objects.hash(id, dataSource, state, detailedState, healthy, spec, specString, type, source, suspended);
   }
 
   @JsonProperty
   public String getId()
   {
     return id;
+  }
+
+  @JsonProperty
+  public String getDataSource()
+  {
+    return dataSource;
   }
 
   @JsonProperty
@@ -152,6 +161,8 @@ public class SupervisorStatus
   {
     @JsonProperty("id")
     private String id;
+    @JsonProperty("dataSource")
+    private String dataSource;
     @JsonProperty("state")
     private String state;
     @JsonProperty("detailedState")
@@ -173,6 +184,13 @@ public class SupervisorStatus
     public Builder withId(String id)
     {
       this.id = Preconditions.checkNotNull(id, "id");
+      return this;
+    }
+
+    @JsonProperty
+    public Builder withDataSource(String dataSource)
+    {
+      this.dataSource = Preconditions.checkNotNull(dataSource, "dataSource");
       return this;
     }
 

--- a/server/src/main/java/org/apache/druid/metadata/IndexerSQLMetadataStorageCoordinator.java
+++ b/server/src/main/java/org/apache/druid/metadata/IndexerSQLMetadataStorageCoordinator.java
@@ -429,14 +429,7 @@ public class IndexerSQLMetadataStorageCoordinator implements IndexerMetadataStor
   ) throws IOException
   {
     verifySegmentsToCommit(segments);
-
-    if ((startMetadata == null && endMetadata != null) || (startMetadata != null && endMetadata == null)) {
-      throw new IllegalArgumentException("start/end metadata pair must be either null or non-null");
-    } else if (startMetadata != null && supervisorId == null) {
-      throw new IllegalArgumentException(
-          "supervisorId cannot be null if startMetadata and endMetadata are both non-null.");
-    }
-
+    IndexerMetadataStorageCoordinator.validateDataSourceMetadata(supervisorId, startMetadata, endMetadata);
     final String dataSource = segments.iterator().next().getDataSource();
 
     // Find which segments are used (i.e. not overshadowed).
@@ -1356,13 +1349,7 @@ public class IndexerSQLMetadataStorageCoordinator implements IndexerMetadataStor
   )
   {
     verifySegmentsToCommit(appendSegments);
-    if ((startMetadata == null && endMetadata != null)
-        || (startMetadata != null && endMetadata == null)) {
-      throw new IllegalArgumentException("start/end metadata pair must be either null or non-null");
-    } else if (startMetadata != null && supervisorId == null) {
-      throw new IllegalArgumentException(
-          "supervisorId cannot be null if startMetadata and endMetadata are both non-null.");
-    }
+    IndexerMetadataStorageCoordinator.validateDataSourceMetadata(supervisorId, startMetadata, endMetadata);
 
     final String dataSource = appendSegments.iterator().next().getDataSource();
     final List<PendingSegmentRecord> segmentIdsForNewVersions = connector.retryTransaction(
@@ -2665,7 +2652,7 @@ public class IndexerSQLMetadataStorageCoordinator implements IndexerMetadataStor
 
     if (retVal.isSuccess()) {
       log.info(
-          "Updated metadata for supervisor[%s] for datasource[%s] from[%s] to[%s].",
+          "Updated metadata for supervisor[%s], datasource[%s] from[%s] to[%s].",
           supervisorId, dataSource, oldCommitMetadataFromDb, newCommitMetadata
       );
     } else {

--- a/server/src/main/java/org/apache/druid/metadata/IndexerSQLMetadataStorageCoordinator.java
+++ b/server/src/main/java/org/apache/druid/metadata/IndexerSQLMetadataStorageCoordinator.java
@@ -407,6 +407,7 @@ public class IndexerSQLMetadataStorageCoordinator implements IndexerMetadataStor
             segments,
             null,
             null,
+            null,
             segmentSchemaMapping
         );
 
@@ -421,6 +422,7 @@ public class IndexerSQLMetadataStorageCoordinator implements IndexerMetadataStor
   @Override
   public SegmentPublishResult commitSegmentsAndMetadata(
       final Set<DataSegment> segments,
+      @Nullable final String supervisorId,
       @Nullable final DataSourceMetadata startMetadata,
       @Nullable final DataSourceMetadata endMetadata,
       @Nullable final SegmentSchemaMapping segmentSchemaMapping
@@ -430,6 +432,9 @@ public class IndexerSQLMetadataStorageCoordinator implements IndexerMetadataStor
 
     if ((startMetadata == null && endMetadata != null) || (startMetadata != null && endMetadata == null)) {
       throw new IllegalArgumentException("start/end metadata pair must be either null or non-null");
+    } else if (startMetadata != null && supervisorId == null) {
+      throw new IllegalArgumentException(
+          "supervisorId cannot be null if startMetadata and endMetadata are both non-null.");
     }
 
     final String dataSource = segments.iterator().next().getDataSource();
@@ -455,6 +460,7 @@ public class IndexerSQLMetadataStorageCoordinator implements IndexerMetadataStor
             if (startMetadata != null) {
               final DataStoreMetadataUpdateResult result = updateDataSourceMetadataWithHandle(
                   handle,
+                  supervisorId,
                   dataSource,
                   startMetadata,
                   endMetadata
@@ -557,6 +563,7 @@ public class IndexerSQLMetadataStorageCoordinator implements IndexerMetadataStor
         appendSegmentToReplaceLock,
         null,
         null,
+        null,
         taskAllocatorId,
         segmentSchemaMapping
     );
@@ -566,6 +573,7 @@ public class IndexerSQLMetadataStorageCoordinator implements IndexerMetadataStor
   public SegmentPublishResult commitAppendSegmentsAndMetadata(
       Set<DataSegment> appendSegments,
       Map<DataSegment, ReplaceTaskLock> appendSegmentToReplaceLock,
+      String supervisorId,
       DataSourceMetadata startMetadata,
       DataSourceMetadata endMetadata,
       String taskAllocatorId,
@@ -575,6 +583,7 @@ public class IndexerSQLMetadataStorageCoordinator implements IndexerMetadataStor
     return commitAppendSegmentsAndMetadataInTransaction(
         appendSegments,
         appendSegmentToReplaceLock,
+        supervisorId,
         startMetadata,
         endMetadata,
         taskAllocatorId,
@@ -584,11 +593,15 @@ public class IndexerSQLMetadataStorageCoordinator implements IndexerMetadataStor
 
   @Override
   public SegmentPublishResult commitMetadataOnly(
+      String supervisorId,
       String dataSource,
       DataSourceMetadata startMetadata,
       DataSourceMetadata endMetadata
   )
   {
+    if (supervisorId == null) {
+      throw new IllegalArgumentException("supervisorId cannot be null");
+    }
     if (dataSource == null) {
       throw new IllegalArgumentException("datasource name cannot be null");
     }
@@ -616,6 +629,7 @@ public class IndexerSQLMetadataStorageCoordinator implements IndexerMetadataStor
 
               final DataStoreMetadataUpdateResult result = updateDataSourceMetadataWithHandle(
                   handle,
+                  supervisorId,
                   dataSource,
                   startMetadata,
                   endMetadata
@@ -1334,6 +1348,7 @@ public class IndexerSQLMetadataStorageCoordinator implements IndexerMetadataStor
   private SegmentPublishResult commitAppendSegmentsAndMetadataInTransaction(
       Set<DataSegment> appendSegments,
       Map<DataSegment, ReplaceTaskLock> appendSegmentToReplaceLock,
+      @Nullable String supervisorId,
       @Nullable DataSourceMetadata startMetadata,
       @Nullable DataSourceMetadata endMetadata,
       String taskAllocatorId,
@@ -1344,6 +1359,9 @@ public class IndexerSQLMetadataStorageCoordinator implements IndexerMetadataStor
     if ((startMetadata == null && endMetadata != null)
         || (startMetadata != null && endMetadata == null)) {
       throw new IllegalArgumentException("start/end metadata pair must be either null or non-null");
+    } else if (startMetadata != null && supervisorId == null) {
+      throw new IllegalArgumentException(
+          "supervisorId cannot be null if startMetadata and endMetadata are both non-null.");
     }
 
     final String dataSource = appendSegments.iterator().next().getDataSource();
@@ -1389,7 +1407,7 @@ public class IndexerSQLMetadataStorageCoordinator implements IndexerMetadataStor
 
             if (startMetadata != null) {
               final DataStoreMetadataUpdateResult metadataUpdateResult
-                  = updateDataSourceMetadataWithHandle(handle, dataSource, startMetadata, endMetadata);
+                  = updateDataSourceMetadataWithHandle(handle, supervisorId, dataSource, startMetadata, endMetadata);
 
               if (metadataUpdateResult.isFailed()) {
                 transactionStatus.setRollbackOnly();
@@ -2467,16 +2485,16 @@ public class IndexerSQLMetadataStorageCoordinator implements IndexerMetadataStor
   }
 
   /**
-   * Read dataSource metadata. Returns null if there is no metadata.
+   * Read dataSource metadata for the given supervisorId. Returns null if there is no metadata.
    */
   @Override
-  public @Nullable DataSourceMetadata retrieveDataSourceMetadata(final String dataSource)
+  public @Nullable DataSourceMetadata retrieveDataSourceMetadata(final String supervisorId)
   {
     final byte[] bytes = connector.lookup(
         dbTables.getDataSourceTable(),
         "dataSource",
         "commit_metadata_payload",
-        dataSource
+        supervisorId
     );
 
     if (bytes == null) {
@@ -2487,11 +2505,11 @@ public class IndexerSQLMetadataStorageCoordinator implements IndexerMetadataStor
   }
 
   /**
-   * Read dataSource metadata as bytes, from a specific handle. Returns null if there is no metadata.
+   * Read supervisor datasource metadata as bytes, from a specific handle. Returns null if there is no metadata.
    */
   private @Nullable byte[] retrieveDataSourceMetadataWithHandleAsBytes(
       final Handle handle,
-      final String dataSource
+      final String supervisorId
   )
   {
     return connector.lookupWithHandle(
@@ -2499,7 +2517,7 @@ public class IndexerSQLMetadataStorageCoordinator implements IndexerMetadataStor
         dbTables.getDataSourceTable(),
         "dataSource",
         "commit_metadata_payload",
-        dataSource
+        supervisorId
     );
   }
 
@@ -2523,16 +2541,18 @@ public class IndexerSQLMetadataStorageCoordinator implements IndexerMetadataStor
    */
   protected DataStoreMetadataUpdateResult updateDataSourceMetadataWithHandle(
       final Handle handle,
+      final String supervisorId,
       final String dataSource,
       final DataSourceMetadata startMetadata,
       final DataSourceMetadata endMetadata
   ) throws IOException
   {
+    Preconditions.checkNotNull(supervisorId, "supervisorId");
     Preconditions.checkNotNull(dataSource, "dataSource");
     Preconditions.checkNotNull(startMetadata, "startMetadata");
     Preconditions.checkNotNull(endMetadata, "endMetadata");
 
-    final byte[] oldCommitMetadataBytesFromDb = retrieveDataSourceMetadataWithHandleAsBytes(handle, dataSource);
+    final byte[] oldCommitMetadataBytesFromDb = retrieveDataSourceMetadataWithHandleAsBytes(handle, supervisorId);
     final String oldCommitMetadataSha1FromDb;
     final DataSourceMetadata oldCommitMetadataFromDb;
 
@@ -2604,7 +2624,7 @@ public class IndexerSQLMetadataStorageCoordinator implements IndexerMetadataStor
               dbTables.getDataSourceTable()
           )
       )
-                                .bind("dataSource", dataSource)
+                                .bind("dataSource", supervisorId)
                                 .bind("created_date", DateTimes.nowUtc().toString())
                                 .bind("commit_metadata_payload", newCommitMetadataBytes)
                                 .bind("commit_metadata_sha1", newCommitMetadataSha1)
@@ -2628,7 +2648,7 @@ public class IndexerSQLMetadataStorageCoordinator implements IndexerMetadataStor
               dbTables.getDataSourceTable()
           )
       )
-                                .bind("dataSource", dataSource)
+                                .bind("dataSource", supervisorId)
                                 .bind("old_commit_metadata_sha1", oldCommitMetadataSha1FromDb)
                                 .bind("new_commit_metadata_payload", newCommitMetadataBytes)
                                 .bind("new_commit_metadata_sha1", newCommitMetadataSha1)
@@ -2644,16 +2664,22 @@ public class IndexerSQLMetadataStorageCoordinator implements IndexerMetadataStor
     }
 
     if (retVal.isSuccess()) {
-      log.info("Updated metadata from[%s] to[%s].", oldCommitMetadataFromDb, newCommitMetadata);
+      log.info(
+          "Updated metadata for supervisor[%s] for datasource[%s] from[%s] to[%s].",
+          supervisorId, dataSource, oldCommitMetadataFromDb, newCommitMetadata
+      );
     } else {
-      log.info("Not updating metadata, compare-and-swap failure.");
+      log.info(
+          "Failed to update metadata for supervisor[%s] for datasource[%s], compare-and-swap failure.",
+          supervisorId, dataSource
+      );
     }
 
     return retVal;
   }
 
   @Override
-  public boolean deleteDataSourceMetadata(final String dataSource)
+  public boolean deleteDataSourceMetadata(final String supervisorId)
   {
     return connector.retryWithHandle(
         new HandleCallback<Boolean>()
@@ -2664,7 +2690,7 @@ public class IndexerSQLMetadataStorageCoordinator implements IndexerMetadataStor
             int rows = handle.createStatement(
                 StringUtils.format("DELETE from %s WHERE dataSource = :dataSource", dbTables.getDataSourceTable())
             )
-                             .bind("dataSource", dataSource)
+                             .bind("dataSource", supervisorId)
                              .execute();
 
             return rows > 0;
@@ -2674,7 +2700,7 @@ public class IndexerSQLMetadataStorageCoordinator implements IndexerMetadataStor
   }
 
   @Override
-  public boolean resetDataSourceMetadata(final String dataSource, final DataSourceMetadata dataSourceMetadata)
+  public boolean resetDataSourceMetadata(final String supervisorId, final DataSourceMetadata dataSourceMetadata)
       throws IOException
   {
     final byte[] newCommitMetadataBytes = jsonMapper.writeValueAsBytes(dataSourceMetadata);
@@ -2697,7 +2723,7 @@ public class IndexerSQLMetadataStorageCoordinator implements IndexerMetadataStor
                     dbTables.getDataSourceTable()
                 )
             )
-                                      .bind("dataSource", dataSource)
+                                      .bind("dataSource", supervisorId)
                                       .bind("new_commit_metadata_payload", newCommitMetadataBytes)
                                       .bind("new_commit_metadata_sha1", newCommitMetadataSha1)
                                       .execute();
@@ -2774,7 +2800,7 @@ public class IndexerSQLMetadataStorageCoordinator implements IndexerMetadataStor
   }
 
   @Override
-  public boolean insertDataSourceMetadata(String dataSource, DataSourceMetadata metadata)
+  public boolean insertDataSourceMetadata(String supervisorId, DataSourceMetadata metadata)
   {
     return 1 == connector.getDBI().inTransaction(
         (handle, status) -> handle
@@ -2785,7 +2811,7 @@ public class IndexerSQLMetadataStorageCoordinator implements IndexerMetadataStor
                     dbTables.getDataSourceTable()
                 )
             )
-            .bind("dataSource", dataSource)
+            .bind("dataSource", supervisorId)
             .bind("created_date", DateTimes.nowUtc().toString())
             .bind("commit_metadata_payload", jsonMapper.writeValueAsBytes(metadata))
             .bind("commit_metadata_sha1", BaseEncoding.base16().encode(
@@ -2795,10 +2821,10 @@ public class IndexerSQLMetadataStorageCoordinator implements IndexerMetadataStor
   }
 
   @Override
-  public int removeDataSourceMetadataOlderThan(long timestamp, @NotNull Set<String> excludeDatasources)
+  public int removeDataSourceMetadataOlderThan(long timestamp, @NotNull Set<String> excludeSupervisorIds)
   {
     DateTime dateTime = DateTimes.utc(timestamp);
-    List<String> datasourcesToDelete = connector.getDBI().withHandle(
+    List<String> supervisorsToDelete = connector.getDBI().withHandle(
         handle -> handle
             .createQuery(
                 StringUtils.format(
@@ -2810,7 +2836,7 @@ public class IndexerSQLMetadataStorageCoordinator implements IndexerMetadataStor
             .mapTo(String.class)
             .list()
     );
-    datasourcesToDelete.removeAll(excludeDatasources);
+    supervisorsToDelete.removeAll(excludeSupervisorIds);
     return connector.getDBI().withHandle(
         handle -> {
           final PreparedBatch batch = handle.prepareBatch(
@@ -2820,8 +2846,8 @@ public class IndexerSQLMetadataStorageCoordinator implements IndexerMetadataStor
                   dateTime.toString()
               )
           );
-          for (String datasource : datasourcesToDelete) {
-            batch.bind("dataSource", datasource).add();
+          for (String supervisorId : supervisorsToDelete) {
+            batch.bind("dataSource", supervisorId).add();
           }
           int[] result = batch.execute();
           return IntStream.of(result).sum();

--- a/server/src/main/java/org/apache/druid/metadata/SQLMetadataConnector.java
+++ b/server/src/main/java/org/apache/druid/metadata/SQLMetadataConnector.java
@@ -298,10 +298,9 @@ public abstract class SQLMetadataConnector implements MetadataStorageConnector
   }
 
   /**
-   * Creates the table for storing datasource metadata for supervisors.
-   * Due to backwards compatibility reasons, the `dataSource` column will always uniquely identify a supervisor.
-   * For certain types of supervisors which support N:1 supervisor:datasource relationship, the `dataSource` column will store the supervisor ID.
-   * Otherwise, it will store the legacy supervisor ID – the `dataSource` itself.
+   * The {@code dataSource} column stores the supervisor ID.
+   * It has not been renamed to retain backwards compatibility.
+   * Supervisors created without an explicit supervisor id default to using the datasource name.
    */
   public void createDataSourceTable(final String tableName)
   {

--- a/server/src/main/java/org/apache/druid/metadata/SQLMetadataConnector.java
+++ b/server/src/main/java/org/apache/druid/metadata/SQLMetadataConnector.java
@@ -297,6 +297,12 @@ public abstract class SQLMetadataConnector implements MetadataStorageConnector
     alterPendingSegmentsTable(tableName);
   }
 
+  /**
+   * Creates the table for storing datasource metadata for supervisors.
+   * Due to backwards compatibility reasons, the `dataSource` column will always uniquely identify a supervisor.
+   * For certain types of supervisors which support N:1 supervisor:datasource relationship, the `dataSource` column will store the supervisor ID.
+   * Otherwise, it will store the legacy supervisor ID – the `dataSource` itself.
+   */
   public void createDataSourceTable(final String tableName)
   {
     createTable(

--- a/server/src/main/java/org/apache/druid/server/coordinator/duty/KillDatasourceMetadata.java
+++ b/server/src/main/java/org/apache/druid/server/coordinator/duty/KillDatasourceMetadata.java
@@ -27,7 +27,6 @@ import org.apache.druid.server.coordinator.config.MetadataCleanupConfig;
 import org.apache.druid.server.coordinator.stats.Stats;
 import org.joda.time.DateTime;
 
-import java.util.Collection;
 import java.util.Map;
 import java.util.Set;
 import java.util.stream.Collectors;
@@ -58,21 +57,20 @@ public class KillDatasourceMetadata extends MetadataCleanupDuty
   protected int cleanupEntriesCreatedBefore(DateTime minCreatedTime)
   {
     // Datasource metadata only exists for datasource with supervisor
-    // To determine if datasource metadata is still active, we check if the supervisor for that particular datasource
+    // To determine if a supervisor's datasource metadata is still active, we check if the particular supervisor
     // is still active or not
     Map<String, SupervisorSpec> allActiveSupervisor = metadataSupervisorManager.getLatestActiveOnly();
-    Set<String> allDatasourceWithActiveSupervisor
+    Set<String> allValidActiveSupervisors
         = allActiveSupervisor.values()
                              .stream()
-                             .map(SupervisorSpec::getDataSources)
-                             .flatMap(Collection::stream)
+                             .map(SupervisorSpec::getId)
                              .filter(datasource -> !Strings.isNullOrEmpty(datasource))
                              .collect(Collectors.toSet());
 
     // We exclude removing datasource metadata with active supervisor
     return indexerMetadataStorageCoordinator.removeDataSourceMetadataOlderThan(
         minCreatedTime.getMillis(),
-        allDatasourceWithActiveSupervisor
+        allValidActiveSupervisors
     );
   }
 }

--- a/server/src/test/java/org/apache/druid/indexing/overlord/supervisor/SupervisorStatusTest.java
+++ b/server/src/test/java/org/apache/druid/indexing/overlord/supervisor/SupervisorStatusTest.java
@@ -50,7 +50,8 @@ public class SupervisorStatusTest
   public void testJsonAttr() throws IOException
   {
     String json = "{"
-                  + "\"id\":\"wikipedia\","
+                  + "\"id\":\"wikipedia_supervisor\","
+                  + "\"dataSource\":\"wikipedia\","
                   + "\"state\":\"UNHEALTHY_SUPERVISOR\","
                   + "\"detailedState\":\"UNHEALTHY_SUPERVISOR\","
                   + "\"healthy\":false,"
@@ -61,7 +62,8 @@ public class SupervisorStatusTest
     final ObjectMapper mapper = new ObjectMapper();
     final SupervisorStatus deserialized = mapper.readValue(json, SupervisorStatus.class);
     Assert.assertNotNull(deserialized);
-    Assert.assertEquals("wikipedia", deserialized.getId());
+    Assert.assertEquals("wikipedia_supervisor", deserialized.getId());
+    Assert.assertEquals("wikipedia", deserialized.getDataSource());
     final String serialized = mapper.writeValueAsString(deserialized);
     Assert.assertTrue(serialized.contains("\"source\""));
     Assert.assertEquals(json, serialized);

--- a/server/src/test/java/org/apache/druid/metadata/IndexerSQLMetadataStorageCoordinatorTest.java
+++ b/server/src/test/java/org/apache/druid/metadata/IndexerSQLMetadataStorageCoordinatorTest.java
@@ -82,6 +82,7 @@ import java.util.stream.Collectors;
 
 public class IndexerSQLMetadataStorageCoordinatorTest extends IndexerSqlMetadataStorageCoordinatorTestBase
 {
+  private static final String SUPERVISOR_ID = "supervisor";
   @Rule
   public final TestDerbyConnector.DerbyConnectorRule derbyConnectorRule = new TestDerbyConnector.DerbyConnectorRule();
 
@@ -114,6 +115,7 @@ public class IndexerSQLMetadataStorageCoordinatorTest extends IndexerSqlMetadata
       @Override
       protected DataStoreMetadataUpdateResult updateDataSourceMetadataWithHandle(
           Handle handle,
+          String supervisorId,
           String dataSource,
           DataSourceMetadata startMetadata,
           DataSourceMetadata endMetadata
@@ -121,7 +123,7 @@ public class IndexerSQLMetadataStorageCoordinatorTest extends IndexerSqlMetadata
       {
         // Count number of times this method is called.
         metadataUpdateCounter.getAndIncrement();
-        return super.updateDataSourceMetadataWithHandle(handle, dataSource, startMetadata, endMetadata);
+        return super.updateDataSourceMetadataWithHandle(handle, supervisorId, dataSource, startMetadata, endMetadata);
       }
 
       @Override
@@ -427,6 +429,7 @@ public class IndexerSQLMetadataStorageCoordinatorTest extends IndexerSqlMetadata
     // Insert first segment.
     final SegmentPublishResult result1 = coordinator.commitSegmentsAndMetadata(
         ImmutableSet.of(defaultSegment),
+        SUPERVISOR_ID,
         new ObjectMetadata(null),
         new ObjectMetadata(ImmutableMap.of("foo", "bar")),
         new SegmentSchemaMapping(CentralizedDatasourceSchemaConfig.SCHEMA_VERSION)
@@ -446,6 +449,7 @@ public class IndexerSQLMetadataStorageCoordinatorTest extends IndexerSqlMetadata
     // Insert second segment.
     final SegmentPublishResult result2 = coordinator.commitSegmentsAndMetadata(
         ImmutableSet.of(defaultSegment2),
+        SUPERVISOR_ID,
         new ObjectMetadata(ImmutableMap.of("foo", "bar")),
         new ObjectMetadata(ImmutableMap.of("foo", "baz")),
         new SegmentSchemaMapping(CentralizedDatasourceSchemaConfig.SCHEMA_VERSION)
@@ -465,7 +469,7 @@ public class IndexerSQLMetadataStorageCoordinatorTest extends IndexerSqlMetadata
     // Examine metadata.
     Assert.assertEquals(
         new ObjectMetadata(ImmutableMap.of("foo", "baz")),
-        coordinator.retrieveDataSourceMetadata("fooDataSource")
+        coordinator.retrieveDataSourceMetadata(SUPERVISOR_ID)
     );
 
     // Should only be tried once per call.
@@ -488,6 +492,7 @@ public class IndexerSQLMetadataStorageCoordinatorTest extends IndexerSqlMetadata
       @Override
       protected DataStoreMetadataUpdateResult updateDataSourceMetadataWithHandle(
           Handle handle,
+          String supervisorId,
           String dataSource,
           DataSourceMetadata startMetadata,
           DataSourceMetadata endMetadata
@@ -497,7 +502,7 @@ public class IndexerSQLMetadataStorageCoordinatorTest extends IndexerSqlMetadata
         if (attemptCounter.getAndIncrement() == 0) {
           return new DataStoreMetadataUpdateResult(true, true, null);
         } else {
-          return super.updateDataSourceMetadataWithHandle(handle, dataSource, startMetadata, endMetadata);
+          return super.updateDataSourceMetadataWithHandle(handle, supervisorId, dataSource, startMetadata, endMetadata);
         }
       }
     };
@@ -505,6 +510,7 @@ public class IndexerSQLMetadataStorageCoordinatorTest extends IndexerSqlMetadata
     // Insert first segment.
     final SegmentPublishResult result1 = failOnceCoordinator.commitSegmentsAndMetadata(
         ImmutableSet.of(defaultSegment),
+        SUPERVISOR_ID,
         new ObjectMetadata(null),
         new ObjectMetadata(ImmutableMap.of("foo", "bar")),
         new SegmentSchemaMapping(CentralizedDatasourceSchemaConfig.SCHEMA_VERSION)
@@ -527,6 +533,7 @@ public class IndexerSQLMetadataStorageCoordinatorTest extends IndexerSqlMetadata
     // Insert second segment.
     final SegmentPublishResult result2 = failOnceCoordinator.commitSegmentsAndMetadata(
         ImmutableSet.of(defaultSegment2),
+        SUPERVISOR_ID,
         new ObjectMetadata(ImmutableMap.of("foo", "bar")),
         new ObjectMetadata(ImmutableMap.of("foo", "baz")),
         new SegmentSchemaMapping(CentralizedDatasourceSchemaConfig.SCHEMA_VERSION)
@@ -546,7 +553,7 @@ public class IndexerSQLMetadataStorageCoordinatorTest extends IndexerSqlMetadata
     // Examine metadata.
     Assert.assertEquals(
         new ObjectMetadata(ImmutableMap.of("foo", "baz")),
-        failOnceCoordinator.retrieveDataSourceMetadata("fooDataSource")
+        failOnceCoordinator.retrieveDataSourceMetadata(SUPERVISOR_ID)
     );
 
     // Should be tried twice per call.
@@ -558,6 +565,7 @@ public class IndexerSQLMetadataStorageCoordinatorTest extends IndexerSqlMetadata
   {
     final SegmentPublishResult result1 = coordinator.commitSegmentsAndMetadata(
         ImmutableSet.of(defaultSegment),
+        SUPERVISOR_ID,
         new ObjectMetadata(ImmutableMap.of("foo", "bar")),
         new ObjectMetadata(ImmutableMap.of("foo", "baz")),
         new SegmentSchemaMapping(CentralizedDatasourceSchemaConfig.SCHEMA_VERSION)
@@ -580,6 +588,7 @@ public class IndexerSQLMetadataStorageCoordinatorTest extends IndexerSqlMetadata
   {
     final SegmentPublishResult result1 = coordinator.commitSegmentsAndMetadata(
         ImmutableSet.of(defaultSegment),
+        SUPERVISOR_ID,
         new ObjectMetadata(null),
         new ObjectMetadata(ImmutableMap.of("foo", "baz")),
         new SegmentSchemaMapping(CentralizedDatasourceSchemaConfig.SCHEMA_VERSION)
@@ -588,6 +597,7 @@ public class IndexerSQLMetadataStorageCoordinatorTest extends IndexerSqlMetadata
 
     final SegmentPublishResult result2 = coordinator.commitSegmentsAndMetadata(
         ImmutableSet.of(defaultSegment2),
+        SUPERVISOR_ID,
         new ObjectMetadata(null),
         new ObjectMetadata(ImmutableMap.of("foo", "baz")),
         new SegmentSchemaMapping(CentralizedDatasourceSchemaConfig.SCHEMA_VERSION)
@@ -658,6 +668,7 @@ public class IndexerSQLMetadataStorageCoordinatorTest extends IndexerSqlMetadata
   {
     final SegmentPublishResult result1 = coordinator.commitSegmentsAndMetadata(
         ImmutableSet.of(defaultSegment),
+        SUPERVISOR_ID,
         new ObjectMetadata(null),
         new ObjectMetadata(ImmutableMap.of("foo", "baz")),
         new SegmentSchemaMapping(CentralizedDatasourceSchemaConfig.SCHEMA_VERSION)
@@ -666,6 +677,7 @@ public class IndexerSQLMetadataStorageCoordinatorTest extends IndexerSqlMetadata
 
     final SegmentPublishResult result2 = coordinator.commitSegmentsAndMetadata(
         ImmutableSet.of(defaultSegment2),
+        SUPERVISOR_ID,
         new ObjectMetadata(ImmutableMap.of("foo", "qux")),
         new ObjectMetadata(ImmutableMap.of("foo", "baz")),
         new SegmentSchemaMapping(CentralizedDatasourceSchemaConfig.SCHEMA_VERSION)
@@ -1935,6 +1947,7 @@ public class IndexerSQLMetadataStorageCoordinatorTest extends IndexerSqlMetadata
   {
     coordinator.commitSegmentsAndMetadata(
         ImmutableSet.of(defaultSegment),
+        SUPERVISOR_ID,
         new ObjectMetadata(null),
         new ObjectMetadata(ImmutableMap.of("foo", "bar")),
         new SegmentSchemaMapping(CentralizedDatasourceSchemaConfig.SCHEMA_VERSION)
@@ -1942,13 +1955,45 @@ public class IndexerSQLMetadataStorageCoordinatorTest extends IndexerSqlMetadata
 
     Assert.assertEquals(
         new ObjectMetadata(ImmutableMap.of("foo", "bar")),
-        coordinator.retrieveDataSourceMetadata("fooDataSource")
+        coordinator.retrieveDataSourceMetadata(SUPERVISOR_ID)
     );
 
-    Assert.assertFalse("deleteInvalidDataSourceMetadata", coordinator.deleteDataSourceMetadata("nonExistentDS"));
-    Assert.assertTrue("deleteValidDataSourceMetadata", coordinator.deleteDataSourceMetadata("fooDataSource"));
+    Assert.assertFalse("deleteInvalidDataSourceMetadata", coordinator.deleteDataSourceMetadata("nonExistentSupervisor"));
+    Assert.assertTrue("deleteValidDataSourceMetadata", coordinator.deleteDataSourceMetadata(SUPERVISOR_ID));
 
-    Assert.assertNull("getDataSourceMetadataNullAfterDelete", coordinator.retrieveDataSourceMetadata("fooDataSource"));
+    Assert.assertNull("getDataSourceMetadataNullAfterDelete", coordinator.retrieveDataSourceMetadata(SUPERVISOR_ID));
+  }
+
+  /**
+   * Multiple supervisors (e.g. one per Kafka region) ingesting into the same datasource must keep
+   * independent committed metadata, keyed by supervisorId rather than datasource (see #18082).
+   * Verifies that insert/retrieve/reset/delete are all isolated per supervisorId.
+   */
+  @Test
+  public void testMultipleSupervisorsForSameDatasourceKeepIsolatedMetadata() throws IOException
+  {
+    final String supervisor1 = "supervisor_1";
+    final String supervisor2 = "supervisor_2";
+    final ObjectMetadata metadata1 = new ObjectMetadata(ImmutableMap.of("offset", 10));
+    final ObjectMetadata metadata2 = new ObjectMetadata(ImmutableMap.of("offset", 20));
+
+    Assert.assertTrue(coordinator.insertDataSourceMetadata(supervisor1, metadata1));
+    Assert.assertTrue(coordinator.insertDataSourceMetadata(supervisor2, metadata2));
+
+    // Each supervisor sees only its own metadata.
+    Assert.assertEquals(metadata1, coordinator.retrieveDataSourceMetadata(supervisor1));
+    Assert.assertEquals(metadata2, coordinator.retrieveDataSourceMetadata(supervisor2));
+
+    // Resetting one supervisor's metadata must not affect the other.
+    final ObjectMetadata resetMetadata1 = new ObjectMetadata(ImmutableMap.of("offset", 999));
+    Assert.assertTrue(coordinator.resetDataSourceMetadata(supervisor1, resetMetadata1));
+    Assert.assertEquals(resetMetadata1, coordinator.retrieveDataSourceMetadata(supervisor1));
+    Assert.assertEquals(metadata2, coordinator.retrieveDataSourceMetadata(supervisor2));
+
+    // Deleting one supervisor's metadata must not affect the other.
+    Assert.assertTrue(coordinator.deleteDataSourceMetadata(supervisor1));
+    Assert.assertNull(coordinator.retrieveDataSourceMetadata(supervisor1));
+    Assert.assertEquals(metadata2, coordinator.retrieveDataSourceMetadata(supervisor2));
   }
 
   @Test
@@ -2872,6 +2917,7 @@ public class IndexerSQLMetadataStorageCoordinatorTest extends IndexerSqlMetadata
   {
     coordinator.commitSegmentsAndMetadata(
         ImmutableSet.of(defaultSegment),
+        SUPERVISOR_ID,
         new ObjectMetadata(null),
         new ObjectMetadata(ImmutableMap.of("foo", "bar")),
         new SegmentSchemaMapping(CentralizedDatasourceSchemaConfig.SCHEMA_VERSION)
@@ -2879,19 +2925,19 @@ public class IndexerSQLMetadataStorageCoordinatorTest extends IndexerSqlMetadata
 
     Assert.assertEquals(
         new ObjectMetadata(ImmutableMap.of("foo", "bar")),
-        coordinator.retrieveDataSourceMetadata("fooDataSource")
+        coordinator.retrieveDataSourceMetadata(SUPERVISOR_ID)
     );
 
     // Try delete. Datasource should not be deleted as it is in excluded set
     int deletedCount = coordinator.removeDataSourceMetadataOlderThan(
         System.currentTimeMillis(),
-        ImmutableSet.of("fooDataSource")
+        ImmutableSet.of(SUPERVISOR_ID)
     );
 
     // Datasource should not be deleted
     Assert.assertEquals(
         new ObjectMetadata(ImmutableMap.of("foo", "bar")),
-        coordinator.retrieveDataSourceMetadata("fooDataSource")
+        coordinator.retrieveDataSourceMetadata(SUPERVISOR_ID)
     );
     Assert.assertEquals(0, deletedCount);
   }
@@ -2901,6 +2947,7 @@ public class IndexerSQLMetadataStorageCoordinatorTest extends IndexerSqlMetadata
   {
     coordinator.commitSegmentsAndMetadata(
         ImmutableSet.of(defaultSegment),
+        SUPERVISOR_ID,
         new ObjectMetadata(null),
         new ObjectMetadata(ImmutableMap.of("foo", "bar")),
         new SegmentSchemaMapping(CentralizedDatasourceSchemaConfig.SCHEMA_VERSION)
@@ -2908,7 +2955,7 @@ public class IndexerSQLMetadataStorageCoordinatorTest extends IndexerSqlMetadata
 
     Assert.assertEquals(
         new ObjectMetadata(ImmutableMap.of("foo", "bar")),
-        coordinator.retrieveDataSourceMetadata("fooDataSource")
+        coordinator.retrieveDataSourceMetadata(SUPERVISOR_ID)
     );
 
     // Try delete. Datasource should be deleted as it is not in excluded set and created time older than given time
@@ -2916,7 +2963,7 @@ public class IndexerSQLMetadataStorageCoordinatorTest extends IndexerSqlMetadata
 
     // Datasource should be deleted
     Assert.assertNull(
-        coordinator.retrieveDataSourceMetadata("fooDataSource")
+        coordinator.retrieveDataSourceMetadata(SUPERVISOR_ID)
     );
     Assert.assertEquals(1, deletedCount);
   }
@@ -2927,6 +2974,7 @@ public class IndexerSQLMetadataStorageCoordinatorTest extends IndexerSqlMetadata
   {
     coordinator.commitSegmentsAndMetadata(
         ImmutableSet.of(defaultSegment),
+        SUPERVISOR_ID,
         new ObjectMetadata(null),
         new ObjectMetadata(ImmutableMap.of("foo", "bar")),
         new SegmentSchemaMapping(CentralizedDatasourceSchemaConfig.SCHEMA_VERSION)
@@ -2934,7 +2982,7 @@ public class IndexerSQLMetadataStorageCoordinatorTest extends IndexerSqlMetadata
 
     Assert.assertEquals(
         new ObjectMetadata(ImmutableMap.of("foo", "bar")),
-        coordinator.retrieveDataSourceMetadata("fooDataSource")
+        coordinator.retrieveDataSourceMetadata(SUPERVISOR_ID)
     );
 
     // Do delete. Datasource metadata should not be deleted. Datasource is not active but it was created just now so it's
@@ -2947,7 +2995,7 @@ public class IndexerSQLMetadataStorageCoordinatorTest extends IndexerSqlMetadata
     // Datasource should not be deleted
     Assert.assertEquals(
         new ObjectMetadata(ImmutableMap.of("foo", "bar")),
-        coordinator.retrieveDataSourceMetadata("fooDataSource")
+        coordinator.retrieveDataSourceMetadata(SUPERVISOR_ID)
     );
     Assert.assertEquals(0, deletedCount);
   }

--- a/server/src/test/java/org/apache/druid/metadata/IndexerSqlMetadataStorageCoordinatorSchemaPersistenceTest.java
+++ b/server/src/test/java/org/apache/druid/metadata/IndexerSqlMetadataStorageCoordinatorSchemaPersistenceTest.java
@@ -97,6 +97,7 @@ public class IndexerSqlMetadataStorageCoordinatorSchemaPersistenceTest extends
       @Override
       protected DataStoreMetadataUpdateResult updateDataSourceMetadataWithHandle(
           Handle handle,
+          String supervisorId,
           String dataSource,
           DataSourceMetadata startMetadata,
           DataSourceMetadata endMetadata
@@ -104,7 +105,7 @@ public class IndexerSqlMetadataStorageCoordinatorSchemaPersistenceTest extends
       {
         // Count number of times this method is called.
         metadataUpdateCounter.getAndIncrement();
-        return super.updateDataSourceMetadataWithHandle(handle, dataSource, startMetadata, endMetadata);
+        return super.updateDataSourceMetadataWithHandle(handle, supervisorId, dataSource, startMetadata, endMetadata);
       }
 
       @Override

--- a/sql/src/main/java/org/apache/druid/sql/calcite/schema/SystemSchema.java
+++ b/sql/src/main/java/org/apache/druid/sql/calcite/schema/SystemSchema.java
@@ -198,6 +198,7 @@ public class SystemSchema extends AbstractSchema
   static final RowSignature SUPERVISOR_SIGNATURE = RowSignature
       .builder()
       .add("supervisor_id", ColumnType.STRING)
+      .add("datasource", ColumnType.STRING)
       .add("state", ColumnType.STRING)
       .add("detailed_state", ColumnType.STRING)
       .add("healthy", ColumnType.LONG)
@@ -971,6 +972,7 @@ public class SystemSchema extends AbstractSchema
               final SupervisorStatus supervisor = it.next();
               return new Object[]{
                   supervisor.getId(),
+                  supervisor.getDataSource(),
                   supervisor.getState(),
                   supervisor.getDetailedState(),
                   supervisor.isHealthy() ? 1L : 0L,

--- a/sql/src/test/java/org/apache/druid/sql/calcite/schema/SystemSchemaTest.java
+++ b/sql/src/test/java/org/apache/druid/sql/calcite/schema/SystemSchemaTest.java
@@ -1320,7 +1320,8 @@ public class SystemSchemaTest extends CalciteTestBase
     EasyMock.replay(supervisorTable);
 
     String json = "[{\n"
-                  + "\t\"id\": \"wikipedia\",\n"
+                  + "\t\"id\": \"wikipedia_supervisor\",\n"
+                  + "\t\"dataSource\": \"wikipedia\",\n"
                   + "\t\"state\": \"UNHEALTHY_SUPERVISOR\",\n"
                   + "\t\"detailedState\": \"UNABLE_TO_CONNECT_TO_STREAM\",\n"
                   + "\t\"healthy\": false,\n"
@@ -1344,16 +1345,17 @@ public class SystemSchemaTest extends CalciteTestBase
     final List<Object[]> rows = supervisorTable.scan(dataContext).toList();
 
     Object[] row0 = rows.get(0);
-    Assert.assertEquals("wikipedia", row0[0].toString());
-    Assert.assertEquals("UNHEALTHY_SUPERVISOR", row0[1].toString());
-    Assert.assertEquals("UNABLE_TO_CONNECT_TO_STREAM", row0[2].toString());
-    Assert.assertEquals(0L, row0[3]);
-    Assert.assertEquals("kafka", row0[4].toString());
-    Assert.assertEquals("wikipedia", row0[5].toString());
-    Assert.assertEquals(0L, row0[6]);
+    Assert.assertEquals("wikipedia_supervisor", row0[0].toString());
+    Assert.assertEquals("wikipedia", row0[1].toString());
+    Assert.assertEquals("UNHEALTHY_SUPERVISOR", row0[2].toString());
+    Assert.assertEquals("UNABLE_TO_CONNECT_TO_STREAM", row0[3].toString());
+    Assert.assertEquals(0L, row0[4]);
+    Assert.assertEquals("kafka", row0[5].toString());
+    Assert.assertEquals("wikipedia", row0[6].toString());
+    Assert.assertEquals(0L, row0[7]);
     Assert.assertEquals(
         "{\"type\":\"kafka\",\"dataSchema\":{\"dataSource\":\"wikipedia\"},\"context\":null,\"suspended\":false}",
-        row0[7].toString()
+        row0[8].toString()
     );
 
     // Verify value types.

--- a/web-console/src/console-application.tsx
+++ b/web-console/src/console-application.tsx
@@ -374,7 +374,7 @@ export class ConsoleApplication extends React.PureComponent<
         goToDatasource={this.goToDatasources}
         goToQuery={this.goToQuery}
         goToStreamingDataLoader={this.goToStreamingDataLoader}
-        goToTasks={this.goToTasksWithDatasource}
+        goToTasks={this.goToTasksWithTaskGroupId}
         capabilities={capabilities}
       />,
     );

--- a/web-console/src/druid-models/ingestion-spec/ingestion-spec.tsx
+++ b/web-console/src/druid-models/ingestion-spec/ingestion-spec.tsx
@@ -481,7 +481,7 @@ export function cleanSpec(
 ): Partial<IngestionSpec> {
   return allowKeys(
     spec,
-    ['type', 'spec', 'context'].concat(allowSuspended ? ['suspended'] : []) as any,
+    ['id', 'type', 'spec', 'context'].concat(allowSuspended ? ['suspended'] : []) as any,
   ) as IngestionSpec;
 }
 

--- a/web-console/src/views/supervisors-view/supervisors-view.tsx
+++ b/web-console/src/views/supervisors-view/supervisors-view.tsx
@@ -777,7 +777,12 @@ export class SupervisorsView extends React.PureComponent<
               }
               return (
                 <TableClickableCell
-                  onClick={() => goToTasks(original.supervisor_id, `index_${original.type}`)}
+                  onClick={() =>
+                    goToTasks(
+                      `index_${original.type}_${original.supervisor_id}`,
+                      `index_${original.type}`,
+                    )
+                  }
                   hoverIcon={IconNames.ARROW_TOP_RIGHT}
                   title="Go to tasks"
                 >

--- a/web-console/src/views/supervisors-view/supervisors-view.tsx
+++ b/web-console/src/views/supervisors-view/supervisors-view.tsx
@@ -90,6 +90,7 @@ import './supervisors-view.scss';
 
 const SUPERVISOR_TABLE_COLUMNS: TableColumnSelectorColumn[] = [
   'Supervisor ID',
+  'Datasource',
   'Type',
   'Topic/Stream',
   'Status',
@@ -119,6 +120,7 @@ interface SupervisorQuery extends TableState {
 
 interface SupervisorQueryResultRow {
   supervisor_id: string;
+  datasource: string;
   type: string;
   source: string;
   detailed_state: string;
@@ -238,6 +240,7 @@ export class SupervisorsView extends React.PureComponent<
           const sqlQuery = assemble(
             'WITH s AS (SELECT',
             '  "supervisor_id",',
+            '  "datasource",',
             '  "type",',
             '  "source",',
             `  CASE WHEN "suspended" = 0 THEN "detailed_state" ELSE 'SUSPENDED' END AS "detailed_state",`,
@@ -275,6 +278,7 @@ export class SupervisorsView extends React.PureComponent<
           supervisors = supervisorList.map((sup: any) => {
             return {
               supervisor_id: deepGet(sup, 'id'),
+              datasource: deepGet(sup, 'dataSource'),
               type: deepGet(sup, 'spec.tuningConfig.type'),
               source:
                 deepGet(sup, 'spec.ioConfig.topic') ||
@@ -406,6 +410,7 @@ export class SupervisorsView extends React.PureComponent<
 
   private getSupervisorActions(
     id: string,
+    datasource: string,
     supervisorSuspended: boolean,
     type: string,
   ): BasicAction[] {
@@ -417,7 +422,7 @@ export class SupervisorsView extends React.PureComponent<
         {
           icon: IconNames.MULTI_SELECT,
           title: 'Go to datasource',
-          onAction: () => goToDatasource(id),
+          onAction: () => goToDatasource(datasource),
         },
         {
           icon: IconNames.CLOUD_UPLOAD,
@@ -628,6 +633,7 @@ export class SupervisorsView extends React.PureComponent<
       supervisorTableActionDialogId: supervisor.supervisor_id,
       supervisorTableActionDialogActions: this.getSupervisorActions(
         supervisor.supervisor_id,
+        supervisor.datasource,
         supervisor.suspended,
         supervisor.type,
       ),
@@ -661,7 +667,7 @@ export class SupervisorsView extends React.PureComponent<
         showPagination
         columns={[
           {
-            Header: twoLines('Supervisor ID', <i>(datasource)</i>),
+            Header: 'Supervisor ID',
             id: 'supervisor_id',
             accessor: 'supervisor_id',
             width: 280,
@@ -674,6 +680,13 @@ export class SupervisorsView extends React.PureComponent<
                 {value}
               </TableClickableCell>
             ),
+          },
+          {
+            Header: 'Datasource',
+            accessor: 'datasource',
+            width: 280,
+            Cell: this.renderSupervisorFilterableCell('datasource'),
+            show: visibleColumns.shown('Datasource'),
           },
           {
             Header: 'Type',
@@ -889,9 +902,15 @@ export class SupervisorsView extends React.PureComponent<
             sortable: false,
             Cell: row => {
               const id = row.value;
+              const datasource = row.original.datasource;
               const type = row.original.type;
               const supervisorSuspended = row.original.suspended;
-              const supervisorActions = this.getSupervisorActions(id, supervisorSuspended, type);
+              const supervisorActions = this.getSupervisorActions(
+                id,
+                datasource,
+                supervisorSuspended,
+                type,
+              );
               return (
                 <ActionCell
                   onDetail={() => this.onSupervisorDetail(row.original)}


### PR DESCRIPTION
## Summary

Backports the **"multiple stream supervisors → single datasource"** feature (upstream Druid 34) and its in-34 follow-ups onto `30.0.1-confluent`, so prod Druid 30 can run N≥1 stream supervisors (e.g. one per Kafka region) ingesting into the same datasource. `supervisorId` is decoupled from datasource and defaults to the datasource name for full backward compatibility.

Hand-ported (not a clean cherry-pick) because the metadata-storage layer was rewritten between Druid 30 and 34 (handle-based → transaction-based). Druid 30's handle-based coordinator was kept and `supervisorId` threaded through it; the `druid_dataSource` offset-metadata table is now keyed by `supervisorId` instead of datasource.

## Commits (each maps to an upstream PR)

| Commit | Upstream PR | Release |
|--------|-------------|---------|
| Allow multiple stream supervisors to ingest into same datasource | apache/druid#18082 | 34.0.0 |
| Add task distribution strategy by supervisor affinity | apache/druid#18634 | 36.0.0 |
| Follow-ups (`validateDataSourceMetadata` helper, etc.) | apache/druid#18149 | 34.0.0 |
| Web console: separate Datasource column for supervisors | apache/druid#18175 | 34.0.0 |
| Web console: go to a supervisor's tasks by task group id | apache/druid#18298 | 34.0.0 |

## Scope decisions
- Limited to Druid-34 changes (per request), **plus** #18634 (our own task-distribution PR, Druid 36) as an intentional exception.
- **Excluded** post-34 observability PRs #18803/#18920/#19525 (supervisorId metric dimensions) — features, not fixes; revisit later if needed. supervisorId is already on the supervisor's own emitted metrics via #18082.
- Where upstream code depended on Druid 31–36 infrastructure absent in Druid 30 (segment metadata cache / transaction APIs, `LagAggregator`, etc.), the equivalent behavior was applied to Druid 30 and incompatible bits omitted.

## Testing
- `mvn test-compile` green across server, indexing-service, kafka/kinesis/rabbit indexing, services, sql, msq, processing (Java 17).
- Unit tests pass: `IndexerSQLMetadataStorageCoordinatorTest` (88), `KafkaSupervisorTest` (116), `KinesisSupervisorTest` (46), `SeekableStreamSupervisorStateTest` (33), `SeekableStreamSupervisorSpecTest` (16), worker-select strategy tests (#18634).
- **Added** `IndexerSQLMetadataStorageCoordinatorTest.testMultipleSupervisorsForSameDatasourceKeepIsolatedMetadata` — verifies two supervisorIds on one datasource keep isolated offset metadata (insert/retrieve/reset/delete) against a real Derby DB.

## Reviewer notes
- Web-console (TypeScript) changes are **not yet built** here (no local `node_modules`); please run `cd web-console && npm install && npm run compile` and regenerate the supervisors-view jest snapshot (`npm test -- -u`).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
