### PR TITLE
[OBSDATA-13995] Backport /status/ready endpoint (apache #19148)

### DIFF
--- a/server/src/main/java/org/apache/druid/curator/discovery/DiscoveryModule.java
+++ b/server/src/main/java/org/apache/druid/curator/discovery/DiscoveryModule.java
@@ -59,6 +59,7 @@ import org.apache.druid.guice.PolyBind;
 import org.apache.druid.guice.annotations.Self;
 import org.apache.druid.java.util.common.lifecycle.Lifecycle;
 import org.apache.druid.server.DruidNode;
+import org.apache.druid.server.ServiceAnnouncementState;
 import org.apache.druid.server.initialization.CuratorDiscoveryConfig;
 import org.apache.druid.server.initialization.ZkPathsConfig;
 
@@ -162,6 +163,8 @@ public class DiscoveryModule implements Module
     JsonConfigProvider.bind(binder, "druid.discovery.curator", CuratorDiscoveryConfig.class);
 
     binder.bind(CuratorServiceAnnouncer.class).in(LazySingleton.class);
+
+    binder.bind(ServiceAnnouncementState.class).in(LazySingleton.class);
 
     // Build the binder so that it will at a minimum inject an empty set.
     DruidBinders.discoveryAnnouncementBinder(binder);

--- a/server/src/main/java/org/apache/druid/server/ServiceAnnouncementState.java
+++ b/server/src/main/java/org/apache/druid/server/ServiceAnnouncementState.java
@@ -1,0 +1,44 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+package org.apache.druid.server;
+
+/**
+ * Tracks whether this service has announced itself to service discovery and is ready to receive traffic.
+ * Used by the {@code /status/ready} endpoint to report readiness to load balancers.
+ */
+public class ServiceAnnouncementState
+{
+  private volatile boolean ready = false;
+
+  public void markReady()
+  {
+    ready = true;
+  }
+
+  public void markNotReady()
+  {
+    ready = false;
+  }
+
+  public boolean isReady()
+  {
+    return ready;
+  }
+}

--- a/server/src/main/java/org/apache/druid/server/StatusResource.java
+++ b/server/src/main/java/org/apache/druid/server/StatusResource.java
@@ -40,6 +40,7 @@ import javax.ws.rs.Path;
 import javax.ws.rs.Produces;
 import javax.ws.rs.core.Context;
 import javax.ws.rs.core.MediaType;
+import javax.ws.rs.core.Response;
 import java.util.ArrayList;
 import java.util.Collection;
 import java.util.HashMap;
@@ -58,19 +59,22 @@ public class StatusResource
   private final DruidServerConfig druidServerConfig;
   private final ExtensionsLoader extnLoader;
   private final RuntimeInfo runtimeInfo;
+  private final ServiceAnnouncementState serviceAnnouncementState;
 
   @Inject
   public StatusResource(
       final Properties properties,
       final DruidServerConfig druidServerConfig,
       final ExtensionsLoader extnLoader,
-      final RuntimeInfo runtimeInfo
+      final RuntimeInfo runtimeInfo,
+      final ServiceAnnouncementState serviceAnnouncementState
   )
   {
     this.properties = properties;
     this.druidServerConfig = druidServerConfig;
     this.extnLoader = extnLoader;
     this.runtimeInfo = runtimeInfo;
+    this.serviceAnnouncementState = serviceAnnouncementState;
   }
 
   @GET
@@ -129,6 +133,23 @@ public class StatusResource
   public boolean getHealth()
   {
     return true;
+  }
+
+  /**
+   * This is an unsecured endpoint, defined as such in UNSECURED_PATHS in the service initialization files.
+   * Returns 200 when the service has announced itself and is ready to receive traffic,
+   * or 503 when the service has not yet announced or has begun unannouncing (e.g. during shutdown).
+   */
+  @GET
+  @Path("/ready")
+  @Produces(MediaType.APPLICATION_JSON)
+  public Response getReady()
+  {
+    final boolean ready = serviceAnnouncementState.isReady();
+    if (ready) {
+      return Response.ok(true).build();
+    }
+    return Response.status(Response.Status.SERVICE_UNAVAILABLE).entity(false).build();
   }
 
   public static class Status

--- a/server/src/test/java/org/apache/druid/server/ServiceAnnouncementStateTest.java
+++ b/server/src/test/java/org/apache/druid/server/ServiceAnnouncementStateTest.java
@@ -1,0 +1,64 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+package org.apache.druid.server;
+
+import org.junit.Assert;
+import org.junit.Test;
+
+public class ServiceAnnouncementStateTest
+{
+  @Test
+  public void testInitialStateIsNotReady()
+  {
+    final ServiceAnnouncementState state = new ServiceAnnouncementState();
+    Assert.assertFalse(state.isReady());
+  }
+
+  @Test
+  public void testMarkReady()
+  {
+    final ServiceAnnouncementState state = new ServiceAnnouncementState();
+    state.markReady();
+    Assert.assertTrue(state.isReady());
+  }
+
+  @Test
+  public void testMarkNotReady()
+  {
+    final ServiceAnnouncementState state = new ServiceAnnouncementState();
+    state.markReady();
+    Assert.assertTrue(state.isReady());
+    state.markNotReady();
+    Assert.assertFalse(state.isReady());
+  }
+
+  @Test
+  public void testMultipleTransitions()
+  {
+    final ServiceAnnouncementState state = new ServiceAnnouncementState();
+    state.markReady();
+    state.markReady();
+    Assert.assertTrue(state.isReady());
+    state.markNotReady();
+    Assert.assertFalse(state.isReady());
+    state.markNotReady();
+    Assert.assertFalse(state.isReady());
+  }
+}

--- a/server/src/test/java/org/apache/druid/server/StatusResourceTest.java
+++ b/server/src/test/java/org/apache/druid/server/StatusResourceTest.java
@@ -32,6 +32,7 @@ import org.apache.druid.utils.JvmUtils;
 import org.junit.Assert;
 import org.junit.Test;
 
+import javax.ws.rs.core.Response;
 import java.util.Collection;
 import java.util.Collections;
 import java.util.List;
@@ -76,6 +77,27 @@ public class StatusResourceTest
   public void testHiddenPropertiesContain() throws Exception
   {
     testHiddenPropertiesWithPropertyFileName("status.resource.test.runtime.hpc.properties");
+  }
+
+  @Test
+  public void testGetReadyReturns200WhenReady()
+  {
+    final ServiceAnnouncementState state = new ServiceAnnouncementState();
+    state.markReady();
+    final StatusResource resource = new StatusResource(new Properties(), null, null, null, state);
+    final Response response = resource.getReady();
+    Assert.assertEquals(200, response.getStatus());
+    Assert.assertEquals(true, response.getEntity());
+  }
+
+  @Test
+  public void testGetReadyReturns503WhenNotReady()
+  {
+    final ServiceAnnouncementState state = new ServiceAnnouncementState();
+    final StatusResource resource = new StatusResource(new Properties(), null, null, null, state);
+    final Response response = resource.getReady();
+    Assert.assertEquals(503, response.getStatus());
+    Assert.assertEquals(false, response.getEntity());
   }
 
   private void testHiddenPropertiesWithPropertyFileName(String fileName) throws Exception

--- a/services/src/main/java/org/apache/druid/cli/CliOverlord.java
+++ b/services/src/main/java/org/apache/druid/cli/CliOverlord.java
@@ -162,7 +162,8 @@ public class CliOverlord extends ServerRunnable
 
   protected static final List<String> UNSECURED_PATHS = ImmutableList.of(
       "/druid/indexer/v1/isLeader",
-      "/status/health"
+      "/status/health",
+      "/status/ready"
   );
 
   private Properties properties;

--- a/services/src/main/java/org/apache/druid/cli/CoordinatorJettyServerInitializer.java
+++ b/services/src/main/java/org/apache/druid/cli/CoordinatorJettyServerInitializer.java
@@ -54,6 +54,7 @@ class CoordinatorJettyServerInitializer implements JettyServerInitializer
       "/coordinator/false",
       "/overlord/false",
       "/status/health",
+      "/status/ready",
       "/druid/coordinator/v1/isLeader"
   );
 

