### PR TITLE
OBSDATA-13249 Use advertisedPlaintextPort for in-process task TaskLocation

### DIFF
--- a/indexing-service/src/main/java/org/apache/druid/indexing/overlord/ThreadingTaskRunner.java
+++ b/indexing-service/src/main/java/org/apache/druid/indexing/overlord/ThreadingTaskRunner.java
@@ -180,7 +180,7 @@ public class ThreadingTaskRunner
 
                           final TaskLocation taskLocation = TaskLocation.create(
                               node.getHost(),
-                              node.getPlaintextPort(),
+                              node.getAdvertisedPlaintextPort(),
                               node.getTlsPort()
                           );
 


### PR DESCRIPTION
## Summary
- `ThreadingTaskRunner` builds the in-process (indexerv2) task's `TaskLocation` from `node.getPlaintextPort()` instead of `node.getAdvertisedPlaintextPort()`, so overlord -> task chat-handler RPC dials the raw Jetty port directly and bypasses the envoy sidecar.
- `ServiceLocation.fromDruidNode` was already switched to `getAdvertisedPlaintextPort()` when advertisedPlaintextPort was added (OBSDATA-5553 / #454); this brings `TaskLocation` in line with it for indexers.
- Found while measuring envoy east-west coverage on druid-devel-44409: 79 live overlord->indexer sockets on raw 8091 despite the indexer's own envoy sidecar advertising 9443.
- Correct because `CliIndexerServerModule` binds `@RemoteChatHandler` DruidNode to `@Self`, so in-process tasks are served on the indexer's own Jetty port -- exactly what the sidecar's `druid_local` cluster already points at.
- Out of scope: `SingleTaskBackgroundRunner` (used by `CliPeon`) intentionally keeps `getPlaintextPort()` -- peons get a dynamic port from `PortFinder`, not the node's own port, so switching it to the advertised port would misroute peon TaskLocations.

## Test plan
- [x] `mvn -pl indexing-service -am install -DskipTests` (JDK 17)
- [x] `mvn -pl indexing-service test -Dtest=ThreadingTaskRunnerTest` -- 2/2 passing