### PR TITLE
OBSDATA-13249 Use advertised port for coordinator->broker dynamic config sync

### DIFF
--- a/server/src/main/java/org/apache/druid/server/http/CoordinatorDynamicConfigSyncer.java
+++ b/server/src/main/java/org/apache/druid/server/http/CoordinatorDynamicConfigSyncer.java
@@ -245,12 +245,7 @@ public class CoordinatorDynamicConfigSyncer
       return null;
     }
 
-    return new ServiceLocation(
-        druidNode.getHost(),
-        druidNode.getPlaintextPort(),
-        druidNode.getTlsPort(),
-        ""
-    );
+    return ServiceLocation.fromDruidNode(druidNode);
   }
 
   private void emitStat(CoordinatorStat stat, RowKey rowKey, long value)


### PR DESCRIPTION
## Summary
- `CoordinatorDynamicConfigSyncer.convertDiscoveryNodeToServiceLocation()` hand-built a `ServiceLocation` from `DruidNode.getPlaintextPort()`/`getTlsPort()` instead of `ServiceLocation.fromDruidNode()`.
- The leader Coordinator's periodic (60s) push of `CoordinatorDynamicConfig` to every discovered Broker therefore dialed each broker's raw bind port, ignoring `advertisedPlaintextPort` -- bypassing the envoy sidecar's mTLS egress capture (`common.envoy.egress.capturePorts`) on clusters running the east-west mTLS sidecar (druid-devel-44409, OBSDATA-13249).
- Confirmed live via `ss`-based socket sweep: coordinator pods showed persistent direct connections to broker pods on port 8082, not the advertised 9443 envoy listener.

## Test plan
- [ ] `mvn install -pl server -am -DskipTests` builds clean
- [ ] Deploy to druid-devel-44409, re-run the socket sweep, confirm coordinator->broker traffic now lands on port 9443 via envoy