### PR TITLE
Implement IntervalAwareBalancerStrategy to balance segment count in an interval

### DIFF
--- a/server/src/main/java/org/apache/druid/server/coordinator/balancer/BalancerStrategyFactory.java
+++ b/server/src/main/java/org/apache/druid/server/coordinator/balancer/BalancerStrategyFactory.java
@@ -31,7 +31,8 @@ import org.apache.druid.java.util.common.logger.Logger;
     @JsonSubTypes.Type(name = "cost", value = CostBalancerStrategyFactory.class),
     @JsonSubTypes.Type(name = "cachingCost", value = DisabledCachingCostBalancerStrategyFactory.class),
     @JsonSubTypes.Type(name = "diskNormalized", value = DiskNormalizedCostBalancerStrategyFactory.class),
-    @JsonSubTypes.Type(name = "random", value = RandomBalancerStrategyFactory.class)
+    @JsonSubTypes.Type(name = "random", value = RandomBalancerStrategyFactory.class),
+    @JsonSubTypes.Type(name = "intervalAware", value = IntervalAwareBalancerStrategyFactory.class)
 })
 public abstract class BalancerStrategyFactory
 {

--- a/server/src/main/java/org/apache/druid/server/coordinator/balancer/IntervalAwareBalancerStrategy.java
+++ b/server/src/main/java/org/apache/druid/server/coordinator/balancer/IntervalAwareBalancerStrategy.java
@@ -1,0 +1,168 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+package org.apache.druid.server.coordinator.balancer;
+
+import org.apache.druid.server.coordinator.SegmentCountsPerInterval;
+import org.apache.druid.server.coordinator.ServerHolder;
+import org.apache.druid.server.coordinator.stats.CoordinatorRunStats;
+import org.apache.druid.timeline.DataSegment;
+import org.joda.time.Interval;
+
+import java.util.ArrayList;
+import java.util.Collections;
+import java.util.Comparator;
+import java.util.Iterator;
+import java.util.List;
+
+/**
+ * A lightweight {@link BalancerStrategy} that spreads segments covering the same
+ * time interval as evenly as possible across the historicals in a tier.
+ * <p>
+ * For a segment being placed (or moved), the "cost" of a server is simply the
+ * number of segments already projected on that server for the segment's interval
+ * (see {@link SegmentCountsPerInterval}). The cheapest
+ * (least-loaded-for-this-interval) server is preferred.
+ * <p>
+ * The count can be scoped in two ways, controlled by {@code perDatasource}:
+ * <ul>
+ *   <li>{@code perDatasource=true} (default): counts only segments of the
+ *   <b>same datasource</b> for the interval. Each datasource is balanced
+ *   independently, which is optimal when a query targets a single datasource.</li>
+ *   <li>{@code perDatasource=false}: counts segments of <b>all datasources</b>
+ *   for the interval. This is optimal when a query unions multiple datasources
+ *   covering the same time range.</li>
+ * </ul>
+ * Compared to {@link CostBalancerStrategy}, this strategy:
+ * <ul>
+ *   <li>does not model query-time-decay across the whole retention window; it
+ *   only equalises the per-interval segment count, which is what matters for
+ *   workloads that query a narrow, recent time range;</li>
+ *   <li>is O(numServers) per placement using an O(1) per-server count lookup,
+ *   instead of the O(segmentsPerServer) pairwise cost computation, so it does
+ *   not inflate the coordinator duty-cycle time.</li>
+ * </ul>
+ * Ties are broken randomly (via a shuffle before a stable sort) so that servers
+ * holding an equal number of segments for the interval are not always picked in
+ * the same order.
+ * <p>
+ * This strategy is only consulted for initial placement when round-robin
+ * assignment is disabled (i.e. {@code useRoundRobinSegmentAssignment=false},
+ * which also requires {@code smartSegmentLoading=false}). It is always used for
+ * balancing moves.
+ */
+public class IntervalAwareBalancerStrategy implements BalancerStrategy
+{
+  private final boolean perDatasource;
+
+  public IntervalAwareBalancerStrategy(boolean perDatasource)
+  {
+    this.perDatasource = perDatasource;
+  }
+
+  @Override
+  public Iterator<ServerHolder> findServersToLoadSegment(
+      DataSegment segmentToLoad,
+      List<ServerHolder> serverHolders
+  )
+  {
+    final List<ServerHolder> eligibleServers = new ArrayList<>();
+    for (ServerHolder server : serverHolders) {
+      if (server.canLoadSegment(segmentToLoad)) {
+        eligibleServers.add(server);
+      }
+    }
+
+    // Shuffle first so that a subsequent stable sort breaks ties randomly.
+    Collections.shuffle(eligibleServers);
+    eligibleServers.sort(Comparator.comparingInt(server -> countSegmentsInInterval(server, segmentToLoad)));
+
+    return eligibleServers.iterator();
+  }
+
+  @Override
+  public ServerHolder findDestinationServerToMoveSegment(
+      DataSegment segmentToMove,
+      ServerHolder sourceServer,
+      List<ServerHolder> destinationServers
+  )
+  {
+    final int sourceCount = countSegmentsInInterval(sourceServer, segmentToMove);
+
+    ServerHolder bestDestination = null;
+    int bestCount = Integer.MAX_VALUE;
+    for (ServerHolder server : destinationServers) {
+      if (server.equals(sourceServer) || !server.canLoadSegment(segmentToMove)) {
+        continue;
+      }
+      final int count = countSegmentsInInterval(server, segmentToMove);
+      if (count < bestCount) {
+        bestCount = count;
+        bestDestination = server;
+      }
+    }
+
+    // Only move if it strictly reduces the maximum per-interval count, i.e. the
+    // destination (after gaining the segment) would hold fewer segments for this
+    // interval than the source currently does. This avoids pointless moves and
+    // oscillation between two servers that differ by a single segment.
+    if (bestDestination != null && bestCount + 1 < sourceCount) {
+      return bestDestination;
+    }
+    return null;
+  }
+
+  @Override
+  public Iterator<ServerHolder> findServersToDropSegment(
+      DataSegment segmentToDrop,
+      List<ServerHolder> serverHolders
+  )
+  {
+    final List<ServerHolder> servers = new ArrayList<>(serverHolders);
+    // Shuffle first so that a subsequent stable sort breaks ties randomly.
+    Collections.shuffle(servers);
+    // Drop from the most heavily loaded server for this interval first.
+    servers.sort(Comparator.comparingInt((ServerHolder server) -> countSegmentsInInterval(server, segmentToDrop)).reversed());
+
+    return servers.iterator();
+  }
+
+  @Override
+  public CoordinatorRunStats getStats()
+  {
+    return CoordinatorRunStats.empty();
+  }
+
+  /**
+   * Number of segments projected on the given server for the segment's interval,
+   * scoped either to the segment's datasource or to all datasources depending on
+   * {@link #perDatasource}. Uses the O(1) per-interval counts maintained by
+   * {@link ServerHolder#getProjectedSegments()}.
+   */
+  private int countSegmentsInInterval(ServerHolder server, DataSegment segment)
+  {
+    final SegmentCountsPerInterval counts = server.getProjectedSegments();
+    final Interval interval = segment.getInterval();
+    if (perDatasource) {
+      return counts.getIntervalToSegmentCount(segment.getDataSource()).getInt(interval);
+    } else {
+      return counts.getIntervalToTotalSegmentCount().getInt(interval);
+    }
+  }
+}

--- a/server/src/main/java/org/apache/druid/server/coordinator/balancer/IntervalAwareBalancerStrategy.java
+++ b/server/src/main/java/org/apache/druid/server/coordinator/balancer/IntervalAwareBalancerStrategy.java
@@ -32,6 +32,7 @@ import java.util.Collections;
 import java.util.Comparator;
 import java.util.Iterator;
 import java.util.List;
+import java.util.concurrent.ThreadLocalRandom;
 import java.util.concurrent.TimeUnit;
 import java.util.concurrent.atomic.AtomicLong;
 
@@ -122,6 +123,7 @@ public class IntervalAwareBalancerStrategy implements BalancerStrategy
 
       ServerHolder bestDestination = null;
       int bestCount = Integer.MAX_VALUE;
+      int numTiedAtBest = 0;
       for (ServerHolder server : destinationServers) {
         if (server.equals(sourceServer) || !server.canLoadSegment(segmentToMove)) {
           continue;
@@ -130,6 +132,17 @@ public class IntervalAwareBalancerStrategy implements BalancerStrategy
         if (count < bestCount) {
           bestCount = count;
           bestDestination = server;
+          numTiedAtBest = 1;
+        } else if (count == bestCount) {
+          // Reservoir sampling over the servers tied at the minimum count, so that
+          // ties are broken uniformly at random rather than always picking the
+          // server that appears earliest in the list. Without this, when many
+          // servers share the lowest count for an interval (common on a large,
+          // lightly-loaded tier), moves would persistently favour the same
+          // early-ordered servers and skew the distribution over repeated runs.
+          if (ThreadLocalRandom.current().nextInt(++numTiedAtBest) == 0) {
+            bestDestination = server;
+          }
         }
       }
 

--- a/server/src/main/java/org/apache/druid/server/coordinator/balancer/IntervalAwareBalancerStrategy.java
+++ b/server/src/main/java/org/apache/druid/server/coordinator/balancer/IntervalAwareBalancerStrategy.java
@@ -19,9 +19,11 @@
 
 package org.apache.druid.server.coordinator.balancer;
 
+import com.google.common.base.Stopwatch;
 import org.apache.druid.server.coordinator.SegmentCountsPerInterval;
 import org.apache.druid.server.coordinator.ServerHolder;
 import org.apache.druid.server.coordinator.stats.CoordinatorRunStats;
+import org.apache.druid.server.coordinator.stats.Stats;
 import org.apache.druid.timeline.DataSegment;
 import org.joda.time.Interval;
 
@@ -30,6 +32,8 @@ import java.util.Collections;
 import java.util.Comparator;
 import java.util.Iterator;
 import java.util.List;
+import java.util.concurrent.TimeUnit;
+import java.util.concurrent.atomic.AtomicLong;
 
 /**
  * A lightweight {@link BalancerStrategy} that spreads segments covering the same
@@ -71,6 +75,9 @@ public class IntervalAwareBalancerStrategy implements BalancerStrategy
 {
   private final boolean perDatasource;
 
+  private final CoordinatorRunStats stats = new CoordinatorRunStats();
+  private final AtomicLong computeTimeNanos = new AtomicLong(0);
+
   public IntervalAwareBalancerStrategy(boolean perDatasource)
   {
     this.perDatasource = perDatasource;
@@ -82,18 +89,24 @@ public class IntervalAwareBalancerStrategy implements BalancerStrategy
       List<ServerHolder> serverHolders
   )
   {
-    final List<ServerHolder> eligibleServers = new ArrayList<>();
-    for (ServerHolder server : serverHolders) {
-      if (server.canLoadSegment(segmentToLoad)) {
-        eligibleServers.add(server);
+    final Stopwatch computeTime = Stopwatch.createStarted();
+    try {
+      final List<ServerHolder> eligibleServers = new ArrayList<>();
+      for (ServerHolder server : serverHolders) {
+        if (server.canLoadSegment(segmentToLoad)) {
+          eligibleServers.add(server);
+        }
       }
+
+      // Shuffle first so that a subsequent stable sort breaks ties randomly.
+      Collections.shuffle(eligibleServers);
+      eligibleServers.sort(Comparator.comparingInt(server -> countSegmentsInInterval(server, segmentToLoad)));
+
+      return eligibleServers.iterator();
     }
-
-    // Shuffle first so that a subsequent stable sort breaks ties randomly.
-    Collections.shuffle(eligibleServers);
-    eligibleServers.sort(Comparator.comparingInt(server -> countSegmentsInInterval(server, segmentToLoad)));
-
-    return eligibleServers.iterator();
+    finally {
+      recordComputeTime(computeTime);
+    }
   }
 
   @Override
@@ -103,29 +116,35 @@ public class IntervalAwareBalancerStrategy implements BalancerStrategy
       List<ServerHolder> destinationServers
   )
   {
-    final int sourceCount = countSegmentsInInterval(sourceServer, segmentToMove);
+    final Stopwatch computeTime = Stopwatch.createStarted();
+    try {
+      final int sourceCount = countSegmentsInInterval(sourceServer, segmentToMove);
 
-    ServerHolder bestDestination = null;
-    int bestCount = Integer.MAX_VALUE;
-    for (ServerHolder server : destinationServers) {
-      if (server.equals(sourceServer) || !server.canLoadSegment(segmentToMove)) {
-        continue;
+      ServerHolder bestDestination = null;
+      int bestCount = Integer.MAX_VALUE;
+      for (ServerHolder server : destinationServers) {
+        if (server.equals(sourceServer) || !server.canLoadSegment(segmentToMove)) {
+          continue;
+        }
+        final int count = countSegmentsInInterval(server, segmentToMove);
+        if (count < bestCount) {
+          bestCount = count;
+          bestDestination = server;
+        }
       }
-      final int count = countSegmentsInInterval(server, segmentToMove);
-      if (count < bestCount) {
-        bestCount = count;
-        bestDestination = server;
-      }
-    }
 
-    // Only move if it strictly reduces the maximum per-interval count, i.e. the
-    // destination (after gaining the segment) would hold fewer segments for this
-    // interval than the source currently does. This avoids pointless moves and
-    // oscillation between two servers that differ by a single segment.
-    if (bestDestination != null && bestCount + 1 < sourceCount) {
-      return bestDestination;
+      // Only move if it strictly reduces the maximum per-interval count, i.e. the
+      // destination (after gaining the segment) would hold fewer segments for this
+      // interval than the source currently does. This avoids pointless moves and
+      // oscillation between two servers that differ by a single segment.
+      if (bestDestination != null && bestCount + 1 < sourceCount) {
+        return bestDestination;
+      }
+      return null;
     }
-    return null;
+    finally {
+      recordComputeTime(computeTime);
+    }
   }
 
   @Override
@@ -146,7 +165,18 @@ public class IntervalAwareBalancerStrategy implements BalancerStrategy
   @Override
   public CoordinatorRunStats getStats()
   {
-    return CoordinatorRunStats.empty();
+    stats.add(
+        Stats.Balancer.COMPUTATION_TIME,
+        TimeUnit.NANOSECONDS.toMillis(computeTimeNanos.getAndSet(0))
+    );
+    return stats;
+  }
+
+  private void recordComputeTime(Stopwatch computeTime)
+  {
+    computeTime.stop();
+    stats.add(Stats.Balancer.COMPUTATION_COUNT, 1);
+    computeTimeNanos.addAndGet(computeTime.elapsed(TimeUnit.NANOSECONDS));
   }
 
   /**

--- a/server/src/main/java/org/apache/druid/server/coordinator/balancer/IntervalAwareBalancerStrategyFactory.java
+++ b/server/src/main/java/org/apache/druid/server/coordinator/balancer/IntervalAwareBalancerStrategyFactory.java
@@ -1,0 +1,54 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+package org.apache.druid.server.coordinator.balancer;
+
+import com.fasterxml.jackson.annotation.JsonCreator;
+import com.fasterxml.jackson.annotation.JsonProperty;
+
+import javax.annotation.Nullable;
+
+public class IntervalAwareBalancerStrategyFactory extends BalancerStrategyFactory
+{
+  /**
+   * Whether to balance the segment count per interval independently for each
+   * datasource ({@code true}, default) or across all datasources ({@code false}).
+   */
+  private final boolean perDatasource;
+
+  @JsonCreator
+  public IntervalAwareBalancerStrategyFactory(
+      @JsonProperty("perDatasource") @Nullable Boolean perDatasource
+  )
+  {
+    this.perDatasource = perDatasource == null || perDatasource;
+  }
+
+  @JsonProperty
+  public boolean isPerDatasource()
+  {
+    return perDatasource;
+  }
+
+  @Override
+  public BalancerStrategy createBalancerStrategy(int numBalancerThreads)
+  {
+    return new IntervalAwareBalancerStrategy(perDatasource);
+  }
+}

--- a/server/src/test/java/org/apache/druid/server/coordinator/balancer/BalancerStrategyFactoryTest.java
+++ b/server/src/test/java/org/apache/druid/server/coordinator/balancer/BalancerStrategyFactoryTest.java
@@ -44,6 +44,33 @@ public class BalancerStrategyFactoryTest
   }
 
   @Test
