### PR TITLE
OBSDATA-13249 Use advertised port for dynamic config sync to peer nodes

### DIFF
--- a/server/src/main/java/org/apache/druid/server/http/BaseDynamicConfigSyncer.java
+++ b/server/src/main/java/org/apache/druid/server/http/BaseDynamicConfigSyncer.java
@@ -262,12 +262,7 @@ public abstract class BaseDynamicConfigSyncer<DynamicConfig>
       return null;
     }
 
-    return new ServiceLocation(
-        druidNode.getHost(),
-        druidNode.getPlaintextPort(),
-        druidNode.getTlsPort(),
-        ""
-    );
+    return ServiceLocation.fromDruidNode(druidNode);
   }
 
   private void emitStat(CoordinatorStat stat, RowKey rowKey, long value)


### PR DESCRIPTION
## Summary
- `BaseDynamicConfigSyncer.convertDiscoveryNodeToServiceLocation()` hand-built a `ServiceLocation` from `DruidNode.getPlaintextPort()`/`getTlsPort()` instead of `ServiceLocation.fromDruidNode()`.
- In 37, this base class is shared by two subclasses -- `CoordinatorDynamicConfigSyncer` (coordinator->broker) and `BrokerDynamicConfigSyncer` (broker->broker, new in 37) -- so both dialed peers' raw bind ports and never picked up `advertisedPlaintextPort`, bypassing the envoy sidecar's mTLS egress capture (`common.envoy.egress.capturePorts`) on clusters running the east-west mTLS sidecar (OBSDATA-13249).
- Same bug already fixed on `34.0.0-confluent` for `CoordinatorDynamicConfigSyncer` (confluentinc/druid#481); this generalizes the fix to the shared base class 37 refactored the logic into.

## Test plan
- [ ] `mvn install -pl server -am -DskipTests` builds clean
- [ ] Deploy to a 37-based devel cluster with the envoy mTLS sidecar, confirm coordinator->broker and broker->broker traffic lands on the advertised envoy port