### PR TITLE
Bump jetty to 12.1.10 and netty4 to 4.2.16.Final for CVE fixes

### DIFF
--- a/licenses.yaml
+++ b/licenses.yaml
@@ -1332,7 +1332,7 @@ name: Netty
 license_category: binary
 module: java-core
 license_name: Apache License version 2.0
-version: 4.2.15.Final
+version: 4.2.16.Final
 libraries:
   - io.netty: netty-buffer
   - io.netty: netty-codec

--- a/pom.xml
+++ b/pom.xml
@@ -98,7 +98,7 @@
         <guava.version>32.1.3-jre</guava.version>
         <guice.version>5.1.0</guice.version>
         <hamcrest.version>2.2</hamcrest.version>
-        <jetty.version>12.1.7</jetty.version>
+        <jetty.version>12.1.10</jetty.version>
         <jersey.version>1.19.4</jersey.version>
         <jackson.core.version>2.21.1</jackson.core.version>
         <jackson.version>2.21.1</jackson.version>
@@ -107,7 +107,7 @@
         <mysql.version>8.2.0</mysql.version>
         <mariadb.version>2.7.3</mariadb.version>
         <netty3.version>3.10.6.Final</netty3.version>
-        <netty4.version>4.2.15.Final</netty4.version>
+        <netty4.version>4.2.16.Final</netty4.version>
         <postgresql.version>42.7.2</postgresql.version>
         <protobuf.version>3.25.5</protobuf.version>
         <resilience4j.version>1.3.1</resilience4j.version>


### PR DESCRIPTION
## Summary
Bumps two dependency versions on `34.0.0-confluent` to remediate CVEs surfaced during cc-druid vulnerability scanning ([confluentinc/cc-druid#3629](https://github.com/confluentinc/cc-druid/pull/3629)):

- **CVE-2026-10050** (Jetty Digest Authentication bypass via ISO-8859-1 encoding collision, HIGH, CVSS 9.1): affects Jetty `>=12.1.0 <12.1.10`. This branch was on `12.1.7`. Bumped `jetty.version` to `12.1.10`.
- **CVE-2026-59901** (Netty Bzip2Decoder infinite loop / event-loop hang DoS): affects Netty `<4.2.16.Final`. This branch was on `4.2.15.Final`. Bumped `netty4.version` to `4.2.16.Final`, which also covers `netty-codec-compression` via the `netty-bom` import.
- Synced the Netty entry in `licenses.yaml` to `4.2.16.Final` to match.

Verified via Trivy (`trivy fs` against the resolved dependency versions) that both target versions are outside the vulnerable ranges per the upstream security advisories, and confirmed both versions are published on Maven Central.

Note: a third CVE in the cc-druid PR (CVE-2026-50270, `dd-java-agent`) is out of scope here — that dependency is not referenced anywhere in `confluentinc/druid`; it's added at the `cc-druid` Docker build layer only.

## Test plan
- [ ] CI build passes
- [ ] No regressions in Jetty-security or Netty-compression related tests