+  public void testIntervalAwareStrategyIsDeserialized() throws JsonProcessingException
+  {
+    final String json = "{\"strategy\":\"intervalAware\"}";
+    BalancerStrategyFactory factory = MAPPER.readValue(json, BalancerStrategyFactory.class);
+    BalancerStrategy strategy = factory.createBalancerStrategy(1);
+
+    Assert.assertTrue(factory instanceof IntervalAwareBalancerStrategyFactory);
+    // perDatasource defaults to true when not specified
+    Assert.assertTrue(((IntervalAwareBalancerStrategyFactory) factory).isPerDatasource());
+    Assert.assertTrue(strategy instanceof IntervalAwareBalancerStrategy);
+
+    factory.stopExecutor();
+  }
+
+  @Test
+  public void testIntervalAwareStrategyRespectsPerDatasourceFlag() throws JsonProcessingException
+  {
+    final String json = "{\"strategy\":\"intervalAware\",\"perDatasource\":false}";
+    BalancerStrategyFactory factory = MAPPER.readValue(json, BalancerStrategyFactory.class);
+
+    Assert.assertTrue(factory instanceof IntervalAwareBalancerStrategyFactory);
+    Assert.assertFalse(((IntervalAwareBalancerStrategyFactory) factory).isPerDatasource());
+
+    factory.stopExecutor();
+  }
+
+  @Test
   public void testBalancerFactoryCreatesNewExecutorIfNumThreadsChanges()
   {
     BalancerStrategyFactory factory = new CostBalancerStrategyFactory();

--- a/server/src/test/java/org/apache/druid/server/coordinator/balancer/IntervalAwareBalancerStrategyTest.java
+++ b/server/src/test/java/org/apache/druid/server/coordinator/balancer/IntervalAwareBalancerStrategyTest.java
@@ -25,6 +25,8 @@ import org.apache.druid.server.coordination.ServerType;
 import org.apache.druid.server.coordinator.CreateDataSegments;
 import org.apache.druid.server.coordinator.ServerHolder;
 import org.apache.druid.server.coordinator.loading.TestLoadQueuePeon;
+import org.apache.druid.server.coordinator.stats.CoordinatorRunStats;
+import org.apache.druid.server.coordinator.stats.Stats;
 import org.apache.druid.timeline.DataSegment;
 import org.junit.Assert;
 import org.junit.Before;
@@ -165,6 +167,20 @@ public class IntervalAwareBalancerStrategyTest
     // Most heavily loaded server for the interval should be dropped from first
     Assert.assertSame(serverB, ordered.next());
     Assert.assertSame(serverA, ordered.next());
+  }
+
+  @Test
+  public void testGetStatsTracksComputation()
+  {
+    final List<DataSegment> intervalSegments = minuteSegments(DS_WIKI, 2);
+    final ServerHolder serverA = createServerWith(new ArrayList<>());
+    final ServerHolder serverB = createServerWith(intervalSegments.subList(0, 1));
+
+    strategy.findServersToLoadSegment(intervalSegments.get(1), Arrays.asList(serverA, serverB));
+
+    final CoordinatorRunStats computeStats = strategy.getStats();
+    Assert.assertEquals(1L, computeStats.get(Stats.Balancer.COMPUTATION_COUNT));
+    Assert.assertTrue(computeStats.get(Stats.Balancer.COMPUTATION_TIME) >= 0);
   }
 
   private List<DataSegment> minuteSegments(String datasource, int count)