--- a/services/src/main/java/org/apache/druid/cli/MiddleManagerJettyServerInitializer.java
+++ b/services/src/main/java/org/apache/druid/cli/MiddleManagerJettyServerInitializer.java
@@ -40,7 +40,6 @@ import org.eclipse.jetty.server.Handler;
 import org.eclipse.jetty.server.Server;
 import org.eclipse.jetty.server.handler.DefaultHandler;
 
-import java.util.Collections;
 import java.util.List;
 
 /**
@@ -59,7 +58,7 @@ class MiddleManagerJettyServerInitializer implements JettyServerInitializer
     this.authConfig = authConfig;
   }
 
-  private static List<String> UNSECURED_PATHS = Collections.singletonList("/status/health");
+  private static final List<String> UNSECURED_PATHS = List.of("/status/health", "/status/ready");
 
   @Override
   public void initialize(Server server, Injector injector)

--- a/services/src/main/java/org/apache/druid/cli/QueryJettyServerInitializer.java
+++ b/services/src/main/java/org/apache/druid/cli/QueryJettyServerInitializer.java
@@ -59,6 +59,7 @@ public class QueryJettyServerInitializer implements JettyServerInitializer
   private static final Logger log = new Logger(QueryJettyServerInitializer.class);
   private static List<String> UNSECURED_PATHS = Lists.newArrayList(
       "/status/health",
+      "/status/ready",
       "/druid/historical/v1/readiness",
       "/druid/broker/v1/readiness"
   );

--- a/services/src/main/java/org/apache/druid/cli/RouterJettyServerInitializer.java
+++ b/services/src/main/java/org/apache/druid/cli/RouterJettyServerInitializer.java
@@ -55,6 +55,7 @@ public class RouterJettyServerInitializer implements JettyServerInitializer
 {
   private static final List<String> UNSECURED_PATHS = ImmutableList.of(
       "/status/health",
+      "/status/ready",
       // JDBC authentication uses the JDBC connection context instead of HTTP headers, skip the normal auth checks.
       // The router will keep the connection context in the forwarded message, and the broker is responsible for
       // performing the auth checks.

--- a/services/src/main/java/org/apache/druid/cli/ServerRunnable.java
+++ b/services/src/main/java/org/apache/druid/cli/ServerRunnable.java
@@ -41,6 +41,7 @@ import org.apache.druid.java.util.common.lifecycle.Lifecycle;
 import org.apache.druid.java.util.common.logger.Logger;
 import org.apache.druid.java.util.emitter.EmittingLogger;
 import org.apache.druid.server.DruidNode;
+import org.apache.druid.server.ServiceAnnouncementState;
 
 import java.lang.annotation.Annotation;
 import java.util.Collections;
@@ -135,6 +136,9 @@ public abstract class ServerRunnable extends GuiceRunnable
     @Inject
     private Map<NodeRole, Set<Class<? extends DruidService>>> serviceClasses;
 
+    @Inject
+    private ServiceAnnouncementState serviceAnnouncementState;
+
     private final boolean useLegacyAnnouncer;
 
     public static DiscoverySideEffectsProvider create()
@@ -181,11 +185,15 @@ public abstract class ServerRunnable extends GuiceRunnable
                 if (useLegacyAnnouncer) {
                   legacyAnnouncer.announce(discoveryDruidNode.getDruidNode());
                 }
+
+                serviceAnnouncementState.markReady();
               }
 
               @Override
               public void stop()
               {
+                serviceAnnouncementState.markNotReady();
+
                 // Reverse order vs. start().
 
                 if (useLegacyAnnouncer) {


### PR DESCRIPTION
## Summary
- Backports upstream `apache/druid#19148` (commit `ee614dc343`) to `34.0.0-confluent`: adds `ServiceAnnouncementState`, a purely local readiness flag flipped by the node's own `announce()`/`unannounce()` lifecycle handlers, and exposes it via a new `/status/ready` endpoint.
- This endpoint predates and is required by the k8s-discovery `isPodReady()` filter we already backported in `b0f841bfb3` (apache `#19139`). Without it, a probe pointed at `/status/selfDiscovered` deadlocks: k8s only marks a container ready after its probe passes, but `isPodReady()` requires k8s to already report the container ready before self-discovery (and therefore `/status/selfDiscovered`) can succeed.
- This surfaced live on `druid-devel-44409`: overlord pods crash-restart-looped continuously after rolling to an image containing the `isPodReady()` filter, because their readiness/startup probes target `/status/selfDiscovered`.
- Pure addition — no existing endpoint or discovery behavior is touched. Safe to ship standalone; it's inert until probes are repointed to `/status/ready` (separate, follow-up chart change in `cc-druid`, sequenced after this lands in an image).

## Test plan
- [x] `mvn compile -pl server,services -am -DskipTests -Dweb.console.skip=true -Pskip-static-checks` succeeds
- [x] Cherry-picked cleanly (zero conflicts) from upstream `ee614dc343`
- [ ] CI

🤖 Generated with [Claude Code](https://claude.com/claude-code)