### PR TITLE
OBSDATA-13249 Use advertisedPlaintextPort for in-process task TaskLocation (34.0.0-confluent)

### DIFF
--- a/indexing-service/src/main/java/org/apache/druid/indexing/overlord/ThreadingTaskRunner.java
+++ b/indexing-service/src/main/java/org/apache/druid/indexing/overlord/ThreadingTaskRunner.java
@@ -180,7 +180,7 @@ public class ThreadingTaskRunner
 
                           final TaskLocation taskLocation = TaskLocation.create(
                               node.getHost(),
-                              node.getPlaintextPort(),
+                              node.getAdvertisedPlaintextPort(),
                               node.getTlsPort()
                           );
 


### PR DESCRIPTION
## Summary
Backport of #476 to 34.0.0-confluent.

- `ThreadingTaskRunner` builds the in-process (indexerv2) task's `TaskLocation` from `node.getPlaintextPort()` instead of `node.getAdvertisedPlaintextPort()`, so overlord -> task chat-handler RPC dials the raw Jetty port directly and bypasses the envoy sidecar.
- `ServiceLocation.fromDruidNode` was already switched to `getAdvertisedPlaintextPort()` when advertisedPlaintextPort was added (OBSDATA-5553 / #454); this brings `TaskLocation` in line with it for indexers.
- Out of scope: `SingleTaskBackgroundRunner` (used by `CliPeon`) intentionally keeps `getPlaintextPort()` -- peons get a dynamic port from `PortFinder`, not the node's own port.

## Test plan
- [x] `mvn -pl indexing-service -am install -DskipTests` (JDK 17)
- [x] `mvn -pl indexing-service test -Dtest=ThreadingTaskRunnerTest` -- 2/2 passing