--- a/server/src/test/java/org/apache/druid/server/coordinator/balancer/IntervalAwareBalancerStrategyTest.java
+++ b/server/src/test/java/org/apache/druid/server/coordinator/balancer/IntervalAwareBalancerStrategyTest.java
@@ -153,6 +153,37 @@ public class IntervalAwareBalancerStrategyTest
   }
 
   @Test
+  public void testMoveTieBreakIsNotBiasedTowardListOrder()
+  {
+    final List<DataSegment> intervalSegments = minuteSegments(DS_WIKI, 4);
+
+    // Source holds 3 segments for the interval; two candidate destinations both
+    // hold 0 (a tie at the minimum). Over many runs, both should be chosen — a
+    // first-wins linear scan would always return destA.
+    final ServerHolder source = createServerWith(intervalSegments.subList(0, 3));
+    final ServerHolder destA = createServerWith(new ArrayList<>());
+    final ServerHolder destB = createServerWith(new ArrayList<>());
+    final DataSegment toMove = intervalSegments.get(0);
+
+    int chosenA = 0;
+    int chosenB = 0;
+    for (int i = 0; i < 2000; i++) {
+      final ServerHolder chosen =
+          strategy.findDestinationServerToMoveSegment(toMove, source, Arrays.asList(destA, destB));
+      if (chosen == destA) {
+        chosenA++;
+      } else if (chosen == destB) {
+        chosenB++;
+      }
+    }
+
+    // Both tied servers must be selected a meaningful fraction of the time.
+    Assert.assertTrue("destA never chosen: " + chosenA, chosenA > 700);
+    Assert.assertTrue("destB never chosen: " + chosenB, chosenB > 700);
+    Assert.assertEquals(2000, chosenA + chosenB);
+  }
+
+  @Test
   public void testDropPrefersMostLoadedServerForInterval()
   {
     final List<DataSegment> intervalSegments = minuteSegments(DS_WIKI, 5);
@@ -167,6 +198,38 @@ public class IntervalAwareBalancerStrategyTest
     // Most heavily loaded server for the interval should be dropped from first
     Assert.assertSame(serverB, ordered.next());
     Assert.assertSame(serverA, ordered.next());
+  }
+
+  @Test
+  public void testFullServerIsExcludedFromLoadCandidates()
+  {
+    final List<DataSegment> targetInterval = minuteSegments(DS_WIKI, 4);
+    // A different interval, used only to fill up the "full" server.
+    final List<DataSegment> otherInterval =
+        CreateDataSegments.ofDatasource(DS_WIKI)
+                          .forIntervals(1, Granularities.MINUTE)
+                          .startingAt("2024-01-01T01:00:00.000Z")
+                          .withNumPartitions(2)
+                          .eachOfSizeInMb(100);
+
+    // Full server: 200 MB capacity holding 2 x 100 MB segments of another interval.
+    // It therefore has 0 segments for the target interval (so by count alone it
+    // would rank first), but it cannot fit any more data.
+    final ServerHolder fullServer = createServerWith(otherInterval, 200L << 20);
+    // Normal server holds 1 segment of the target interval (count = 1).
+    final ServerHolder normalServer = createServerWith(targetInterval.subList(0, 1));
+
+    final DataSegment newSegment = targetInterval.get(1);
+    final Iterator<ServerHolder> ordered =
+        strategy.findServersToLoadSegment(newSegment, Arrays.asList(fullServer, normalServer));
+
+    final List<ServerHolder> result = new ArrayList<>();
+    ordered.forEachRemaining(result::add);
+
+    // Despite having the lowest interval count, the full server must be filtered out.
+    Assert.assertFalse("full server must be excluded", result.contains(fullServer));
+    Assert.assertTrue(result.contains(normalServer));
+    Assert.assertEquals(1, result.size());
   }
 
   @Test
@@ -194,9 +257,14 @@ public class IntervalAwareBalancerStrategyTest
 
   private ServerHolder createServerWith(List<DataSegment> segments)
   {
+    return createServerWith(segments, 10L << 30);
+  }
+
+  private ServerHolder createServerWith(List<DataSegment> segments, long maxSizeBytes)
+  {
     final String name = "hist_" + uniqueServerId++;
     final DruidServer server =
-        new DruidServer(name, name, null, 10L << 30, ServerType.HISTORICAL, "hot", 1);
+        new DruidServer(name, name, null, maxSizeBytes, ServerType.HISTORICAL, "hot", 1);
     for (DataSegment segment : segments) {
       server.addDataSegment(segment);
     }

--- a/server/src/test/java/org/apache/druid/server/coordinator/balancer/IntervalAwareBalancerStrategyTest.java
+++ b/server/src/test/java/org/apache/druid/server/coordinator/balancer/IntervalAwareBalancerStrategyTest.java
@@ -1,0 +1,189 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+package org.apache.druid.server.coordinator.balancer;
+
+import org.apache.druid.client.DruidServer;
+import org.apache.druid.java.util.common.granularity.Granularities;
+import org.apache.druid.server.coordination.ServerType;
+import org.apache.druid.server.coordinator.CreateDataSegments;
+import org.apache.druid.server.coordinator.ServerHolder;
+import org.apache.druid.server.coordinator.loading.TestLoadQueuePeon;
+import org.apache.druid.timeline.DataSegment;
+import org.junit.Assert;
+import org.junit.Before;
+import org.junit.Test;
+
+import java.util.ArrayList;
+import java.util.Arrays;
+import java.util.Iterator;
+import java.util.List;
+
+public class IntervalAwareBalancerStrategyTest
+{
+  private static final String DS_WIKI = "wiki";
+  private static final String DS_KOALA = "koala";
+  private static final String MINUTE_START = "2024-01-01T00:00:00.000Z";
+
+  private IntervalAwareBalancerStrategy strategy;
+  private int uniqueServerId;
+
+  @Before
+  public void setUp()
+  {
+    // Default tests use per-datasource scoping; the cross-datasource behaviour
+    // is covered explicitly in the dedicated tests below.
+    strategy = new IntervalAwareBalancerStrategy(true);
+    uniqueServerId = 0;
+  }
+
+  @Test
+  public void testLeastLoadedServerForIntervalIsPreferred()
+  {
+    // Segments for the target 1-minute interval
+    final List<DataSegment> intervalSegments = minuteSegments(DS_WIKI, 6);
+
+    // serverA already holds 3 of them, serverB holds 1, serverC holds none
+    final ServerHolder serverA = createServerWith(intervalSegments.subList(0, 3));
+    final ServerHolder serverB = createServerWith(intervalSegments.subList(3, 4));
+    final ServerHolder serverC = createServerWith(new ArrayList<>());
+
+    final DataSegment newSegment = intervalSegments.get(5);
+    final Iterator<ServerHolder> ordered =
+        strategy.findServersToLoadSegment(newSegment, Arrays.asList(serverA, serverB, serverC));
+
+    // Emptiest server for this interval comes first, fullest last
+    Assert.assertSame(serverC, ordered.next());
+    Assert.assertSame(serverB, ordered.next());
+    Assert.assertSame(serverA, ordered.next());
+    Assert.assertFalse(ordered.hasNext());
+  }
+
+  @Test
+  public void testPerDatasourceCountIgnoresOtherDatasources()
+  {
+    final IntervalAwareBalancerStrategy perDsStrategy = new IntervalAwareBalancerStrategy(true);
+
+    final List<DataSegment> wikiSegments = minuteSegments(DS_WIKI, 3);
+    final List<DataSegment> koalaSegments = minuteSegments(DS_KOALA, 3);
+
+    // serverA holds 2 koala + 0 wiki (wiki count = 0 for the interval)
+    // serverB holds 2 wiki (wiki count = 2 for the interval)
+    final ServerHolder serverA = createServerWith(koalaSegments.subList(0, 2));
+    final ServerHolder serverB = createServerWith(wikiSegments.subList(0, 2));
+
+    // A new wiki segment should prefer serverA, because only the wiki count
+    // matters in per-datasource mode (serverA has 0 wiki despite holding koala).
+    final DataSegment newWiki = wikiSegments.get(2);
+    final Iterator<ServerHolder> ordered =
+        perDsStrategy.findServersToLoadSegment(newWiki, Arrays.asList(serverA, serverB));
+
+    Assert.assertSame(serverA, ordered.next());
+    Assert.assertSame(serverB, ordered.next());
+  }
+
+  @Test
+  public void testTotalCountIsAcrossAllDatasources()
+  {
+    final IntervalAwareBalancerStrategy totalStrategy = new IntervalAwareBalancerStrategy(false);
+
+    final List<DataSegment> wikiSegments = minuteSegments(DS_WIKI, 3);
+    final List<DataSegment> koalaSegments = minuteSegments(DS_KOALA, 3);
+
+    // serverA holds 2 wiki + 1 koala (total 3 for the interval)
+    // serverB holds 1 wiki only (total 1 for the interval)
+    final List<DataSegment> serverASegments = new ArrayList<>(wikiSegments.subList(0, 2));
+    serverASegments.add(koalaSegments.get(0));
+    final ServerHolder serverA = createServerWith(serverASegments);
+    final ServerHolder serverB = createServerWith(wikiSegments.subList(2, 3));
+
+    // A new koala segment should prefer serverB, because in total mode the count
+    // is across all datasources, not just koala.
+    final DataSegment newKoala = koalaSegments.get(1);
+    final Iterator<ServerHolder> ordered =
+        totalStrategy.findServersToLoadSegment(newKoala, Arrays.asList(serverA, serverB));
+
+    Assert.assertSame(serverB, ordered.next());
+    Assert.assertSame(serverA, ordered.next());
+  }
+
+  @Test
+  public void testMovePrefersEmptierServerAndAvoidsOscillation()
+  {
+    final List<DataSegment> intervalSegments = minuteSegments(DS_WIKI, 4);
+
+    // source holds 3 segments for the interval, dest holds 0
+    final ServerHolder source = createServerWith(intervalSegments.subList(0, 3));
+    final ServerHolder dest = createServerWith(new ArrayList<>());
+
+    final DataSegment toMove = intervalSegments.get(0);
+    final ServerHolder chosen =
+        strategy.findDestinationServerToMoveSegment(toMove, source, Arrays.asList(source, dest));
+    Assert.assertSame(dest, chosen);
+
+    // When source has 2 and dest has 1 (differ by one), no move should happen
+    // to avoid oscillation.
+    final ServerHolder source2 = createServerWith(intervalSegments.subList(0, 2));
+    final ServerHolder dest2 = createServerWith(intervalSegments.subList(2, 3));
+    final ServerHolder chosen2 =
+        strategy.findDestinationServerToMoveSegment(
+            intervalSegments.get(0),
+            source2,
+            Arrays.asList(source2, dest2)
+        );
+    Assert.assertNull(chosen2);
+  }
+
+  @Test
+  public void testDropPrefersMostLoadedServerForInterval()
+  {
+    final List<DataSegment> intervalSegments = minuteSegments(DS_WIKI, 5);
+
+    final ServerHolder serverA = createServerWith(intervalSegments.subList(0, 1));
+    final ServerHolder serverB = createServerWith(intervalSegments.subList(1, 4));
+
+    final DataSegment segmentToDrop = intervalSegments.get(0);
+    final Iterator<ServerHolder> ordered =
+        strategy.findServersToDropSegment(segmentToDrop, Arrays.asList(serverA, serverB));
+
+    // Most heavily loaded server for the interval should be dropped from first
+    Assert.assertSame(serverB, ordered.next());
+    Assert.assertSame(serverA, ordered.next());
+  }
+
+  private List<DataSegment> minuteSegments(String datasource, int count)
+  {
+    return CreateDataSegments.ofDatasource(datasource)
+                             .forIntervals(1, Granularities.MINUTE)
+                             .startingAt(MINUTE_START)
+                             .withNumPartitions(count)
+                             .eachOfSizeInMb(100);
+  }
+
+  private ServerHolder createServerWith(List<DataSegment> segments)
+  {
+    final String name = "hist_" + uniqueServerId++;
+    final DruidServer server =
+        new DruidServer(name, name, null, 10L << 30, ServerType.HISTORICAL, "hot", 1);
+    for (DataSegment segment : segments) {
+      server.addDataSegment(segment);
+    }
+    return new ServerHolder(server.toImmutableDruidServer(), new TestLoadQueuePeon());
+  }
+}


### PR DESCRIPTION
## what
Add an IntervalAwareBalancerStrategy to balance segment count per interval per datasource across available historicals

## why
The current roundRobin distribution strategy creates a skew in the segments queried to answer export endpoint calls per historical